### PR TITLE
feat(tools): Implement inspection_start, inspection_status, inspection_navigate, inspection_suggest_next

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
+        "yaml": "^2.4.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -3543,6 +3544,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "better-sqlite3": "^12.6.2",
+    "yaml": "^2.4.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,14 +1,18 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerTools } from "./tools/index.js";
+import { StorageService } from "./storage/index.js";
 
 const server = new McpServer({
   name: "ai-inspection",
   version: "0.1.0",
 });
 
-// Register all tools
-registerTools(server);
+// Initialize storage service
+const storage = new StorageService();
+
+// Register all tools with storage
+registerTools(server, storage);
 
 // Start server with stdio transport
 async function main() {

--- a/server/src/services/checklist.ts
+++ b/server/src/services/checklist.ts
@@ -1,0 +1,234 @@
+/**
+ * Checklist Service - Issues #3, #5
+ * 
+ * Loads and manages inspection checklists from config files.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ChecklistItem {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+  subareas?: ChecklistSubarea[];
+  report_section?: number;
+}
+
+export interface ChecklistSubarea {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+}
+
+export interface ChecklistMetadata {
+  required: string[];
+  optional: string[];
+}
+
+export interface Checklist {
+  id: string;
+  name: string;
+  version: string;
+  standard?: string;
+  metadata?: ChecklistMetadata;
+  sections: ChecklistItem[];
+  conclusions?: Record<string, string>;
+}
+
+// ============================================================================
+// Checklist Service
+// ============================================================================
+
+class ChecklistService {
+  private checklists: Map<string, Checklist> = new Map();
+  private configPath: string;
+  private loaded: boolean = false;
+
+  constructor(configPath?: string) {
+    // Default to config/checklists relative to project root
+    const projectRoot = join(__dirname, '..', '..', '..');
+    this.configPath = configPath || join(projectRoot, 'config', 'checklists');
+  }
+
+  /**
+   * Load all checklists from config directory
+   */
+  loadChecklists(): void {
+    if (this.loaded) return;
+
+    if (!existsSync(this.configPath)) {
+      console.warn(`Checklist config path not found: ${this.configPath}`);
+      return;
+    }
+
+    const files = readdirSync(this.configPath).filter(
+      f => f.endsWith('.yaml') || f.endsWith('.yml')
+    );
+
+    for (const file of files) {
+      try {
+        const filePath = join(this.configPath, file);
+        const content = readFileSync(filePath, 'utf-8');
+        const data = parseYaml(content);
+        
+        // Generate ID from filename (e.g., nz-ppi.yaml -> nz-ppi)
+        const id = basename(file, '.yaml').replace('.yml', '');
+        
+        const checklist: Checklist = {
+          id,
+          name: data.name || id,
+          version: data.version || '1.0',
+          standard: data.standard,
+          metadata: data.metadata,
+          sections: this.normalizeSections(data.sections || []),
+          conclusions: data.conclusions,
+        };
+
+        this.checklists.set(id, checklist);
+        console.error(`Loaded checklist: ${id} (${checklist.sections.length} sections)`);
+      } catch (error) {
+        console.error(`Failed to load checklist ${file}:`, error);
+      }
+    }
+
+    this.loaded = true;
+  }
+
+  /**
+   * Normalize sections to ensure consistent structure
+   */
+  private normalizeSections(sections: any[]): ChecklistItem[] {
+    return sections.map(section => ({
+      id: section.id,
+      name: section.name,
+      prompt: section.prompt || `Check ${section.name.toLowerCase()}.`,
+      items: section.items || [],
+      subareas: section.subareas?.map((sub: any) => ({
+        id: sub.id,
+        name: sub.name,
+        prompt: sub.prompt || `Check ${sub.name.toLowerCase()}.`,
+        items: sub.items || [],
+      })),
+      report_section: section.report_section,
+    }));
+  }
+
+  /**
+   * Get a checklist by ID
+   */
+  getChecklist(id: string): Checklist | null {
+    this.loadChecklists();
+    return this.checklists.get(id) || null;
+  }
+
+  /**
+   * Get the default checklist (first one loaded, or 'nz-ppi' if available)
+   */
+  getDefaultChecklist(): Checklist | null {
+    this.loadChecklists();
+    
+    // Prefer nz-ppi as default
+    if (this.checklists.has('nz-ppi')) {
+      return this.checklists.get('nz-ppi')!;
+    }
+    
+    // Otherwise return first available
+    const first = this.checklists.values().next();
+    return first.value || null;
+  }
+
+  /**
+   * Get all available checklist IDs
+   */
+  getAvailableChecklists(): string[] {
+    this.loadChecklists();
+    return Array.from(this.checklists.keys());
+  }
+
+  /**
+   * Get the first section of a checklist
+   */
+  getFirstSection(checklistId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist || checklist.sections.length === 0) return null;
+    return checklist.sections[0];
+  }
+
+  /**
+   * Get a specific section by ID
+   */
+  getSection(checklistId: string, sectionId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return null;
+    return checklist.sections.find(s => s.id === sectionId) || null;
+  }
+
+  /**
+   * Get section index
+   */
+  getSectionIndex(checklistId: string, sectionId: string): number {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return -1;
+    return checklist.sections.findIndex(s => s.id === sectionId);
+  }
+
+  /**
+   * Get section by index
+   */
+  getSectionByIndex(checklistId: string, index: number): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist || index < 0 || index >= checklist.sections.length) return null;
+    return checklist.sections[index];
+  }
+
+  /**
+   * Get total section count
+   */
+  getSectionCount(checklistId: string): number {
+    const checklist = this.getChecklist(checklistId);
+    return checklist?.sections.length || 0;
+  }
+
+  /**
+   * Get all sections for a checklist (flattened, including subareas)
+   */
+  getAllSections(checklistId: string): Array<{ id: string; name: string }> {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return [];
+
+    const sections: Array<{ id: string; name: string }> = [];
+    
+    for (const section of checklist.sections) {
+      sections.push({ id: section.id, name: section.name });
+      
+      // Add subareas if present
+      if (section.subareas) {
+        for (const subarea of section.subareas) {
+          sections.push({ 
+            id: `${section.id}.${subarea.id}`, 
+            name: `${section.name} - ${subarea.name}` 
+          });
+        }
+      }
+    }
+
+    return sections;
+  }
+}
+
+// Export singleton instance
+export const checklistService = new ChecklistService();
+
+// Export class for testing with custom paths
+export { ChecklistService };

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,10 +1,6 @@
 /**
  * Business logic services for the inspection workflow.
- * 
- * Services to implement:
- * - InspectionService: Manage inspection lifecycle
- * - ChecklistService: Handle checklist navigation
- * - FindingService: Process and categorize findings
  */
 
