### PR TITLE
chore(dx): Add pre-commit hooks and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+<!-- Brief description of changes -->
+
+## Changes
+<!-- List key changes -->
+- 
+
+## Testing
+<!-- How was this tested? -->
+- [ ] Ran locally
+- [ ] Added/updated tests
+
+## Checklist
+- [ ] `npm run typecheck` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run build` succeeds
+- [ ] PR title follows conventional commits (feat/fix/chore/docs)
+- [ ] Linked to issue (Closes #XX or Relates to #XX)
+
+## Screenshots
+<!-- If applicable -->

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,7 @@
+// Skip Husky install in CI or if not in a git repo
+if (process.env.CI || !process.env.npm_lifecycle_event?.includes('prepare')) {
+  process.exit(0);
+}
+
+const husky = (await import('husky')).default;
+console.log(husky());

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run from mcp directory (MCP server)
+cd mcp
+
+echo "🔍 Running typecheck..."
+npm run typecheck || exit 1
+
+echo "🧹 Running lint..."
+npm run lint || exit 1
+
+echo "✅ Pre-commit checks passed!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "ai-inspection",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-inspection",
+      "devDependencies": {
+        "husky": "^9.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "web"
   ],
   "scripts": {
+    "prepare": "husky || true",
     "dev": "npm run dev --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present"
+  },
+  "devDependencies": {
+    "husky": "^9.0.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
Adds developer workflow improvements to catch issues before CI.

## Changes

### Pre-commit hooks (Husky)
- Runs `npm run typecheck` before commit
- Runs `npm run lint` before commit
- Devs can't commit if checks fail

### PR Template
- Summary/Changes sections
- Testing checklist
- **CI checklist** (typecheck, lint, build)
- Conventional commit reminder
- Issue linking reminder

## Setup
After pulling, run `npm install` in root to activate hooks.

## Note
Pre-commit hook caught existing issues in main (missing type declarations for vitest, puppeteer, handlebars). Separate fix needed.

## Checklist
- [x] PR template created
- [x] Pre-commit hooks configured
- [x] Husky setup in root package.json

Closes #48