### PR TITLE
[Taylor] chore(infra): docker-compose for full stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,67 @@ npm run dev    # Watch mode with auto-reload
 
 The server communicates via stdio (JSON-RPC), so you won't see output directly — use tests or OpenClaw to interact with it.
 
-## Docker
+## Local Development
+
+### Full Stack (API + DB + Web)
 
 ```bash
-docker-compose up --build
+# Start backend services (API + PostgreSQL)
+docker-compose up -d api db
+
+# Wait for healthy state
+docker-compose ps
+
+# Run database migrations
+docker-compose exec api npx prisma migrate deploy
+
+# In another terminal, start the web UI
+cd web && npm run dev
+```
+
+**Services:**
+- **API:** http://localhost:3000
+- **Web:** http://localhost:3001 (or Next.js default port)
+- **PostgreSQL:** localhost:5432
+
+### API Only
+
+```bash
+# Start API + DB
+docker-compose up api db
+
+# API available at http://localhost:3000
+# Health check: http://localhost:3000/health
+```
+
+### Database Access
+
+```bash
+# Connect to PostgreSQL
+docker-compose exec db psql -U inspection -d inspection
+
+# Run Prisma Studio (DB GUI)
+cd api && npx prisma studio
+```
+
+### Stopping Services
+
+```bash
+docker-compose down          # Stop containers
+docker-compose down -v       # Stop and remove volumes (deletes data!)
+```
+
+## Docker Services
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| `api` | 3000 | Express backend with Prisma |
+| `db` | 5432 | PostgreSQL 16 database |
+| `mcp` | 3100 | MCP server for OpenClaw |
+
+```bash
+docker-compose up --build    # Build and start all services
+docker-compose up api db     # Start only API + database
 ```
 
 ## Documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,45 @@
 services:
+  api:
+    build: ./api
+    container_name: ai-inspection-api
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+      - DATABASE_URL=postgresql://inspection:inspection@db:5432/inspection
+      - PHOTO_DIR=/app/photos
+    volumes:
+      - photos:/app/photos
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r => process.exit(r.ok ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  db:
+    image: postgres:16-alpine
+    container_name: ai-inspection-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=inspection
+      - POSTGRES_PASSWORD=inspection
+      - POSTGRES_DB=inspection
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U inspection -d inspection"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   mcp:
     build:
       context: ./mcp
@@ -8,9 +49,7 @@ services:
     ports:
       - "${MCP_PORT:-3100}:3100"
     volumes:
-      # Persist SQLite database and photos
       - ./data:/app/data
-      # Mount config files (checklists, templates)
       - ./config:/app/config:ro
     environment:
       - NODE_ENV=production
@@ -24,4 +63,5 @@ services:
       start_period: 10s
 
 volumes:
-  data:
+  pgdata:
+  photos:


### PR DESCRIPTION
## Summary
Add docker-compose.yml for local development with API + PostgreSQL.

## Changes
- **api service**: Express backend on port 3000, depends on db
- **db service**: PostgreSQL 16 on port 5432 with health checks
- **mcp service**: Kept existing MCP server config
- **README**: Added comprehensive local dev instructions

## Services
| Service | Port | Purpose |
|---------|------|---------|
| api | 3000 | Express + Prisma backend |
| db | 5432 | PostgreSQL 16 database |
| mcp | 3100 | MCP server for OpenClaw |

## Testing
⚠️ Docker daemon not running on dev machine - could not test locally.

Reviewer: please verify `docker-compose up api db` works.

## Checklist
- [x] docker-compose.yml updated
- [x] README with local dev instructions
- [x] Health checks configured
- [ ] Local testing (blocked - Docker not running)

Closes #37