-export {};
+export { checklistService, ChecklistService } from './checklist.js';
+export type { Checklist, ChecklistItem, ChecklistSubarea } from './checklist.js';

--- a/server/src/tools/inspection.ts
+++ b/server/src/tools/inspection.ts
@@ -1,0 +1,237 @@
+/**
+ * Inspection Tools - Issues #3, #5
+ * 
+ * MCP tools for starting and managing inspections.
+ * - inspection_start: Create a new inspection session
+ * - inspection_status: Get current inspection state
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { StorageService } from "../storage/index.js";
+import { checklistService } from "../services/checklist.js";
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerInspectionTools(server: McpServer, storage: StorageService): void {
+  // -------------------------------------------------------------------------
+  // inspection_start
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_start",
+    "Start a new building inspection at the specified address",
+    {
+      address: z.string().describe("Property address for the inspection"),
+      client_name: z.string().describe("Name of the client"),
+      inspector_name: z.string().optional().describe("Name of the inspector"),
+      checklist: z.string().optional().describe("Checklist ID (default: 'nz-ppi')"),
+      metadata: z.object({
+        property_type: z.string().optional().describe("Type of property"),
+        bedrooms: z.number().optional().describe("Number of bedrooms"),
+        bathrooms: z.number().optional().describe("Number of bathrooms"),
+        year_built: z.number().optional().describe("Year the property was built"),
+      }).optional().describe("Additional property metadata"),
+    },
+    async ({ address, client_name, inspector_name, checklist, metadata }) => {
+      try {
+        // Determine checklist to use
+        const checklistId = checklist || 'nz-ppi';
+        const checklistData = checklistService.getChecklist(checklistId);
+        
+        if (!checklistData) {
+          const available = checklistService.getAvailableChecklists();
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Checklist '${checklistId}' not found`,
+                available_checklists: available,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get first section
+        const firstSection = checklistService.getFirstSection(checklistId);
+        if (!firstSection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Checklist '${checklistId}' has no sections`,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Create the inspection using real storage
+        const inspection = storage.createInspection({
+          address,
+          client_name,
+          inspector_name,
+        });
+
+        // Set current section
+        storage.updateInspection(inspection.id, {
+          current_section: firstSection.id,
+        });
+
+        // Build response
+        const response = {
+          inspection_id: inspection.id,
+          status: "started",
+          address: inspection.address,
+          client_name: inspection.client_name,
+          checklist: checklistId,
+          first_section: {
+            id: firstSection.id,
+            name: firstSection.name,
+            prompt: firstSection.prompt,
+            items: firstSection.items,
+          },
+          message: `Inspection started at ${address}. Ready to begin with ${firstSection.name}.`,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to start inspection",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // inspection_status
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_status",
+    "Get the current inspection state and progress",
+    {
+      inspection_id: z.string().describe("ID of the inspection to check"),
+    },
+    async ({ inspection_id }) => {
+      try {
+        // Get inspection
+        const inspection = storage.getInspection(inspection_id);
+        
+        if (!inspection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get findings for this inspection
+        const findings = storage.getFindings(inspection_id);
+        const photos = storage.getPhotos(inspection_id);
+
+        // Get checklist info (default to nz-ppi if not stored)
+        const checklistId = 'nz-ppi'; // TODO: Store checklist ID with inspection
+        const checklist = checklistService.getChecklist(checklistId);
+        const sections = checklist?.sections || [];
+        
+        // Build section statuses
+        const sectionStatuses = sections.map(section => {
+          const sectionFindings = findings.filter(f => f.section === section.id);
+          const isCurrentSection = inspection.current_section === section.id;
+          
+          // Determine status based on findings and position
+          let status: string = 'pending';
+          if (isCurrentSection) {
+            status = 'in_progress';
+          } else if (sectionFindings.length > 0) {
+            status = 'completed';
+          }
+
+          return {
+            id: section.id,
+            name: section.name,
+            status,
+            findings_count: sectionFindings.length,
+          };
+        });
+
+        // Calculate progress
+        const completedSections = sectionStatuses.filter(s => 
+          s.status === 'completed' || s.status === 'skipped'
+        ).length;
+        const totalSections = sectionStatuses.length;
+        
+        // Get current section details
+        const currentSection = sections.find(s => s.id === inspection.current_section);
+        const currentSectionStatus = sectionStatuses.find(s => s.id === inspection.current_section);
+
+        // Determine if can complete (at least 50% done)
+        const canComplete = completedSections >= Math.ceil(totalSections * 0.5);
+
+        // Build response
+        const response = {
+          inspection_id: inspection.id,
+          address: inspection.address,
+          client_name: inspection.client_name,
+          inspector_name: inspection.inspector_name,
+          started_at: inspection.started_at,
+          status: inspection.status,
+          current_section: currentSection ? {
+            id: inspection.current_section,
+            name: currentSection.name,
+            status: currentSectionStatus?.status || 'in_progress',
+            findings_count: currentSectionStatus?.findings_count || 0,
+            prompt: currentSection.prompt,
+            items: currentSection.items,
+          } : null,
+          sections: sectionStatuses,
+          progress: {
+            completed: completedSections,
+            total: totalSections,
+            percentage: totalSections > 0 ? Math.round((completedSections / totalSections) * 100) : 0,
+          },
+          total_findings: findings.length,
+          total_photos: photos.length,
+          can_complete: canComplete,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to get inspection status",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/server/src/tools/navigation.ts
+++ b/server/src/tools/navigation.ts
@@ -1,0 +1,305 @@
+/**
+ * Navigation Tools - Issue #5
+ * 
+ * MCP tools for navigating through inspection sections.
+ * - inspection_suggest_next: Get guidance for current section
+ * - inspection_navigate: Move between sections
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { StorageService } from "../storage/index.js";
+import { checklistService } from "../services/checklist.js";
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerNavigationTools(server: McpServer, storage: StorageService): void {
+  // -------------------------------------------------------------------------
+  // inspection_suggest_next
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_suggest_next",
+    "Get guidance for what to do next based on current inspection state",
+    {
+      inspection_id: z.string().describe("ID of the active inspection"),
+    },
+    async ({ inspection_id }) => {
+      try {
+        // Get inspection
+        const inspection = storage.getInspection(inspection_id);
+        
+        if (!inspection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get checklist and current section
+        const checklistId = 'nz-ppi'; // TODO: Store with inspection
+        const checklist = checklistService.getChecklist(checklistId);
+        const sections = checklist?.sections || [];
+        const currentSection = sections.find(s => s.id === inspection.current_section);
+        const currentIndex = sections.findIndex(s => s.id === inspection.current_section);
+
+        // Get findings for current section
+        const findings = storage.getFindings(inspection_id);
+        const currentFindings = findings.filter(f => f.section === inspection.current_section);
+
+        // Generate suggestions based on checklist items
+        const suggestions: string[] = [];
+        if (currentSection?.items) {
+          suggestions.push(...currentSection.items.slice(0, 3).map(item => `Check: ${item}`));
+        }
+
+        // Add contextual suggestions
+        if (currentFindings.length === 0) {
+          suggestions.push("Send a photo if you notice any issues");
+        }
+
+        // Calculate progress
+        const completedSections = sections.filter(s => {
+          const sectionFindings = findings.filter(f => f.section === s.id);
+          return sectionFindings.length > 0 || s.id < (inspection.current_section || '');
+        }).length;
+        const totalSections = sections.length;
+        const canComplete = completedSections >= Math.ceil(totalSections * 0.5);
+
+        // Get next section info
+        let nextSection = null;
+        if (currentIndex >= 0 && currentIndex < sections.length - 1) {
+          const next = sections[currentIndex + 1];
+          nextSection = { id: next.id, name: next.name };
+        }
+
+        // Build response
+        const response = {
+          inspection_id,
+          current_section: currentSection ? {
+            id: inspection.current_section,
+            name: currentSection.name,
+            prompt: currentSection.prompt,
+            items: currentSection.items,
+            findings_count: currentFindings.length,
+          } : null,
+          progress: {
+            completed: completedSections,
+            total: totalSections,
+            percentage: totalSections > 0 ? Math.round((completedSections / totalSections) * 100) : 0,
+          },
+          suggestions,
+          next_section: nextSection,
+          can_complete: canComplete,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to get suggestions",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // inspection_navigate
+  // -------------------------------------------------------------------------
+  server.tool(
+    "inspection_navigate",
+    "Navigate to a different section of the inspection checklist",
+    {
+      inspection_id: z.string().describe("ID of the active inspection"),
+      action: z.string().describe("'next', 'back', 'skip', or a section ID to jump to"),
+    },
+    async ({ inspection_id, action }) => {
+      try {
+        // Get inspection
+        const inspection = storage.getInspection(inspection_id);
+        
+        if (!inspection) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Get checklist
+        const checklistId = 'nz-ppi'; // TODO: Store with inspection
+        const checklist = checklistService.getChecklist(checklistId);
+        const sections = checklist?.sections || [];
+        const currentIndex = sections.findIndex(s => s.id === inspection.current_section);
+        const totalSections = sections.length;
+        
+        let newSectionId: string | null = null;
+        const actionLower = action.toLowerCase();
+
+        switch (actionLower) {
+          case 'next':
+            if (currentIndex < totalSections - 1) {
+              newSectionId = sections[currentIndex + 1].id;
+            } else {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    error: "Already at last section",
+                    current_section: inspection.current_section,
+                    suggestion: "Use 'inspection_complete' to finish the inspection",
+                  }, null, 2),
+                }],
+                isError: true,
+              };
+            }
+            break;
+
+          case 'back':
+            if (currentIndex > 0) {
+              newSectionId = sections[currentIndex - 1].id;
+            } else {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    error: "Already at first section",
+                    current_section: inspection.current_section,
+                  }, null, 2),
+                }],
+                isError: true,
+              };
+            }
+            break;
+
+          case 'skip':
+            if (currentIndex < totalSections - 1) {
+              newSectionId = sections[currentIndex + 1].id;
+            } else {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    error: "Already at last section",
+                    current_section: inspection.current_section,
+                    suggestion: "Use 'inspection_complete' to finish the inspection",
+                  }, null, 2),
+                }],
+                isError: true,
+              };
+            }
+            break;
+
+          default:
+            // Treat action as section ID
+            const targetSection = sections.find(s => s.id === actionLower);
+            if (targetSection) {
+              newSectionId = targetSection.id;
+            } else {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    error: "Invalid section ID",
+                    provided: action,
+                    available_sections: sections.map(s => s.id),
+                  }, null, 2),
+                }],
+                isError: true,
+              };
+            }
+        }
+
+        if (!newSectionId) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Navigation failed",
+                action,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        // Update inspection's current section
+        storage.updateInspection(inspection_id, {
+          current_section: newSectionId,
+        });
+
+        // Get new section details
+        const newSection = sections.find(s => s.id === newSectionId);
+
+        // Calculate progress
+        const findings = storage.getFindings(inspection_id);
+        const completedSections = sections.filter(s => {
+          const sectionFindings = findings.filter(f => f.section === s.id);
+          return sectionFindings.length > 0;
+        }).length;
+
+        // Build response
+        const response = {
+          inspection_id,
+          action,
+          previous_section: {
+            id: inspection.current_section,
+          },
+          current_section: newSection ? {
+            id: newSectionId,
+            name: newSection.name,
+            prompt: newSection.prompt,
+            items: newSection.items,
+          } : null,
+          progress: {
+            completed: completedSections,
+            total: totalSections,
+            percentage: totalSections > 0 ? Math.round((completedSections / totalSections) * 100) : 0,
+          },
+          message: newSection ? `Moved to ${newSection.name}. ${newSection.prompt}` : `Moved to ${newSectionId}`,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Navigation failed",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
Implement the first four MCP tools for the inspection workflow, using the real SQLite storage layer.

## Tools Implemented

### `inspection_start` (Issue #3)
Create a new inspection session.
- Creates inspection in SQLite database
- Loads checklist from config
- Returns first section with prompt and items

### `inspection_status` (Issue #3)
Get current inspection state and progress.
- Returns all section statuses
- Calculates completion percentage
- Includes current section details

### `inspection_suggest_next` (Issue #5)
Get guidance for current section.
- Current section prompt and checklist items
- Progress tracking
- Suggestions based on checklist
- Next section preview

### `inspection_navigate` (Issue #5)
Move between sections.
- 'next': Move to next section
- 'back': Return to previous section
- 'skip': Skip current, move to next
- Section ID: Jump to specific section

## New Files
- `server/src/tools/inspection.ts` — inspection_start, inspection_status
- `server/src/tools/navigation.ts` — inspection_navigate, inspection_suggest_next
- `server/src/services/checklist.ts` — Checklist loading from YAML

## Changes
- `server/src/index.ts` — Initialize storage, pass to tools
- `server/src/tools/index.ts` — Register new tools
- `server/src/services/index.ts` — Export checklist service
- `server/package.json` — Added yaml dependency

## Testing
```bash
cd server
npm install
npm run typecheck  # ✅ Passes
npm run build      # ✅ Builds successfully
```

## Notes
- Uses real SQLite storage layer from main branch
- Checklist ID currently defaults to 'nz-ppi' (TODO: store with inspection)
- Stub implementations remain for #4 and #6

Closes #3, Closes #5