### PR TITLE
[Alex] feat(api): implement findings and photos endpoints

### DIFF
--- a/api/src/__tests__/findings.test.ts
+++ b/api/src/__tests__/findings.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  FindingService,
+  FindingNotFoundError,
+  InspectionNotFoundError,
+} from '../services/finding.js';
+import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
+import type { Finding, Inspection } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): IInspectionRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  createFinding: vi.fn(),
+  findFindingById: vi.fn(),
+  findFindingsByInspection: vi.fn(),
+  updateFinding: vi.fn(),
+  deleteFinding: vi.fn(),
+  createPhoto: vi.fn(),
+  findPhotoById: vi.fn(),
+  findPhotosByFinding: vi.fn(),
+  deletePhoto: vi.fn(),
+  createReport: vi.fn(),
+  findReportById: vi.fn(),
+  findReportsByInspection: vi.fn(),
+});
+
+const mockInspection: Inspection = {
+  id: 'insp-1',
+  address: '123 Test St',
+  clientName: 'Test Client',
+  inspectorName: 'Test Inspector',
+  checklistId: 'nz-ppi',
+  status: 'IN_PROGRESS',
+  currentSection: 'exterior',
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  completedAt: null,
+};
+
+const mockFinding: Finding = {
+  id: 'find-1',
+  inspectionId: 'insp-1',
+  section: 'exterior',
+  text: 'Crack in foundation',
+  severity: 'MAJOR',
+  matchedComment: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('FindingService', () => {
+  let repository: IInspectionRepository;
+  let service: FindingService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new FindingService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a finding for existing inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.createFinding).mockResolvedValue(mockFinding);
+
+      const result = await service.create({
+        inspectionId: 'insp-1',
+        section: 'exterior',
+        text: 'Crack in foundation',
+        severity: 'MAJOR',
+      });
+
+      expect(repository.findById).toHaveBeenCalledWith('insp-1');
+      expect(repository.createFinding).toHaveBeenCalled();
+      expect(result).toEqual(mockFinding);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          inspectionId: 'non-existent',
+          section: 'exterior',
+          text: 'Test',
+        })
+      ).rejects.toThrow(InspectionNotFoundError);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return finding by id', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+
+      const result = await service.findById('find-1');
+      expect(result).toEqual(mockFinding);
+    });
+
+    it('should throw FindingNotFoundError for non-existent finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        FindingNotFoundError
+      );
+    });
+  });
+
+  describe('findByInspection', () => {
+    it('should return all findings for inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([mockFinding]);
+
+      const result = await service.findByInspection('insp-1');
+      expect(result).toEqual([mockFinding]);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findByInspection('non-existent')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update finding', async () => {
+      const updatedFinding = { ...mockFinding, text: 'Updated text' };
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+      vi.mocked(repository.updateFinding).mockResolvedValue(updatedFinding);
+
+      const result = await service.update('find-1', { text: 'Updated text' });
+      expect(result.text).toBe('Updated text');
+    });
+
+    it('should throw FindingNotFoundError for non-existent finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { text: 'Updated' })
+      ).rejects.toThrow(FindingNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+      vi.mocked(repository.deleteFinding).mockResolvedValue();
+
+      await expect(service.delete('find-1')).resolves.toBeUndefined();
+      expect(repository.deleteFinding).toHaveBeenCalledWith('find-1');
+    });
+
+    it('should throw FindingNotFoundError for non-existent finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        FindingNotFoundError
+      );
+    });
+  });
+});

