### PR TITLE
[Alex] feat(api): implement inspection CRUD endpoints

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import { healthRouter } from './routes/health.js';
+import { inspectionsRouter } from './routes/inspections.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -13,6 +14,7 @@ app.use(express.json());
 
 // Routes
 app.use('/health', healthRouter);
+app.use('/api/inspections', inspectionsRouter);
 
 // Error handling
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -1,1 +1,2 @@
 export * from './health.js';
+export * from './inspections.js';

--- a/api/src/routes/inspections.ts
+++ b/api/src/routes/inspections.ts
@@ -1,0 +1,126 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient, type Prisma } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import { InspectionService, InspectionNotFoundError } from '../services/inspection.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new InspectionService(repository);
+
+export const inspectionsRouter = Router();
+
+// Validation schemas
+const CreateInspectionSchema = z.object({
+  address: z.string().min(1, 'Address is required'),
+  clientName: z.string().min(1, 'Client name is required'),
+  inspectorName: z.string().optional(),
+  checklistId: z.string().min(1, 'Checklist ID is required'),
+  currentSection: z.string().default('exterior'),
+  metadata: z.any().optional(),
+});
+
+const UpdateInspectionSchema = z.object({
+  address: z.string().min(1).optional(),
+  clientName: z.string().min(1).optional(),
+  inspectorName: z.string().optional(),
+  status: z.enum(['STARTED', 'IN_PROGRESS', 'COMPLETED']).optional(),
+  currentSection: z.string().optional(),
+  metadata: z.any().optional(),
+  completedAt: z.string().datetime().optional(),
+});
+
+// POST /api/inspections - Create inspection
+inspectionsRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = CreateInspectionSchema.safeParse(req.body);
+    
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const inspection = await service.create({
+      ...parsed.data,
+      metadata: parsed.data.metadata as Prisma.InputJsonValue | undefined,
+    });
+    res.status(201).json(inspection);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/inspections - List all inspections
+inspectionsRouter.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const inspections = await service.findAll();
+    res.json(inspections);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/inspections/:id - Get inspection by ID
+inspectionsRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const inspection = await service.findById(id);
+    res.json(inspection);
+  } catch (error) {
+    if (error instanceof InspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// PUT /api/inspections/:id - Update inspection
+inspectionsRouter.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateInspectionSchema.safeParse(req.body);
+    
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    // Convert completedAt string to Date if provided
+    const updateData = {
+      ...parsed.data,
+      metadata: parsed.data.metadata as Prisma.InputJsonValue | undefined,
+      completedAt: parsed.data.completedAt ? new Date(parsed.data.completedAt) : undefined,
+    };
+    
+    const inspection = await service.update(id, updateData);
+    res.json(inspection);
+  } catch (error) {
+    if (error instanceof InspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/inspections/:id - Delete inspection
+inspectionsRouter.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.delete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof InspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,2 +1,1 @@
-// Services will be implemented in future issues
-// This file is a placeholder for the service layer
+export * from './inspection.js';

--- a/api/src/services/inspection.ts
+++ b/api/src/services/inspection.ts
@@ -1,0 +1,59 @@
+import type { Inspection } from '@prisma/client';
+import type {
+  IInspectionRepository,
+  CreateInspectionInput,
+  UpdateInspectionInput,
+} from '../repositories/interfaces/inspection.js';
+
+export class InspectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Inspection not found: ${id}`);
+    this.name = 'InspectionNotFoundError';
+  }
+}
+
+export class InspectionService {
+  constructor(private repository: IInspectionRepository) {}
+
+  async create(input: CreateInspectionInput): Promise<Inspection> {
+    return this.repository.create(input);
+  }
+
+  async findAll(): Promise<Inspection[]> {
+    return this.repository.findAll();
+  }
+
+  async findById(id: string): Promise<Inspection> {
+    const inspection = await this.repository.findById(id);
+    if (!inspection) {
+      throw new InspectionNotFoundError(id);
+    }
+    return inspection;
+  }
+
+  async update(id: string, input: UpdateInspectionInput): Promise<Inspection> {
+    // Verify exists first
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    // Verify exists first
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+
+  async complete(id: string): Promise<Inspection> {
+    return this.update(id, {
+      status: 'COMPLETED',
+      completedAt: new Date(),
+    });
+  }
+
+  async navigate(id: string, section: string): Promise<Inspection> {
+    return this.update(id, {
+      currentSection: section,
+      status: 'IN_PROGRESS',
+    });
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -33,6 +33,7 @@
     "eslint": "^9.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.56.0",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,7 @@
         "eslint": "^9.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
+        "typescript-eslint": "^8.56.0",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -4635,7 +4636,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5519,6 +5519,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/uglify-js": {


### PR DESCRIPTION
## Summary
Implements inspection CRUD endpoints as specified in #29.

## Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/inspections` | Create inspection |
| GET | `/api/inspections` | List all inspections |
| GET | `/api/inspections/:id` | Get inspection by ID |
| PUT | `/api/inspections/:id` | Update inspection |
| DELETE | `/api/inspections/:id` | Delete inspection (cascades) |

## Changes
- **InspectionService** — Business logic layer with error handling
- **Routes** — Express routes with Zod validation
- **Error handling** — 400 for validation, 404 for not found, 500 for server errors

## Validation
Uses Zod schemas for input validation:
- `address` — required string
- `clientName` — required string
- `checklistId` — required string
- `currentSection` — defaults to 'exterior'
- `metadata` — optional JSON object

## Testing
```bash
# Health check
curl http://localhost:3000/health
# {"status":"ok"}

# Create inspection (requires DATABASE_URL)
curl -X POST http://localhost:3000/api/inspections \
  -H "Content-Type: application/json" \
  -d '{"address":"123 Test St","clientName":"John","checklistId":"residential"}'
```

## Acceptance Criteria
- [x] Can create inspection with address + clientName
- [x] Can list all inspections
- [x] Can get single inspection by ID
- [x] Can update inspection fields
- [x] Can delete inspection (cascades to findings/photos)
- [x] Returns 404 for non-existent ID
- [x] Returns 400 for invalid input

Closes #29