### PR TITLE
feat(tools): Implement inspection_add_finding tool

### DIFF
--- a/server/src/__tests__/comments.test.ts
+++ b/server/src/__tests__/comments.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Comment Library Service Tests - Issue #4
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CommentLibraryService } from '../services/comments.js';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('CommentLibraryService', () => {
+  let service: CommentLibraryService;
+
+  beforeEach(() => {
+    // Use the project's config directory
+    const configDir = join(__dirname, '..', '..', '..', 'config', 'comments');
+    service = new CommentLibraryService(configDir);
+  });
+
+  describe('load()', () => {
+    it('should load defaults.yaml', () => {
+      service.load();
+      // If load succeeds without error, we're good
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('match()', () => {
+    it('should match "rust" to roof rust comment', () => {
+      const result = service.match('Minor rust spots on roof', 'exterior');
+      expect(result.matched).toBe(true);
+      expect(result.comment).toBeDefined();
+      expect(result.comment?.toLowerCase()).toContain('rust');
+    });
+
+    it('should match "pooling water" to drainage comment', () => {
+      const result = service.match('Water pooling near foundation', 'site_ground');
+      expect(result.matched).toBe(true);
+      expect(result.comment).toBeDefined();
+      expect(result.comment?.toLowerCase()).toContain('drainage');
+    });
+
+    it('should match "moss" to roof moss comment', () => {
+      const result = service.match('Moss growth on roof tiles');
+      expect(result.matched).toBe(true);
+      expect(result.comment).toBeDefined();
+    });
+
+    it('should match "blocked gutter" to gutter comment', () => {
+      const result = service.match('Gutters blocked with leaves');
+      expect(result.matched).toBe(true);
+      expect(result.comment).toBeDefined();
+      expect(result.comment?.toLowerCase()).toContain('gutter');
+    });
+
+    it('should return no match for unrelated text', () => {
+      const result = service.match('The quick brown fox jumps over the lazy dog');
+      expect(result.matched).toBe(false);
+    });
+
+    it('should return exact confidence for strong keyword matches', () => {
+      const result = service.match('heavy rust on roofing material');
+      if (result.matched) {
+        expect(['exact', 'partial']).toContain(result.confidence);
+      }
+    });
+
+    it('should normalize section names', () => {
+      // "Site & Ground" should normalize to "site_ground"
+      const result = service.match('poor drainage', 'Site & Ground');
+      expect(result.matched).toBe(true);
+    });
+  });
+
+  describe('getConclusion()', () => {
+    it('should return good conclusion', () => {
+      const conclusion = service.getConclusion('good');
+      expect(conclusion).toBeDefined();
+      expect(conclusion?.toLowerCase()).toContain('no');
+    });
+
+    it('should return minor conclusion', () => {
+      const conclusion = service.getConclusion('minor');
+      expect(conclusion).toBeDefined();
+      expect(conclusion?.toLowerCase()).toContain('minor');
+    });
+
+    it('should return urgent conclusion', () => {
+      const conclusion = service.getConclusion('urgent');
+      expect(conclusion).toBeDefined();
+      expect(conclusion?.toLowerCase()).toContain('immediate');
+    });
+
+    it('should return null for invalid severity', () => {
+      // @ts-expect-error Testing invalid input
+      const conclusion = service.getConclusion('invalid');
+      expect(conclusion).toBeNull();
+    });
+  });
+
+  describe('reload()', () => {
+    it('should reload the library', () => {
+      service.load();
+      const firstResult = service.match('rust on roof');
+      
+      service.reload();
+      const secondResult = service.match('rust on roof');
+      
+      expect(firstResult.matched).toBe(secondResult.matched);
+    });
+  });
+});

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -1,0 +1,269 @@
+/**
+ * Comment Library Service - Issue #4
+ * 
+ * Loads and matches boilerplate comments from YAML config.
+ * - Loads defaults.yaml
+ * - Loads custom.yaml if exists (overrides defaults)
+ * - Matches keywords in finding text to boilerplate
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CommentEntry {
+  match?: string[];
+  text: string;
+}
+
+interface CommentSection {
+  [key: string]: CommentEntry | CommentSection;
+}
+
+interface CommentLibrary {
+  version?: string;
+  conclusions?: Record<string, CommentEntry>;
+  [section: string]: unknown;
+}
+
+export interface MatchResult {
+  matched: boolean;
+  comment?: string;
+  section?: string;
+  key?: string;
+  confidence: 'exact' | 'partial' | 'none';
+}
+
+// ============================================================================
+// Comment Library Service
+// ============================================================================
+
+class CommentLibraryService {
+  private library: CommentLibrary = {};
+  private configDir: string;
+  private loaded = false;
+
+  constructor(configDir?: string) {
+    // Default to project's config/comments directory
+    const projectRoot = join(__dirname, '..', '..', '..');
+    this.configDir = configDir || join(projectRoot, 'config', 'comments');
+  }
+
+  /**
+   * Load comment library from YAML files.
+   * Loads defaults.yaml first, then merges custom.yaml if exists.
+   */
+  load(): void {
+    if (this.loaded) return;
+
+    const defaultsPath = join(this.configDir, 'defaults.yaml');
+    const customPath = join(this.configDir, 'custom.yaml');
+
+    // Load defaults
+    if (existsSync(defaultsPath)) {
+      try {
+        const content = readFileSync(defaultsPath, 'utf-8');
+        this.library = parseYaml(content) || {};
+      } catch (error) {
+        console.error('Failed to load defaults.yaml:', error);
+        this.library = {};
+      }
+    }
+
+    // Load and merge custom (overrides defaults)
+    if (existsSync(customPath)) {
+      try {
+        const content = readFileSync(customPath, 'utf-8');
+        const custom = parseYaml(content) || {};
+        this.library = this.deepMerge(this.library, custom);
+      } catch (error) {
+        console.error('Failed to load custom.yaml:', error);
+      }
+    }
+
+    this.loaded = true;
+  }
+
+  /**
+   * Deep merge two objects, with source overriding target.
+   */
+  private deepMerge(target: CommentLibrary, source: CommentLibrary): CommentLibrary {
+    const result = { ...target };
+    
+    for (const key of Object.keys(source)) {
+      if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+        if (target[key] && typeof target[key] === 'object' && !Array.isArray(target[key])) {
+          result[key] = this.deepMerge(
+            target[key] as CommentLibrary,
+            source[key] as CommentLibrary
+          );
+        } else {
+          result[key] = source[key];
+        }
+      } else {
+        result[key] = source[key];
+      }
+    }
+    
+    return result;
+  }
+
+  /**
+   * Match finding text against comment library.
+   * Returns the best matching boilerplate comment.
+   * 
+   * @param text - The finding text to match
+   * @param section - Optional section context to narrow matching
+   */
+  match(text: string, section?: string): MatchResult {
+    this.load();
+    
+    const textLower = text.toLowerCase();
+    let bestMatch: MatchResult = { matched: false, confidence: 'none' };
+    let bestScore = 0;
+
+    // If section provided, search that section first
+    if (section) {
+      const sectionKey = this.normalizeSectionKey(section);
+      const sectionData = this.library[sectionKey];
+      
+      if (sectionData && typeof sectionData === 'object') {
+        const result = this.searchSection(textLower, sectionData as CommentSection, sectionKey);
+        if (result.matched && this.getMatchScore(result) > bestScore) {
+          bestMatch = result;
+          bestScore = this.getMatchScore(result);
+        }
+      }
+    }
+
+    // Search all sections if no match or searching globally
+    if (!bestMatch.matched || bestScore < 3) {
+      for (const [sectionKey, sectionData] of Object.entries(this.library)) {
+        // Skip metadata fields
+        if (sectionKey === 'version') continue;
+        
+        if (sectionData && typeof sectionData === 'object') {
+          const result = this.searchSection(textLower, sectionData as CommentSection, sectionKey);
+          if (result.matched && this.getMatchScore(result) > bestScore) {
+            bestMatch = result;
+            bestScore = this.getMatchScore(result);
+          }
+        }
+      }
+    }
+
+    return bestMatch;
+  }
+
+  /**
+   * Search a section for matching comments.
+   */
+  private searchSection(textLower: string, section: CommentSection, sectionKey: string): MatchResult {
+    let bestMatch: MatchResult = { matched: false, confidence: 'none' };
+    let bestScore = 0;
+
+    for (const [key, value] of Object.entries(section)) {
+      if (!value || typeof value !== 'object') continue;
+
+      // Check if this is a comment entry (has 'text' property)
+      if ('text' in value && typeof value.text === 'string') {
+        const entry = value as CommentEntry;
+        const matchScore = this.scoreMatch(textLower, entry.match || []);
+        
+        if (matchScore > bestScore) {
+          bestScore = matchScore;
+          bestMatch = {
+            matched: true,
+            comment: entry.text,
+            section: sectionKey,
+            key,
+            confidence: matchScore >= 3 ? 'exact' : 'partial',
+          };
+        }
+      } else {
+        // Nested section - recurse
+        const nestedResult = this.searchSection(textLower, value as CommentSection, sectionKey);
+        if (nestedResult.matched && this.getMatchScore(nestedResult) > bestScore) {
+          bestMatch = nestedResult;
+          bestScore = this.getMatchScore(nestedResult);
+        }
+      }
+    }
+
+    return bestMatch;
+  }
+
+  /**
+   * Score how well text matches the keywords.
+   */
+  private scoreMatch(textLower: string, keywords: string[]): number {
+    if (!keywords || keywords.length === 0) return 0;
+    
+    let score = 0;
+    for (const keyword of keywords) {
+      const keywordLower = keyword.toLowerCase();
+      if (textLower.includes(keywordLower)) {
+        // Longer keywords = higher score
+        score += Math.min(keywordLower.length / 3, 3);
+      }
+    }
+    
+    return score;
+  }
+
+  /**
+   * Get numeric score for a match result.
+   */
+  private getMatchScore(result: MatchResult): number {
+    if (!result.matched) return 0;
+    return result.confidence === 'exact' ? 10 : 5;
+  }
+
+  /**
+   * Normalize section name to match YAML keys.
+   * e.g., "Site & Ground" -> "site_ground"
+   */
+  private normalizeSectionKey(section: string): string {
+    return section
+      .toLowerCase()
+      .replace(/[&]/g, '')
+      .replace(/\s+/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^_|_$/g, '');
+  }
+
+  /**
+   * Get a conclusion comment by severity.
+   */
+  getConclusion(severity: 'good' | 'minor' | 'attention' | 'urgent'): string | null {
+    this.load();
+    const conclusions = this.library.conclusions as Record<string, CommentEntry> | undefined;
+    return conclusions?.[severity]?.text || null;
+  }
+
+  /**
+   * Reload the library (for testing or config changes).
+   */
+  reload(): void {
+    this.loaded = false;
+    this.library = {};
+    this.load();
+  }
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+// Singleton instance
+export const commentLibrary = new CommentLibraryService();
+
+// Export class for testing
+export { CommentLibraryService };

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -6,3 +6,6 @@
 
 export { checklistService, ChecklistService } from './checklist.js';
 export type { Checklist, ChecklistItem, ChecklistSubarea } from './checklist.js';
+
+export { commentLibrary, CommentLibraryService } from './comments.js';
+export type { MatchResult } from './comments.js';

--- a/server/src/tools/finding.ts
+++ b/server/src/tools/finding.ts
@@ -1,0 +1,189 @@
+/**
+ * Finding Tools - Issue #4
+ * 
+ * MCP tool for recording findings during inspection.
+ * - inspection_add_finding: Record a finding with optional photos
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mockStorage } from "../storage/mock-storage.js";
+import { commentLibrary } from "../services/comments.js";
+import { randomUUID } from "crypto";
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ============================================================================
+// Photo Storage
+// ============================================================================
+
+interface PhotoInput {
+  data: string;
+  filename?: string;
+  mime_type?: string;
+}
+
+interface StoredPhoto {
+  id: string;
+  filename: string;
+  path: string;
+  mime_type: string;
+}
+
+/**
+ * Store a base64-encoded photo to disk.
+ */
+function storePhoto(
+  inspectionId: string,
+  findingId: string,
+  photo: PhotoInput,
+  index: number
+): StoredPhoto {
+  // Default values
+  const mimeType = photo.mime_type || 'image/jpeg';
+  const extension = mimeType.split('/')[1] || 'jpg';
+  const filename = photo.filename || `photo_${index + 1}.${extension}`;
+  
+  // Create photo directory
+  const projectRoot = join(__dirname, '..', '..', '..');
+  const photoDir = join(projectRoot, 'data', 'photos', inspectionId, findingId);
+  
+  if (!existsSync(photoDir)) {
+    mkdirSync(photoDir, { recursive: true });
+  }
+  
+  // Decode and save
+  const id = randomUUID();
+  const filePath = join(photoDir, `${id}_${filename}`);
+  
+  // Handle base64 with or without data URI prefix
+  let base64Data = photo.data;
+  if (base64Data.includes(',')) {
+    base64Data = base64Data.split(',')[1];
+  }
+  
+  const buffer = Buffer.from(base64Data, 'base64');
+  writeFileSync(filePath, buffer);
+  
+  return {
+    id,
+    filename,
+    path: filePath,
+    mime_type: mimeType,
+  };
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerFindingTools(server: McpServer): void {
+  // -------------------------------------------------------------------------
+  // inspection_add_finding
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_add_finding",
+    "Record a finding or issue during the inspection with optional photos",
+    {
+      inspection_id: z.string().describe("ID of the active inspection"),
+      section: z.string().optional().describe("Section ID (defaults to current section)"),
+      text: z.string().describe("Inspector's note or description of the finding"),
+      photos: z.array(z.object({
+        data: z.string().describe("Base64 encoded photo data"),
+        filename: z.string().optional().describe("Original filename"),
+        mime_type: z.string().optional().describe("MIME type (default: image/jpeg)"),
+      })).optional().describe("Photos to attach to this finding"),
+      severity: z.enum(["info", "minor", "major", "urgent"]).optional()
+        .describe("Severity level (default: info)"),
+    },
+    async ({ inspection_id, section, text, photos, severity }) => {
+      try {
+        // Get inspection
+        const inspection = await mockStorage.getInspection(inspection_id);
+        
+        if (!inspection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Use current section if not specified
+        const findingSection = section || inspection.current_section;
+
+        // Match against comment library
+        const matchResult = commentLibrary.match(text, findingSection);
+
+        // Add finding to storage
+        const finding = await mockStorage.addFinding({
+          inspection_id,
+          section: findingSection,
+          text,
+          severity: severity || 'info',
+          matched_comment: matchResult.matched ? matchResult.comment : undefined,
+        });
+
+        // Store photos if provided
+        const storedPhotos: StoredPhoto[] = [];
+        if (photos && photos.length > 0) {
+          for (let i = 0; i < photos.length; i++) {
+            const stored = storePhoto(inspection_id, finding.id, photos[i], i);
+            storedPhotos.push(stored);
+          }
+        }
+
+        // Build response
+        const response: Record<string, unknown> = {
+          finding_id: finding.id,
+          section: findingSection,
+          severity: finding.severity,
+          text: finding.text,
+          photos_stored: storedPhotos.length,
+          message: `Finding recorded in ${findingSection}.`,
+        };
+
+        // Include matched comment if found
+        if (matchResult.matched && matchResult.comment) {
+          response.matched_comment = matchResult.comment;
+          response.match_confidence = matchResult.confidence;
+          response.message = `Finding recorded in ${findingSection}. Matched boilerplate comment available.`;
+        }
+
+        // Include photo details if any
+        if (storedPhotos.length > 0) {
+          response.photos = storedPhotos.map(p => ({
+            id: p.id,
+            filename: p.filename,
+          }));
+        }
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to add finding",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { registerInspectionTools } from "./inspection.js";
+import { registerFindingTools } from "./finding.js";
 
 /**
  * Register all MCP tools with the server.
@@ -9,42 +10,11 @@ export function registerTools(server: McpServer): void {
   // Register inspection_start and inspection_status tools (Issue #3)
   registerInspectionTools(server);
 
+  // Register inspection_add_finding tool (Issue #4)
+  registerFindingTools(server);
+
   // Stub tools for future implementation
   // These will be replaced as their respective issues are completed
-
-  // Tool: Add a finding to the current inspection (Issue #4)
-  server.tool(
-    "inspection_add_finding",
-    "Record a finding or issue during the inspection",
-    {
-      inspection_id: z.string().describe("ID of the active inspection"),
-      section: z.string().optional().describe("Section ID (default: current section)"),
-      text: z.string().describe("Description of the finding"),
-      photos: z.array(z.object({
-        data: z.string().describe("Base64 encoded photo data"),
-        filename: z.string().optional(),
-        mime_type: z.string().optional(),
-      })).optional().describe("Photos to attach"),
-      severity: z.enum(["info", "minor", "major", "urgent"]).optional().describe("Severity level"),
-    },
-    async ({ inspection_id, section, text, photos, severity }) => {
-      // TODO: Implement in #4
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              stub: true,
-              message: `Finding would be added: ${text} (${severity || "info"})`,
-              inspection_id,
-              section,
-              photos_count: photos?.length || 0,
-            }, null, 2),
-          },
-        ],
-      };
-    }
-  );
 
   // Tool: Navigate to a section (Issue #5)
   server.tool(


### PR DESCRIPTION
## Summary
Implements the `inspection_add_finding` MCP tool for recording findings during inspections.

## Changes
- **CommentLibraryService** (`server/src/services/comments.ts`):
  - Loads `config/comments/defaults.yaml`
  - Merges `custom.yaml` if exists (overrides defaults)
  - Keyword matching against boilerplate comments
  - Section-aware matching with confidence scoring

- **Finding Tool** (`server/src/tools/finding.ts`):
  - `inspection_add_finding` tool implementation
  - Handles text, severity, optional section
  - Photo base64 decoding and storage
  - Returns matched boilerplate comment if found

- **Tests**: 13 unit tests for comment matching logic

## Tool Parameters
| Param | Required | Description |
|-------|----------|-------------|
| inspection_id | Yes | Active inspection ID |
| text | Yes | Inspector's note |
| section | No | Section ID (default: current) |
| photos | No | Array of {data, filename, mime_type} |
| severity | No | info/minor/major/urgent |

## Returns
```json
{
  "finding_id": "uuid",
  "section": "exterior",
  "matched_comment": "Boilerplate text if matched...",
  "photos_stored": 2,
  "message": "Finding recorded..."
}
```

## Testing
- `npm test` - 24 tests passing
- `npm run build` - TypeScript compiles cleanly

## Dependencies
- #19 (inspection_start/status tools)
- #18 (SQLite storage - mock storage used for now)

Closes #4