### PR TITLE
feat(tools): Implement inspection_start and inspection_status tools

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "yaml": "^2.4.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -18,7 +19,8 @@
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
         "tsx": "^4.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -743,6 +745,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -783,6 +792,356 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -803,6 +1162,7 @@
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1041,6 +1401,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1134,6 +1607,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1184,6 +1667,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1223,6 +1716,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1238,6 +1748,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1355,6 +1875,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1417,6 +1947,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1720,6 +2257,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1758,6 +2305,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2349,6 +2906,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2425,6 +2999,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2585,6 +3178,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -2606,6 +3223,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2707,6 +3353,51 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/router": {
@@ -2888,6 +3579,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2896,6 +3611,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2923,6 +3645,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2938,6 +3674,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -3059,6 +3825,585 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3072,6 +4417,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -3089,6 +4451,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -9,12 +9,15 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": ["mcp", "inspection", "ai"],
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "yaml": "^2.4.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
@@ -23,7 +26,8 @@
     "typescript": "^5.7.0",
     "eslint": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
-    "@typescript-eslint/parser": "^8.0.0"
+    "@typescript-eslint/parser": "^8.0.0",
+    "vitest": "^2.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/server/src/__tests__/inspection-tools.test.ts
+++ b/server/src/__tests__/inspection-tools.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Inspection Tools Tests - Issue #3
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockStorage } from '../storage/mock-storage.js';
+import { checklistService, ChecklistService } from '../services/checklist.js';
+import { join } from 'path';
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+describe('Inspection Tools', () => {
+  beforeEach(() => {
+    // Clear mock storage between tests
+    mockStorage.clear();
+  });
+
+  // ==========================================================================
+  // Mock Storage Tests
+  // ==========================================================================
+
+  describe('MockStorage', () => {
+    it('should create an inspection', async () => {
+      const inspection = await mockStorage.createInspection({
+        address: '123 Test Street',
+        client_name: 'John Doe',
+        inspector_name: 'Jane Inspector',
+        checklist_id: 'nz-ppi',
+        first_section: 'exterior',
+        sections: [
+          { id: 'exterior', name: 'Exterior' },
+          { id: 'interior', name: 'Interior' },
+        ],
+      });
+
+      expect(inspection.id).toBeDefined();
+      expect(inspection.address).toBe('123 Test Street');
+      expect(inspection.client_name).toBe('John Doe');
+      expect(inspection.inspector_name).toBe('Jane Inspector');
+      expect(inspection.status).toBe('started');
+      expect(inspection.current_section).toBe('exterior');
+    });
+
+    it('should retrieve an inspection by ID', async () => {
+      const created = await mockStorage.createInspection({
+        address: '456 Another Road',
+        client_name: 'Alice Smith',
+        checklist_id: 'nz-ppi',
+        first_section: 'site_ground',
+        sections: [{ id: 'site_ground', name: 'Site and Ground' }],
+      });
+
+      const retrieved = await mockStorage.getInspection(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(created.id);
+      expect(retrieved?.address).toBe('456 Another Road');
+    });
+
+    it('should return null for non-existent inspection', async () => {
+      const result = await mockStorage.getInspection('non-existent-id');
+      expect(result).toBeNull();
+    });
+
+    it('should update an inspection', async () => {
+      const created = await mockStorage.createInspection({
+        address: '789 Update Lane',
+        client_name: 'Bob Update',
+        checklist_id: 'nz-ppi',
+        first_section: 'exterior',
+        sections: [{ id: 'exterior', name: 'Exterior' }],
+      });
+
+      const updated = await mockStorage.updateInspection(created.id, {
+        current_section: 'interior',
+        status: 'in_progress',
+      });
+
+      expect(updated?.current_section).toBe('interior');
+      expect(updated?.status).toBe('in_progress');
+    });
+
+    it('should track section statuses', async () => {
+      const inspection = await mockStorage.createInspection({
+        address: '100 Status Street',
+        client_name: 'Status Test',
+        checklist_id: 'nz-ppi',
+        first_section: 'exterior',
+        sections: [
+          { id: 'exterior', name: 'Exterior' },
+          { id: 'interior', name: 'Interior' },
+          { id: 'services', name: 'Services' },
+        ],
+      });
+
+      const statuses = await mockStorage.getSectionStatuses(inspection.id);
+
+      expect(statuses).toHaveLength(3);
+      expect(statuses[0].status).toBe('in_progress'); // First section
+      expect(statuses[1].status).toBe('pending');
+      expect(statuses[2].status).toBe('pending');
+    });
+
+    it('should add and count findings', async () => {
+      const inspection = await mockStorage.createInspection({
+        address: '200 Finding Ave',
+        client_name: 'Finding Test',
+        checklist_id: 'nz-ppi',
+        first_section: 'exterior',
+        sections: [{ id: 'exterior', name: 'Exterior' }],
+      });
+
+      await mockStorage.addFinding({
+        inspection_id: inspection.id,
+        section: 'exterior',
+        text: 'Rust on gutters',
+        severity: 'minor',
+      });
+
+      await mockStorage.addFinding({
+        inspection_id: inspection.id,
+        section: 'exterior',
+        text: 'Cracked tiles',
+        severity: 'major',
+      });
+
+      const count = await mockStorage.getFindingsCount(inspection.id);
+      expect(count).toBe(2);
+
+      const findings = await mockStorage.getFindings(inspection.id);
+      expect(findings).toHaveLength(2);
+      expect(findings[0].text).toBe('Rust on gutters');
+      expect(findings[1].text).toBe('Cracked tiles');
+    });
+  });
+
+  // ==========================================================================
+  // Checklist Service Tests
+  // ==========================================================================
+
+  describe('ChecklistService', () => {
+    it('should load checklists from config', () => {
+      // Use the actual config path
+      const service = new ChecklistService(
+        join(process.cwd(), '..', 'config', 'checklists')
+      );
+      
+      const available = service.getAvailableChecklists();
+      expect(available.length).toBeGreaterThan(0);
+    });
+
+    it('should get a specific checklist', () => {
+      const service = new ChecklistService(
+        join(process.cwd(), '..', 'config', 'checklists')
+      );
+
+      const checklist = service.getChecklist('nz-ppi');
+      
+      // May or may not exist depending on test environment
+      if (checklist) {
+        expect(checklist.name).toBeDefined();
+        expect(checklist.sections.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should return null for non-existent checklist', () => {
+      const service = new ChecklistService(
+        join(process.cwd(), '..', 'config', 'checklists')
+      );
+
+      const checklist = service.getChecklist('non-existent-checklist');
+      expect(checklist).toBeNull();
+    });
+
+    it('should get first section of a checklist', () => {
+      const service = new ChecklistService(
+        join(process.cwd(), '..', 'config', 'checklists')
+      );
+
+      const available = service.getAvailableChecklists();
+      if (available.length > 0) {
+        const firstSection = service.getFirstSection(available[0]);
+        expect(firstSection).not.toBeNull();
+        expect(firstSection?.id).toBeDefined();
+        expect(firstSection?.name).toBeDefined();
+        expect(firstSection?.prompt).toBeDefined();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Integration Tests (Tool Logic)
+  // ==========================================================================
+
+  describe('Tool Integration', () => {
+    it('should start inspection and get status', async () => {
+      // Simulate what the tools would do
+      const service = new ChecklistService(
+        join(process.cwd(), '..', 'config', 'checklists')
+      );
+
+      const available = service.getAvailableChecklists();
+      if (available.length === 0) {
+        console.warn('No checklists available, skipping integration test');
+        return;
+      }
+
+      const checklistId = available[0];
+      const checklist = service.getChecklist(checklistId);
+      const firstSection = service.getFirstSection(checklistId);
+      const allSections = service.getAllSections(checklistId);
+
+      // Start inspection
+      const inspection = await mockStorage.createInspection({
+        address: '999 Integration Test Road',
+        client_name: 'Integration Test Client',
+        inspector_name: 'Test Inspector',
+        checklist_id: checklistId,
+        first_section: firstSection!.id,
+        sections: allSections,
+      });
+
+      expect(inspection.id).toBeDefined();
+      expect(inspection.status).toBe('started');
+
+      // Get status
+      const retrieved = await mockStorage.getInspection(inspection.id);
+      expect(retrieved?.address).toBe('999 Integration Test Road');
+      expect(retrieved?.current_section).toBe(firstSection!.id);
+
+      // Get section statuses
+      const statuses = await mockStorage.getSectionStatuses(inspection.id);
+      expect(statuses.length).toBe(allSections.length);
+    });
+  });
+});

--- a/server/src/services/checklist.ts
+++ b/server/src/services/checklist.ts
@@ -1,0 +1,204 @@
+/**
+ * Checklist Service - Issue #3
+ * 
+ * Loads and manages inspection checklists from config files.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ChecklistItem {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+  subareas?: ChecklistSubarea[];
+  report_section?: number;
+}
+
+export interface ChecklistSubarea {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+}
+
+export interface ChecklistMetadata {
+  required: string[];
+  optional: string[];
+}
+
+export interface Checklist {
+  id: string;
+  name: string;
+  version: string;
+  standard?: string;
+  metadata?: ChecklistMetadata;
+  sections: ChecklistItem[];
+  conclusions?: Record<string, string>;
+}
+
+// ============================================================================
+// Checklist Service
+// ============================================================================
+
+class ChecklistService {
+  private checklists: Map<string, Checklist> = new Map();
+  private configPath: string;
+  private loaded: boolean = false;
+
+  constructor(configPath?: string) {
+    // Default to config/checklists relative to project root
+    this.configPath = configPath || join(process.cwd(), 'config', 'checklists');
+  }
+
+  /**
+   * Load all checklists from config directory
+   */
+  loadChecklists(): void {
+    if (this.loaded) return;
+
+    if (!existsSync(this.configPath)) {
+      console.warn(`Checklist config path not found: ${this.configPath}`);
+      return;
+    }
+
+    const files = readdirSync(this.configPath).filter(
+      f => f.endsWith('.yaml') || f.endsWith('.yml')
+    );
+
+    for (const file of files) {
+      try {
+        const filePath = join(this.configPath, file);
+        const content = readFileSync(filePath, 'utf-8');
+        const data = parseYaml(content);
+        
+        // Generate ID from filename (e.g., nz-ppi.yaml -> nz-ppi)
+        const id = basename(file, '.yaml').replace('.yml', '');
+        
+        const checklist: Checklist = {
+          id,
+          name: data.name || id,
+          version: data.version || '1.0',
+          standard: data.standard,
+          metadata: data.metadata,
+          sections: this.normalizeSections(data.sections || []),
+          conclusions: data.conclusions,
+        };
+
+        this.checklists.set(id, checklist);
+        console.error(`Loaded checklist: ${id} (${checklist.sections.length} sections)`);
+      } catch (error) {
+        console.error(`Failed to load checklist ${file}:`, error);
+      }
+    }
+
+    this.loaded = true;
+  }
+
+  /**
+   * Normalize sections to ensure consistent structure
+   */
+  private normalizeSections(sections: any[]): ChecklistItem[] {
+    return sections.map(section => ({
+      id: section.id,
+      name: section.name,
+      prompt: section.prompt || `Check ${section.name.toLowerCase()}.`,
+      items: section.items || [],
+      subareas: section.subareas?.map((sub: any) => ({
+        id: sub.id,
+        name: sub.name,
+        prompt: sub.prompt || `Check ${sub.name.toLowerCase()}.`,
+        items: sub.items || [],
+      })),
+      report_section: section.report_section,
+    }));
+  }
+
+  /**
+   * Get a checklist by ID
+   */
+  getChecklist(id: string): Checklist | null {
+    this.loadChecklists();
+    return this.checklists.get(id) || null;
+  }
+
+  /**
+   * Get the default checklist (first one loaded, or 'nz-ppi' if available)
+   */
+  getDefaultChecklist(): Checklist | null {
+    this.loadChecklists();
+    
+    // Prefer nz-ppi as default
+    if (this.checklists.has('nz-ppi')) {
+      return this.checklists.get('nz-ppi')!;
+    }
+    
+    // Otherwise return first available
+    const first = this.checklists.values().next();
+    return first.value || null;
+  }
+
+  /**
+   * Get all available checklist IDs
+   */
+  getAvailableChecklists(): string[] {
+    this.loadChecklists();
+    return Array.from(this.checklists.keys());
+  }
+
+  /**
+   * Get the first section of a checklist
+   */
+  getFirstSection(checklistId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist || checklist.sections.length === 0) return null;
+    return checklist.sections[0];
+  }
+
+  /**
+   * Get a specific section by ID
+   */
+  getSection(checklistId: string, sectionId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return null;
+    return checklist.sections.find(s => s.id === sectionId) || null;
+  }
+
+  /**
+   * Get all sections for a checklist (flattened, including subareas)
+   */
+  getAllSections(checklistId: string): Array<{ id: string; name: string }> {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return [];
+
+    const sections: Array<{ id: string; name: string }> = [];
+    
+    for (const section of checklist.sections) {
+      sections.push({ id: section.id, name: section.name });
+      
+      // Add subareas if present
+      if (section.subareas) {
+        for (const subarea of section.subareas) {
+          sections.push({ 
+            id: `${section.id}.${subarea.id}`, 
+            name: `${section.name} - ${subarea.name}` 
+          });
+        }
+      }
+    }
+
+    return sections;
+  }
+}
+
+// Export singleton instance
+export const checklistService = new ChecklistService();
+
+// Export class for testing with custom paths
+export { ChecklistService };

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,10 +1,8 @@
 /**
- * Business logic services for the inspection workflow.
+ * Services Module
  * 
- * Services to implement:
- * - InspectionService: Manage inspection lifecycle
- * - ChecklistService: Handle checklist navigation
- * - FindingService: Process and categorize findings
+ * Business logic and shared services.
  */
 
-export {};
+export { checklistService, ChecklistService } from './checklist.js';
+export type { Checklist, ChecklistItem, ChecklistSubarea } from './checklist.js';

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -1,10 +1,15 @@
 /**
- * Storage layer for inspections and media.
+ * Storage Module
  * 
- * Components to implement:
- * - Database connection (SQLite for MVP)
- * - File storage for photos
- * - Inspection state persistence
+ * Data persistence layer for inspections and media.
+ * Currently using mock storage - will be replaced by SQLite in #2.
  */
 
-export {};
+export { mockStorage, MockStorage } from './mock-storage.js';
+export type { 
+  Inspection, 
+  Finding, 
+  Photo, 
+  SectionStatus,
+  InspectionMetadata,
+} from './mock-storage.js';

--- a/server/src/storage/mock-storage.ts
+++ b/server/src/storage/mock-storage.ts
@@ -1,0 +1,212 @@
+/**
+ * Mock Storage Layer - Issue #3
+ * 
+ * Temporary in-memory storage for development.
+ * Will be replaced by SQLite storage from #2.
+ */
+
+import { randomUUID } from 'crypto';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface InspectionMetadata {
+  property_type?: string;
+  bedrooms?: number;
+  bathrooms?: number;
+  year_built?: number;
+}
+
+export interface Inspection {
+  id: string;
+  address: string;
+  client_name: string;
+  inspector_name?: string;
+  checklist_id: string;
+  metadata?: InspectionMetadata;
+  status: 'started' | 'in_progress' | 'completed';
+  current_section: string;
+  started_at: string;
+  completed_at?: string;
+}
+
+export interface Finding {
+  id: string;
+  inspection_id: string;
+  section: string;
+  text: string;
+  severity: 'info' | 'minor' | 'major' | 'urgent';
+  matched_comment?: string;
+  timestamp: string;
+}
+
+export interface Photo {
+  id: string;
+  finding_id: string;
+  filename: string;
+  path: string;
+  mime_type: string;
+}
+
+export interface SectionStatus {
+  id: string;
+  name: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'skipped';
+  findings_count: number;
+}
+
+// ============================================================================
+// Mock Storage Implementation
+// ============================================================================
+
+class MockStorage {
+  private inspections: Map<string, Inspection> = new Map();
+  private findings: Map<string, Finding[]> = new Map();
+  private photos: Map<string, Photo[]> = new Map();
+  private sectionStatuses: Map<string, SectionStatus[]> = new Map();
+
+  /**
+   * Create a new inspection
+   */
+  async createInspection(data: {
+    address: string;
+    client_name: string;
+    inspector_name?: string;
+    checklist_id: string;
+    metadata?: InspectionMetadata;
+    first_section: string;
+    sections: Array<{ id: string; name: string }>;
+  }): Promise<Inspection> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    const inspection: Inspection = {
+      id,
+      address: data.address,
+      client_name: data.client_name,
+      inspector_name: data.inspector_name,
+      checklist_id: data.checklist_id,
+      metadata: data.metadata,
+      status: 'started',
+      current_section: data.first_section,
+      started_at: now,
+    };
+
+    this.inspections.set(id, inspection);
+    this.findings.set(id, []);
+    this.photos.set(id, []);
+
+    // Initialize section statuses
+    const statuses: SectionStatus[] = data.sections.map((section, index) => ({
+      id: section.id,
+      name: section.name,
+      status: index === 0 ? 'in_progress' : 'pending',
+      findings_count: 0,
+    }));
+    this.sectionStatuses.set(id, statuses);
+
+    return inspection;
+  }
+
+  /**
+   * Get an inspection by ID
+   */
+  async getInspection(id: string): Promise<Inspection | null> {
+    return this.inspections.get(id) || null;
+  }
+
+  /**
+   * Update an inspection
+   */
+  async updateInspection(id: string, updates: Partial<Inspection>): Promise<Inspection | null> {
+    const inspection = this.inspections.get(id);
+    if (!inspection) return null;
+
+    const updated = { ...inspection, ...updates };
+    this.inspections.set(id, updated);
+    return updated;
+  }
+
+  /**
+   * Get findings for an inspection
+   */
+  async getFindings(inspection_id: string): Promise<Finding[]> {
+    return this.findings.get(inspection_id) || [];
+  }
+
+  /**
+   * Get section statuses for an inspection
+   */
+  async getSectionStatuses(inspection_id: string): Promise<SectionStatus[]> {
+    return this.sectionStatuses.get(inspection_id) || [];
+  }
+
+  /**
+   * Add a finding
+   */
+  async addFinding(data: {
+    inspection_id: string;
+    section: string;
+    text: string;
+    severity?: 'info' | 'minor' | 'major' | 'urgent';
+    matched_comment?: string;
+  }): Promise<Finding> {
+    const id = randomUUID();
+    const finding: Finding = {
+      id,
+      inspection_id: data.inspection_id,
+      section: data.section,
+      text: data.text,
+      severity: data.severity || 'info',
+      matched_comment: data.matched_comment,
+      timestamp: new Date().toISOString(),
+    };
+
+    const findings = this.findings.get(data.inspection_id) || [];
+    findings.push(finding);
+    this.findings.set(data.inspection_id, findings);
+
+    // Update section findings count
+    const statuses = this.sectionStatuses.get(data.inspection_id) || [];
+    const sectionStatus = statuses.find(s => s.id === data.section);
+    if (sectionStatus) {
+      sectionStatus.findings_count++;
+      sectionStatus.status = 'in_progress';
+    }
+
+    return finding;
+  }
+
+  /**
+   * Get total findings count for an inspection
+   */
+  async getFindingsCount(inspection_id: string): Promise<number> {
+    const findings = this.findings.get(inspection_id) || [];
+    return findings.length;
+  }
+
+  /**
+   * Get total photos count for an inspection
+   */
+  async getPhotosCount(inspection_id: string): Promise<number> {
+    const photos = this.photos.get(inspection_id) || [];
+    return photos.length;
+  }
+
+  /**
+   * Clear all data (for testing)
+   */
+  clear(): void {
+    this.inspections.clear();
+    this.findings.clear();
+    this.photos.clear();
+    this.sectionStatuses.clear();
+  }
+}
+
+// Export singleton instance
+export const mockStorage = new MockStorage();
+
+// Export class for testing
+export { MockStorage };

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -1,128 +1,148 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { registerInspectionTools } from "./inspection.js";
 
 /**
  * Register all MCP tools with the server.
- * Tools are stubs for now — implementations will be added as features are built.
  */
 export function registerTools(server: McpServer): void {
-  // Tool: Start a new inspection
-  server.tool(
-    "start_inspection",
-    "Start a new building inspection at the specified address",
-    {
-      address: z.string().describe("Property address for the inspection"),
-      inspector_name: z.string().optional().describe("Name of the inspector"),
-    },
-    async ({ address, inspector_name }) => {
-      // TODO: Implement in #2
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Inspection started at ${address}${inspector_name ? ` by ${inspector_name}` : ""}. [STUB]`,
-          },
-        ],
-      };
-    }
-  );
+  // Register inspection_start and inspection_status tools (Issue #3)
+  registerInspectionTools(server);
 
-  // Tool: Add a finding to the current inspection
+  // Stub tools for future implementation
+  // These will be replaced as their respective issues are completed
+
+  // Tool: Add a finding to the current inspection (Issue #4)
   server.tool(
-    "add_finding",
+    "inspection_add_finding",
     "Record a finding or issue during the inspection",
     {
-      section: z.string().describe("Section of the inspection (e.g., exterior, subfloor)"),
-      description: z.string().describe("Description of the finding"),
-      severity: z.enum(["info", "minor", "major", "critical"]).optional().describe("Severity level"),
+      inspection_id: z.string().describe("ID of the active inspection"),
+      section: z.string().optional().describe("Section ID (default: current section)"),
+      text: z.string().describe("Description of the finding"),
+      photos: z.array(z.object({
+        data: z.string().describe("Base64 encoded photo data"),
+        filename: z.string().optional(),
+        mime_type: z.string().optional(),
+      })).optional().describe("Photos to attach"),
+      severity: z.enum(["info", "minor", "major", "urgent"]).optional().describe("Severity level"),
     },
-    async ({ section, description, severity }) => {
-      // TODO: Implement in #3
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Finding added to ${section}: ${description} (${severity || "info"}). [STUB]`,
-          },
-        ],
-      };
-    }
-  );
-
-  // Tool: Add a photo to the current inspection
-  server.tool(
-    "add_photo",
-    "Attach a photo to the current section or finding",
-    {
-      section: z.string().describe("Section the photo belongs to"),
-      caption: z.string().optional().describe("Caption for the photo"),
-      photo_url: z.string().describe("URL or path to the photo"),
-    },
-    async ({ section, caption, photo_url }) => {
+    async ({ inspection_id, section, text, photos, severity }) => {
       // TODO: Implement in #4
       return {
         content: [
           {
             type: "text" as const,
-            text: `Photo added to ${section}${caption ? `: ${caption}` : ""}. [STUB]`,
+            text: JSON.stringify({
+              stub: true,
+              message: `Finding would be added: ${text} (${severity || "info"})`,
+              inspection_id,
+              section,
+              photos_count: photos?.length || 0,
+            }, null, 2),
           },
         ],
       };
     }
   );
 
-  // Tool: Navigate to a section
+  // Tool: Navigate to a section (Issue #5)
   server.tool(
-    "go_to_section",
-    "Navigate to a specific section of the inspection checklist",
+    "inspection_navigate",
+    "Navigate to a different section of the inspection checklist",
     {
-      section: z.string().describe("Section to navigate to"),
+      inspection_id: z.string().describe("ID of the active inspection"),
+      action: z.string().describe("'next', 'back', 'skip', or section ID"),
     },
-    async ({ section }) => {
-      // TODO: Implement in #2
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Moved to section: ${section}. [STUB]`,
-          },
-        ],
-      };
-    }
-  );
-
-  // Tool: Get current inspection status
-  server.tool(
-    "get_status",
-    "Get the current inspection progress and status",
-    {},
-    async () => {
-      // TODO: Implement in #2
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: "No active inspection. [STUB]",
-          },
-        ],
-      };
-    }
-  );
-
-  // Tool: Complete inspection and generate report
-  server.tool(
-    "complete_inspection",
-    "Finish the inspection and generate the PDF report",
-    {
-      summary: z.string().optional().describe("Overall summary or notes"),
-    },
-    async ({ summary }) => {
+    async ({ inspection_id, action }) => {
       // TODO: Implement in #5
       return {
         content: [
           {
             type: "text" as const,
-            text: `Inspection completed${summary ? ` with summary: ${summary}` : ""}. Report generation pending. [STUB]`,
+            text: JSON.stringify({
+              stub: true,
+              message: `Navigation action: ${action}`,
+              inspection_id,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // Tool: Get suggestions for next steps (Issue #5)
+  server.tool(
+    "inspection_suggest_next",
+    "Get guidance for what to do next based on current state",
+    {
+      inspection_id: z.string().describe("ID of the active inspection"),
+    },
+    async ({ inspection_id }) => {
+      // TODO: Implement in #5
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              stub: true,
+              message: "Suggestions would be provided here",
+              inspection_id,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // Tool: Complete inspection and generate report (Issue #6)
+  server.tool(
+    "inspection_complete",
+    "Finish the inspection and generate the PDF report",
+    {
+      inspection_id: z.string().describe("ID of the inspection to complete"),
+      summary_notes: z.string().optional().describe("Overall summary or notes"),
+      weather: z.string().optional().describe("Weather at time of inspection"),
+    },
+    async ({ inspection_id, summary_notes, weather }) => {
+      // TODO: Implement in #6
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              stub: true,
+              message: "Inspection would be completed and report generated",
+              inspection_id,
+              summary_notes,
+              weather,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // Tool: Get generated report (Issue #6)
+  server.tool(
+    "inspection_get_report",
+    "Retrieve a generated inspection report",
+    {
+      inspection_id: z.string().describe("ID of the inspection"),
+      format: z.enum(["pdf", "markdown"]).optional().describe("Report format (default: pdf)"),
+    },
+    async ({ inspection_id, format }) => {
+      // TODO: Implement in #6
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              stub: true,
+              message: "Report would be retrieved here",
+              inspection_id,
+              format: format || "pdf",
+            }, null, 2),
           },
         ],
       };

--- a/server/src/tools/inspection.ts
+++ b/server/src/tools/inspection.ts
@@ -1,0 +1,224 @@
+/**
+ * Inspection Tools - Issue #3
+ * 
+ * MCP tools for starting and managing inspections.
+ * - inspection_start: Create a new inspection session
+ * - inspection_status: Get current inspection state
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mockStorage, InspectionMetadata } from "../storage/mock-storage.js";
+import { checklistService } from "../services/checklist.js";
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerInspectionTools(server: McpServer): void {
+  // -------------------------------------------------------------------------
+  // inspection_start
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_start",
+    "Start a new building inspection at the specified address",
+    {
+      address: z.string().describe("Property address for the inspection"),
+      client_name: z.string().describe("Name of the client"),
+      inspector_name: z.string().optional().describe("Name of the inspector"),
+      checklist: z.string().optional().describe("Checklist ID (default: 'nz-ppi')"),
+      metadata: z.object({
+        property_type: z.string().optional().describe("Type of property (e.g., 'residential', 'commercial')"),
+        bedrooms: z.number().optional().describe("Number of bedrooms"),
+        bathrooms: z.number().optional().describe("Number of bathrooms"),
+        year_built: z.number().optional().describe("Year the property was built"),
+      }).optional().describe("Additional property metadata"),
+    },
+    async ({ address, client_name, inspector_name, checklist, metadata }) => {
+      try {
+        // Determine checklist to use
+        const checklistId = checklist || 'nz-ppi';
+        const checklistData = checklistService.getChecklist(checklistId);
+        
+        if (!checklistData) {
+          const available = checklistService.getAvailableChecklists();
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Checklist '${checklistId}' not found`,
+                available_checklists: available,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get first section
+        const firstSection = checklistService.getFirstSection(checklistId);
+        if (!firstSection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Checklist '${checklistId}' has no sections`,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get all sections for status tracking
+        const allSections = checklistService.getAllSections(checklistId);
+
+        // Create the inspection
+        const inspection = await mockStorage.createInspection({
+          address,
+          client_name,
+          inspector_name,
+          checklist_id: checklistId,
+          metadata: metadata as InspectionMetadata | undefined,
+          first_section: firstSection.id,
+          sections: allSections,
+        });
+
+        // Build response
+        const response = {
+          inspection_id: inspection.id,
+          status: "started",
+          address: inspection.address,
+          client_name: inspection.client_name,
+          checklist: checklistId,
+          first_section: {
+            id: firstSection.id,
+            name: firstSection.name,
+            prompt: firstSection.prompt,
+            items: firstSection.items,
+          },
+          message: `Inspection started at ${address}. Ready to begin with ${firstSection.name}.`,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to start inspection",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // inspection_status
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_status",
+    "Get the current inspection state and progress",
+    {
+      inspection_id: z.string().describe("ID of the inspection to check"),
+    },
+    async ({ inspection_id }) => {
+      try {
+        // Get inspection
+        const inspection = await mockStorage.getInspection(inspection_id);
+        
+        if (!inspection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get section statuses
+        const sectionStatuses = await mockStorage.getSectionStatuses(inspection_id);
+        
+        // Calculate progress
+        const completedSections = sectionStatuses.filter(s => 
+          s.status === 'completed' || s.status === 'skipped'
+        ).length;
+        const totalSections = sectionStatuses.length;
+        
+        // Get counts
+        const totalFindings = await mockStorage.getFindingsCount(inspection_id);
+        const totalPhotos = await mockStorage.getPhotosCount(inspection_id);
+
+        // Determine if inspection can be completed
+        const canComplete = completedSections >= Math.ceil(totalSections * 0.5); // At least 50% done
+
+        // Get current section details
+        const currentSectionStatus = sectionStatuses.find(s => s.id === inspection.current_section);
+        const checklistSection = checklistService.getSection(
+          inspection.checklist_id, 
+          inspection.current_section
+        );
+
+        // Build response
+        const response = {
+          inspection_id: inspection.id,
+          address: inspection.address,
+          client_name: inspection.client_name,
+          inspector_name: inspection.inspector_name,
+          started_at: inspection.started_at,
+          status: inspection.status,
+          current_section: {
+            id: inspection.current_section,
+            name: currentSectionStatus?.name || inspection.current_section,
+            status: currentSectionStatus?.status || 'in_progress',
+            findings_count: currentSectionStatus?.findings_count || 0,
+            prompt: checklistSection?.prompt,
+            items: checklistSection?.items,
+          },
+          sections: sectionStatuses.map(s => ({
+            id: s.id,
+            name: s.name,
+            status: s.status,
+            findings_count: s.findings_count,
+          })),
+          progress: {
+            completed: completedSections,
+            total: totalSections,
+            percentage: Math.round((completedSections / totalSections) * 100),
+          },
+          total_findings: totalFindings,
+          total_photos: totalPhotos,
+          can_complete: canComplete,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to get inspection status",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
Implement the first two MCP tools for starting and checking inspection status.

## Tools Implemented

### `inspection_start`
Creates a new inspection session.

**Parameters:**
- `address` (required): Property address
- `client_name` (required): Client name
- `inspector_name` (optional): Inspector name
- `checklist` (optional): Checklist ID (default: 'nz-ppi')
- `metadata` (optional): property_type, bedrooms, bathrooms, year_built

**Returns:**
- inspection_id, status, first_section with prompt and items

### `inspection_status`
Get current inspection state.

**Parameters:**
- `inspection_id` (required)

**Returns:**
- Full inspection state including sections, progress, findings count

## New Files
- `server/src/tools/inspection.ts` — Tool implementations
- `server/src/services/checklist.ts` — Checklist loading from YAML
- `server/src/storage/mock-storage.ts` — In-memory storage (placeholder for #2)
- `server/src/__tests__/inspection-tools.test.ts` — 11 unit tests

## Dependencies
- Based on `feat/mcp-server-structure` branch (PR #11)
- Uses mock storage until #2 (SQLite layer) merges
- Added `yaml` package for config parsing
- Added `vitest` for testing

## Testing
```bash
cd server
npm install
npm test        # 11 tests pass
npm run build   # Compiles successfully
```

## Acceptance Criteria
- [x] Can start inspection via MCP call
- [x] Returns first section prompt
- [x] Can retrieve inspection status
- [x] Handles invalid inspection_id gracefully
- [x] Loads checklist config from config/checklists/
- [x] Unit tests

Closes #3