--- a/api/src/__tests__/photos.test.ts
+++ b/api/src/__tests__/photos.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  PhotoService,
+  PhotoNotFoundError,
+  FindingNotFoundError,
+  InvalidBase64Error,
+} from '../services/photo.js';
+import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
+import type { Finding, Photo } from '@prisma/client';
+
+// Mock fs module
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(Buffer.from('test')),
+}));
+
+// Mock repository
+const createMockRepository = (): IInspectionRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  createFinding: vi.fn(),
+  findFindingById: vi.fn(),
+  findFindingsByInspection: vi.fn(),
+  updateFinding: vi.fn(),
+  deleteFinding: vi.fn(),
+  createPhoto: vi.fn(),
+  findPhotoById: vi.fn(),
+  findPhotosByFinding: vi.fn(),
+  deletePhoto: vi.fn(),
+  createReport: vi.fn(),
+  findReportById: vi.fn(),
+  findReportsByInspection: vi.fn(),
+});
+
+const mockFinding: Finding = {
+  id: 'find-1',
+  inspectionId: 'insp-1',
+  section: 'exterior',
+  text: 'Crack in foundation',
+  severity: 'MAJOR',
+  matchedComment: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockPhoto: Photo = {
+  id: 'photo-1',
+  findingId: 'find-1',
+  filename: 'test.jpg',
+  path: '/tmp/photos/test.jpg',
+  mimeType: 'image/jpeg',
+  createdAt: new Date(),
+};
+
+// Valid base64 for a tiny PNG
+const validBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('PhotoService', () => {
+  let repository: IInspectionRepository;
+  let service: PhotoService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new PhotoService(repository, '/tmp/test-photos');
+    vi.clearAllMocks();
+  });
+
+  describe('upload', () => {
+    it('should upload photo for existing finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+      vi.mocked(repository.createPhoto).mockResolvedValue(mockPhoto);
+
+      const result = await service.upload({
+        findingId: 'find-1',
+        base64Data: validBase64,
+        mimeType: 'image/png',
+      });
+
+      expect(repository.findFindingById).toHaveBeenCalledWith('find-1');
+      expect(fs.mkdir).toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalled();
+      expect(repository.createPhoto).toHaveBeenCalled();
+      expect(result).toEqual(mockPhoto);
+    });
+
+    it('should handle data URL format', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+      vi.mocked(repository.createPhoto).mockResolvedValue(mockPhoto);
+
+      await service.upload({
+        findingId: 'find-1',
+        base64Data: `data:image/png;base64,${validBase64}`,
+      });
+
+      expect(repository.createPhoto).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mimeType: 'image/png',
+        })
+      );
+    });
+
+    it('should throw FindingNotFoundError for non-existent finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(null);
+
+      await expect(
+        service.upload({
+          findingId: 'non-existent',
+          base64Data: validBase64,
+        })
+      ).rejects.toThrow(FindingNotFoundError);
+    });
+
+    it('should throw InvalidBase64Error for invalid base64', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+
+      await expect(
+        service.upload({
+          findingId: 'find-1',
+          base64Data: '!!!invalid!!!',
+        })
+      ).rejects.toThrow(InvalidBase64Error);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return photo by id', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(mockPhoto);
+
+      const result = await service.findById('photo-1');
+      expect(result).toEqual(mockPhoto);
+    });
+
+    it('should throw PhotoNotFoundError for non-existent photo', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        PhotoNotFoundError
+      );
+    });
+  });
+
+  describe('findByFinding', () => {
+    it('should return all photos for finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(mockFinding);
+      vi.mocked(repository.findPhotosByFinding).mockResolvedValue([mockPhoto]);
+
+      const result = await service.findByFinding('find-1');
+      expect(result).toEqual([mockPhoto]);
+    });
+
+    it('should throw FindingNotFoundError for non-existent finding', async () => {
+      vi.mocked(repository.findFindingById).mockResolvedValue(null);
+
+      await expect(service.findByFinding('non-existent')).rejects.toThrow(
+        FindingNotFoundError
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete photo and file', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(mockPhoto);
+      vi.mocked(repository.deletePhoto).mockResolvedValue();
+
+      await expect(service.delete('photo-1')).resolves.toBeUndefined();
+      expect(fs.unlink).toHaveBeenCalledWith(mockPhoto.path);
+      expect(repository.deletePhoto).toHaveBeenCalledWith('photo-1');
+    });
+
+    it('should throw PhotoNotFoundError for non-existent photo', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        PhotoNotFoundError
+      );
+    });
+
+    it('should continue if file deletion fails', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(mockPhoto);
+      vi.mocked(fs.unlink).mockRejectedValue(new Error('File not found'));
+      vi.mocked(repository.deletePhoto).mockResolvedValue();
+
+      // Should not throw - just logs warning
+      await expect(service.delete('photo-1')).resolves.toBeUndefined();
+      expect(repository.deletePhoto).toHaveBeenCalledWith('photo-1');
+    });
+  });
+
+  describe('getFilePath', () => {
+    it('should return file path for photo', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(mockPhoto);
+
+      const result = await service.getFilePath('photo-1');
+      expect(result).toBe(mockPhoto.path);
+    });
+
+    it('should throw PhotoNotFoundError for non-existent photo', async () => {
+      vi.mocked(repository.findPhotoById).mockResolvedValue(null);
+
+      await expect(service.getFilePath('non-existent')).rejects.toThrow(
+        PhotoNotFoundError
+      );
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,6 +3,8 @@ import cors from 'cors';
 import helmet from 'helmet';
 import { healthRouter } from './routes/health.js';
 import { inspectionsRouter } from './routes/inspections.js';
+import { findingsRouter } from './routes/findings.js';
+import { photosRouter } from './routes/photos.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -10,11 +12,13 @@ const PORT = process.env.PORT || 3000;
 // Middleware
 app.use(helmet());
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 
 // Routes
 app.use('/health', healthRouter);
 app.use('/api/inspections', inspectionsRouter);
+app.use('/api', findingsRouter);
+app.use('/api', photosRouter);
 
 // Error handling
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/routes/findings.ts
+++ b/api/src/routes/findings.ts
@@ -1,0 +1,123 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient, type Severity } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import { FindingService, FindingNotFoundError, InspectionNotFoundError } from '../services/finding.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new FindingService(repository);
+
+export const findingsRouter = Router();
+
+// Validation schemas
+const CreateFindingSchema = z.object({
+  section: z.string().min(1, 'Section is required'),
+  text: z.string().min(1, 'Text is required'),
+  severity: z.enum(['INFO', 'MINOR', 'MAJOR', 'URGENT']).optional(),
+  matchedComment: z.string().optional(),
+});
+
+const UpdateFindingSchema = z.object({
+  text: z.string().min(1).optional(),
+  severity: z.enum(['INFO', 'MINOR', 'MAJOR', 'URGENT']).optional(),
+  matchedComment: z.string().optional(),
+});
+
+// POST /api/inspections/:inspectionId/findings - Add finding to inspection
+findingsRouter.post(
+  '/inspections/:inspectionId/findings',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = CreateFindingSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const finding = await service.create({
+        inspectionId,
+        section: parsed.data.section,
+        text: parsed.data.text,
+        severity: parsed.data.severity as Severity | undefined,
+        matchedComment: parsed.data.matchedComment,
+      });
+
+      res.status(201).json(finding);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/inspections/:inspectionId/findings - List findings for inspection
+findingsRouter.get(
+  '/inspections/:inspectionId/findings',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const findings = await service.findByInspection(inspectionId);
+      res.json(findings);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// PUT /api/findings/:id - Update finding
+findingsRouter.put('/findings/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateFindingSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const finding = await service.update(id, {
+      text: parsed.data.text,
+      severity: parsed.data.severity as Severity | undefined,
+      matchedComment: parsed.data.matchedComment,
+    });
+
+    res.json(finding);
+  } catch (error) {
+    if (error instanceof FindingNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/findings/:id - Delete finding
+findingsRouter.delete('/findings/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.delete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof FindingNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -1,2 +1,4 @@
 export * from './health.js';
 export * from './inspections.js';
+export * from './findings.js';
+export * from './photos.js';

--- a/api/src/routes/photos.ts
+++ b/api/src/routes/photos.ts
@@ -1,0 +1,119 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import * as fs from 'node:fs/promises';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import {
+  PhotoService,
+  PhotoNotFoundError,
+  FindingNotFoundError,
+  InvalidBase64Error,
+} from '../services/photo.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new PhotoService(repository);
+
+export const photosRouter = Router();
+
+// Validation schema
+const UploadPhotoSchema = z.object({
+  base64Data: z.string().min(1, 'Base64 data is required'),
+  mimeType: z.string().optional(),
+});
+
+// POST /api/findings/:findingId/photos - Upload photo to finding
+photosRouter.post(
+  '/findings/:findingId/photos',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const findingId = req.params.findingId as string;
+      const parsed = UploadPhotoSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const photo = await service.upload({
+        findingId,
+        base64Data: parsed.data.base64Data,
+        mimeType: parsed.data.mimeType,
+      });
+
+      res.status(201).json(photo);
+    } catch (error) {
+      if (error instanceof FindingNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof InvalidBase64Error) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/photos/:id - Get photo (serve file)
+photosRouter.get('/photos/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const photo = await service.findById(id);
+
+    // Check if file exists
+    try {
+      await fs.access(photo.path);
+    } catch {
+      res.status(404).json({ error: 'Photo file not found on disk' });
+      return;
+    }
+
+    // Serve the file
+    res.setHeader('Content-Type', photo.mimeType);
+    res.setHeader('Content-Disposition', `inline; filename="${photo.filename}"`);
+    
+    const fileBuffer = await fs.readFile(photo.path);
+    res.send(fileBuffer);
+  } catch (error) {
+    if (error instanceof PhotoNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// GET /api/photos/:id/metadata - Get photo metadata
+photosRouter.get('/photos/:id/metadata', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const photo = await service.findById(id);
+    res.json(photo);
+  } catch (error) {
+    if (error instanceof PhotoNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/photos/:id - Delete photo
+photosRouter.delete('/photos/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.delete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof PhotoNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/services/finding.ts
+++ b/api/src/services/finding.ts
@@ -1,0 +1,58 @@
+import type { Finding } from '@prisma/client';
+import type {
+  IInspectionRepository,
+  CreateFindingInput,
+  UpdateFindingInput,
+} from '../repositories/interfaces/inspection.js';
+import { InspectionNotFoundError } from './inspection.js';
+
+export { InspectionNotFoundError };
+
+export class FindingNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Finding not found: ${id}`);
+    this.name = 'FindingNotFoundError';
+  }
+}
+
+export class FindingService {
+  constructor(private repository: IInspectionRepository) {}
+
+  async create(input: CreateFindingInput): Promise<Finding> {
+    // Verify inspection exists
+    const inspection = await this.repository.findById(input.inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(input.inspectionId);
+    }
+    return this.repository.createFinding(input);
+  }
+
+  async findById(id: string): Promise<Finding> {
+    const finding = await this.repository.findFindingById(id);
+    if (!finding) {
+      throw new FindingNotFoundError(id);
+    }
+    return finding;
+  }
+
+  async findByInspection(inspectionId: string): Promise<Finding[]> {
+    // Verify inspection exists
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+    return this.repository.findFindingsByInspection(inspectionId);
+  }
+
+  async update(id: string, input: UpdateFindingInput): Promise<Finding> {
+    // Verify exists
+    await this.findById(id);
+    return this.repository.updateFinding(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    // Verify exists
+    await this.findById(id);
+    await this.repository.deleteFinding(id);
+  }
+}

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,1 +1,3 @@
-export * from './inspection.js';
+export { InspectionService, InspectionNotFoundError } from './inspection.js';
+export { FindingService, FindingNotFoundError } from './finding.js';
+export { PhotoService, PhotoNotFoundError, InvalidBase64Error, type UploadPhotoInput } from './photo.js';

--- a/api/src/services/photo.ts
+++ b/api/src/services/photo.ts
@@ -1,0 +1,157 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import type { Photo } from '@prisma/client';
+import type { IInspectionRepository, CreatePhotoInput } from '../repositories/interfaces/inspection.js';
+import { FindingNotFoundError } from './finding.js';
+
+export { FindingNotFoundError };
+
+export class PhotoNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Photo not found: ${id}`);
+    this.name = 'PhotoNotFoundError';
+  }
+}
+
+export class InvalidBase64Error extends Error {
+  constructor() {
+    super('Invalid base64 data');
+    this.name = 'InvalidBase64Error';
+  }
+}
+
+export interface UploadPhotoInput {
+  findingId: string;
+  base64Data: string;
+  mimeType?: string;
+}
+
+export class PhotoService {
+  private photoDir: string;
+
+  constructor(private repository: IInspectionRepository, photoDir?: string) {
+    this.photoDir = photoDir || process.env.PHOTO_DIR || './uploads/photos';
+  }
+
+  async upload(input: UploadPhotoInput): Promise<Photo> {
+    // Verify finding exists
+    const finding = await this.repository.findFindingById(input.findingId);
+    if (!finding) {
+      throw new FindingNotFoundError(input.findingId);
+    }
+
+    // Parse base64 data
+    let base64Data = input.base64Data;
+    let mimeType = input.mimeType || 'image/jpeg';
+
+    // Handle data URL format (e.g., "data:image/png;base64,...")
+    if (base64Data.startsWith('data:')) {
+      const matches = base64Data.match(/^data:([^;]+);base64,(.+)$/);
+      if (matches) {
+        mimeType = matches[1] as string;
+        base64Data = matches[2] as string;
+      }
+    }
+
+    // Validate base64
+    let buffer: Buffer;
+    try {
+      // Check if it's valid base64 by verifying it can be decoded and re-encoded
+      buffer = Buffer.from(base64Data, 'base64');
+      const reEncoded = buffer.toString('base64');
+      // Allow some padding differences, but core content must match
+      if (buffer.length === 0 || !this.isValidBase64(base64Data)) {
+        throw new InvalidBase64Error();
+      }
+    } catch (err) {
+      if (err instanceof InvalidBase64Error) {
+        throw err;
+      }
+      throw new InvalidBase64Error();
+    }
+
+    // Generate unique filename
+    const ext = this.getExtensionFromMimeType(mimeType);
+    const filename = `${crypto.randomUUID()}${ext}`;
+
+    // Ensure directory exists
+    await fs.mkdir(this.photoDir, { recursive: true });
+
+    // Write file
+    const filePath = path.join(this.photoDir, filename);
+    await fs.writeFile(filePath, buffer);
+
+    // Create database record
+    const photoInput: CreatePhotoInput = {
+      findingId: input.findingId,
+      filename,
+      path: filePath,
+      mimeType,
+    };
+
+    return this.repository.createPhoto(photoInput);
+  }
+
+  async findById(id: string): Promise<Photo> {
+    const photo = await this.repository.findPhotoById(id);
+    if (!photo) {
+      throw new PhotoNotFoundError(id);
+    }
+    return photo;
+  }
+
+  async findByFinding(findingId: string): Promise<Photo[]> {
+    // Verify finding exists
+    const finding = await this.repository.findFindingById(findingId);
+    if (!finding) {
+      throw new FindingNotFoundError(findingId);
+    }
+    return this.repository.findPhotosByFinding(findingId);
+  }
+
+  async delete(id: string): Promise<void> {
+    // Get photo first to get file path
+    const photo = await this.findById(id);
+
+    // Delete file from disk
+    try {
+      await fs.unlink(photo.path);
+    } catch (err) {
+      // Log but don't fail if file doesn't exist
+      console.warn(`Failed to delete photo file: ${photo.path}`, err);
+    }
+
+    // Delete database record
+    await this.repository.deletePhoto(id);
+  }
+
+  async getFilePath(id: string): Promise<string> {
+    const photo = await this.findById(id);
+    return photo.path;
+  }
+
+  private getExtensionFromMimeType(mimeType: string): string {
+    const extensions: Record<string, string> = {
+      'image/jpeg': '.jpg',
+      'image/jpg': '.jpg',
+      'image/png': '.png',
+      'image/gif': '.gif',
+      'image/webp': '.webp',
+    };
+    return extensions[mimeType] || '.jpg';
+  }
+
+  private isValidBase64(str: string): boolean {
+    // Valid base64 pattern: alphanumeric, +, /, and optional = padding
+    const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+    if (!base64Regex.test(str)) {
+      return false;
+    }
+    // Length should be a multiple of 4 (accounting for padding)
+    if (str.length % 4 !== 0) {
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
Implements findings and photos endpoints with repository pattern.

## Changes
### Findings Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/inspections/:id/findings` | Add finding |
| GET | `/api/inspections/:id/findings` | List findings |
| PUT | `/api/findings/:id` | Update finding |
| DELETE | `/api/findings/:id` | Delete finding |

### Photos Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/findings/:id/photos` | Upload photo (base64) |
| GET | `/api/photos/:id` | Get/serve photo |
| DELETE | `/api/photos/:id` | Delete photo |

### Key Features
- FindingService with full CRUD operations
- PhotoService with base64 upload and disk storage
- Data URL format support (`data:image/png;base64,...`)
- Cascade delete from finding to photos
- 404 for non-existent IDs
- Increased JSON body limit to 10MB for photo uploads

## Tests
- FindingService: 10 unit tests
- PhotoService: 13 unit tests

All 77 tests pass (API + MCP).

## Checklist
- [x] Can add finding to inspection with text + severity
- [x] Can upload photo (base64) to finding
- [x] Can retrieve photo by ID
- [x] Can delete finding (cascades to photos)
- [x] Photos stored on disk, path saved in DB
- [x] Returns 404 for non-existent IDs

Closes #30