### PR TITLE
[Alex] feat(api): implement report generation endpoint

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,9 +20,11 @@
   },
   "dependencies": {
     "@prisma/client": "^6.0.0",
-    "express": "^4.21.0",
     "cors": "^2.8.5",
+    "express": "^4.21.0",
+    "handlebars": "^4.7.8",
     "helmet": "^8.0.0",
+    "puppeteer": "^24.37.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/api/src/__tests__/reports.test.ts
+++ b/api/src/__tests__/reports.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ReportService,
+  ReportNotFoundError,
+  InspectionNotFoundError,
+} from '../services/report.js';
+import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
+import type { Report, Inspection, Finding, Photo } from '@prisma/client';
+
+// Mock puppeteer
+vi.mock('puppeteer', () => ({
+  default: {
+    launch: vi.fn().mockResolvedValue({
+      newPage: vi.fn().mockResolvedValue({
+        setContent: vi.fn().mockResolvedValue(undefined),
+        pdf: vi.fn().mockResolvedValue(Buffer.from('mock pdf')),
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+// Mock fs
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue('<html>{{address}}</html>'),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(Buffer.from('mock pdf')),
+}));
+
+// Mock repository
+const createMockRepository = (): IInspectionRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  createFinding: vi.fn(),
+  findFindingById: vi.fn(),
+  findFindingsByInspection: vi.fn(),
+  updateFinding: vi.fn(),
+  deleteFinding: vi.fn(),
+  createPhoto: vi.fn(),
+  findPhotoById: vi.fn(),
+  findPhotosByFinding: vi.fn(),
+  deletePhoto: vi.fn(),
+  createReport: vi.fn(),
+  findReportById: vi.fn(),
+  findReportsByInspection: vi.fn(),
+});
+
+const mockInspection: Inspection = {
+  id: 'insp-1',
+  address: '123 Test St',
+  clientName: 'Test Client',
+  inspectorName: 'Test Inspector',
+  checklistId: 'nz-ppi',
+  status: 'COMPLETED',
+  currentSection: 'exterior',
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  completedAt: new Date(),
+};
+
+const mockFinding: Finding = {
+  id: 'find-1',
+  inspectionId: 'insp-1',
+  section: 'exterior',
+  text: 'Crack in foundation',
+  severity: 'MAJOR',
+  matchedComment: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockReport: Report = {
+  id: 'report-1',
+  inspectionId: 'insp-1',
+  format: 'pdf',
+  path: '/tmp/reports/insp-1.pdf',
+  createdAt: new Date(),
+};
+
+describe('ReportService', () => {
+  let repository: IInspectionRepository;
+  let service: ReportService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new ReportService(repository, '/tmp/template.html', '/tmp/reports');
+    vi.clearAllMocks();
+  });
+
+  describe('generate', () => {
+    it('should generate a report for existing inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([mockFinding]);
+      vi.mocked(repository.findPhotosByFinding).mockResolvedValue([]);
+      vi.mocked(repository.createReport).mockResolvedValue(mockReport);
+
+      const result = await service.generate('insp-1');
+
+      expect(repository.findById).toHaveBeenCalledWith('insp-1');
+      expect(repository.findFindingsByInspection).toHaveBeenCalledWith('insp-1');
+      expect(repository.createReport).toHaveBeenCalled();
+      expect(result).toEqual(mockReport);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.generate('non-existent')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+  });
+
+  describe('getLatest', () => {
+    it('should return the latest report', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findReportsByInspection).mockResolvedValue([mockReport]);
+
+      const result = await service.getLatest('insp-1');
+      expect(result).toEqual(mockReport);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.getLatest('non-existent')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+
+    it('should throw ReportNotFoundError when no reports exist', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findReportsByInspection).mockResolvedValue([]);
+
+      await expect(service.getLatest('insp-1')).rejects.toThrow(
+        ReportNotFoundError
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should return report by id', async () => {
+      vi.mocked(repository.findReportById).mockResolvedValue(mockReport);
+
+      const result = await service.findById('report-1');
+      expect(result).toEqual(mockReport);
+    });
+
+    it('should throw ReportNotFoundError for non-existent report', async () => {
+      vi.mocked(repository.findReportById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        ReportNotFoundError
+      );
+    });
+  });
+
+  describe('getFilePath', () => {
+    it('should return file path for latest report', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findReportsByInspection).mockResolvedValue([mockReport]);
+
+      const result = await service.getFilePath('insp-1');
+      expect(result).toBe(mockReport.path);
+    });
+
+    it('should throw when no report exists', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findReportsByInspection).mockResolvedValue([]);
+
+      await expect(service.getFilePath('insp-1')).rejects.toThrow(
+        ReportNotFoundError
+      );
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,6 +5,7 @@ import { healthRouter } from './routes/health.js';
 import { inspectionsRouter } from './routes/inspections.js';
 import { findingsRouter } from './routes/findings.js';
 import { photosRouter } from './routes/photos.js';
+import { reportsRouter } from './routes/reports.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -19,6 +20,7 @@ app.use('/health', healthRouter);
 app.use('/api/inspections', inspectionsRouter);
 app.use('/api', findingsRouter);
 app.use('/api', photosRouter);
+app.use('/api', reportsRouter);
 
 // Error handling
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -2,3 +2,4 @@ export * from './health.js';
 export * from './inspections.js';
 export * from './findings.js';
 export * from './photos.js';
+export * from './reports.js';

--- a/api/src/routes/reports.ts
+++ b/api/src/routes/reports.ts
@@ -1,0 +1,110 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import * as fs from 'node:fs/promises';
+import { PrismaClient } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import {
+  ReportService,
+  ReportNotFoundError,
+  InspectionNotFoundError,
+  ReportGenerationError,
+} from '../services/report.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new ReportService(repository);
+
+export const reportsRouter = Router();
+
+// POST /api/inspections/:inspectionId/report - Generate PDF report
+reportsRouter.post(
+  '/inspections/:inspectionId/report',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const report = await service.generate(inspectionId);
+
+      res.status(201).json({
+        id: report.id,
+        inspectionId: report.inspectionId,
+        format: report.format,
+        path: report.path,
+        createdAt: report.createdAt,
+      });
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof ReportGenerationError) {
+        res.status(500).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/inspections/:inspectionId/report - Get latest report (metadata)
+reportsRouter.get(
+  '/inspections/:inspectionId/report',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const report = await service.getLatest(inspectionId);
+
+      res.json({
+        id: report.id,
+        inspectionId: report.inspectionId,
+        format: report.format,
+        path: report.path,
+        createdAt: report.createdAt,
+      });
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof ReportNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/inspections/:inspectionId/report/download - Download PDF file
+reportsRouter.get(
+  '/inspections/:inspectionId/report/download',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const filePath = await service.getFilePath(inspectionId);
+
+      // Check if file exists
+      try {
+        await fs.access(filePath);
+      } catch {
+        res.status(404).json({ error: 'Report file not found on disk' });
+        return;
+      }
+
+      // Serve the PDF file
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="inspection-${inspectionId}.pdf"`);
+
+      const fileBuffer = await fs.readFile(filePath);
+      res.send(fileBuffer);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof ReportNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,3 +1,4 @@
 export { InspectionService, InspectionNotFoundError } from './inspection.js';
 export { FindingService, FindingNotFoundError } from './finding.js';
 export { PhotoService, PhotoNotFoundError, InvalidBase64Error, type UploadPhotoInput } from './photo.js';
+export { ReportService, ReportNotFoundError, ReportGenerationError } from './report.js';

--- a/api/src/services/report.ts
+++ b/api/src/services/report.ts
@@ -1,0 +1,396 @@
+/**
+ * Report Generation Service
+ * Generates PDF inspection reports using Puppeteer.
+ */
+
+import puppeteer from 'puppeteer';
+import * as fs from 'node:fs/promises';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import Handlebars from 'handlebars';
+import type { Report, Inspection, Finding, Photo } from '@prisma/client';
+import type { IInspectionRepository, CreateReportInput } from '../repositories/interfaces/inspection.js';
+
+export class ReportNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Report not found: ${id}`);
+    this.name = 'ReportNotFoundError';
+  }
+}
+
+export class InspectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Inspection not found: ${id}`);
+    this.name = 'InspectionNotFoundError';
+  }
+}
+
+export class ReportGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReportGenerationError';
+  }
+}
+
+// Types for report data
+interface ReportFinding {
+  id: string;
+  section: string;
+  text: string;
+  severity: 'info' | 'minor' | 'major' | 'urgent';
+  matchedComment?: string | null;
+}
+
+interface ReportSection {
+  id: string;
+  name: string;
+  findings: ReportFinding[];
+  conclusion: string;
+  conclusionClass: string;
+}
+
+// Register Handlebars helpers
+Handlebars.registerHelper('add', (a: number, b: number) => a + b);
+
+export class ReportService {
+  private templatePath: string;
+  private outputDir: string;
+
+  constructor(
+    private repository: IInspectionRepository,
+    templatePath?: string,
+    outputDir?: string
+  ) {
+    const projectRoot = path.resolve(process.cwd(), '..');
+    this.templatePath = templatePath || path.join(projectRoot, 'templates', 'reports', 'inspection-report.html');
+    this.outputDir = outputDir || process.env.REPORT_DIR || path.join(projectRoot, 'data', 'reports');
+  }
+
+  /**
+   * Generate a PDF report for an inspection.
+   */
+  async generate(inspectionId: string): Promise<Report> {
+    // Get inspection with findings and photos
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+
+    // Get findings and photos
+    const findings = await this.repository.findFindingsByInspection(inspectionId);
+    
+    // Collect photos from all findings
+    const photos: Photo[] = [];
+    for (const finding of findings) {
+      const findingPhotos = await this.repository.findPhotosByFinding(finding.id);
+      photos.push(...findingPhotos);
+    }
+
+    // Ensure output directory exists
+    if (!existsSync(this.outputDir)) {
+      mkdirSync(this.outputDir, { recursive: true });
+    }
+
+    // Load and compile template
+    if (!existsSync(this.templatePath)) {
+      throw new ReportGenerationError(`Template not found: ${this.templatePath}`);
+    }
+    const templateHtml = readFileSync(this.templatePath, 'utf-8');
+    const template = Handlebars.compile(templateHtml);
+
+    // Prepare template data
+    const templateData = this.prepareTemplateData(inspection, findings, photos);
+
+    // Render HTML
+    const html = template(templateData);
+
+    // Generate PDF
+    const outputPath = path.join(this.outputDir, `${inspectionId}.pdf`);
+    await this.renderPdf(html, outputPath, inspectionId);
+
+    // Save report to database
+    const reportInput: CreateReportInput = {
+      inspectionId,
+      format: 'pdf',
+      path: outputPath,
+    };
+
+    return this.repository.createReport(reportInput);
+  }
+
+  /**
+   * Get the latest report for an inspection.
+   */
+  async getLatest(inspectionId: string): Promise<Report> {
+    // Verify inspection exists
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+
+    const reports = await this.repository.findReportsByInspection(inspectionId);
+    if (reports.length === 0) {
+      throw new ReportNotFoundError(`No report generated for inspection: ${inspectionId}`);
+    }
+
+    // Reports are ordered by createdAt desc, so first is latest
+    return reports[0] as Report;
+  }
+
+  /**
+   * Get report by ID.
+   */
+  async findById(id: string): Promise<Report> {
+    const report = await this.repository.findReportById(id);
+    if (!report) {
+      throw new ReportNotFoundError(id);
+    }
+    return report;
+  }
+
+  /**
+   * Get the file path for a report.
+   */
+  async getFilePath(inspectionId: string): Promise<string> {
+    const report = await this.getLatest(inspectionId);
+    return report.path;
+  }
+
+  /**
+   * Prepare data for the template.
+   */
+  private prepareTemplateData(
+    inspection: Inspection,
+    findings: Finding[],
+    photos: Photo[]
+  ): Record<string, unknown> {
+    // Format date
+    const date = inspection.completedAt
+      ? new Date(inspection.completedAt).toLocaleDateString('en-NZ', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
+        })
+      : new Date().toLocaleDateString('en-NZ');
+
+    // Generate job number from inspection ID
+    const jobNumber = inspection.id.substring(0, 8).toUpperCase();
+
+    // Parse metadata
+    const metadata = (inspection.metadata as Record<string, unknown>) || {};
+
+    // Convert findings to report format
+    const reportFindings: ReportFinding[] = findings.map((f) => ({
+      id: f.id,
+      section: f.section,
+      text: f.text,
+      severity: f.severity.toLowerCase() as 'info' | 'minor' | 'major' | 'urgent',
+      matchedComment: f.matchedComment,
+    }));
+
+    // Get unique sections from findings
+    const sectionSet = new Set<string>();
+    for (const finding of reportFindings) {
+      sectionSet.add(finding.section);
+    }
+
+    // Build section data
+    const sections: ReportSection[] = Array.from(sectionSet).map((sectionId) => {
+      const sectionFindings = reportFindings.filter((f) => f.section === sectionId);
+      const { conclusion, conclusionClass } = this.generateConclusion(sectionFindings);
+
+      return {
+        id: sectionId,
+        name: this.formatSectionName(sectionId),
+        findings: sectionFindings,
+        conclusion,
+        conclusionClass,
+      };
+    });
+
+    // Separate urgent and major findings for summary
+    const urgentFindings = reportFindings.filter((f) => f.severity === 'urgent');
+    const majorFindings = reportFindings.filter((f) => f.severity === 'major');
+
+    // Generate executive summary
+    const executiveSummary = this.generateExecutiveSummary(reportFindings, sections.length);
+
+    // Prepare photos with captions
+    const photosWithCaptions = photos.map((photo, index) => ({
+      ...photo,
+      caption: `Inspection photo ${index + 1}`,
+      path: photo.path.startsWith('/') ? `file://${photo.path}` : photo.path,
+    }));
+
+    return {
+      // Inspection details
+      job_number: jobNumber,
+      address: inspection.address,
+      client_name: inspection.clientName,
+      inspector_name: inspection.inspectorName || 'Inspector',
+      date,
+      weather: (metadata.weather as string) || 'Fine',
+
+      // Building description
+      property_type: (metadata.property_type as string) || 'Residential',
+      year_built: (metadata.year_built as number) || 'Unknown',
+      bedrooms: (metadata.bedrooms as number) || '-',
+      bathrooms: (metadata.bathrooms as number) || '-',
+
+      // Summary
+      executive_summary: executiveSummary,
+      urgent_findings: urgentFindings.length > 0 ? urgentFindings : null,
+      major_findings: majorFindings.length > 0 ? majorFindings : null,
+
+      // Sections
+      sections,
+
+      // Photos
+      photos: photosWithCaptions,
+    };
+  }
+
+  /**
+   * Format section ID to display name.
+   */
+  private formatSectionName(sectionId: string): string {
+    return sectionId
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  /**
+   * Generate conclusion text for a section based on findings.
+   */
+  private generateConclusion(findings: ReportFinding[]): { conclusion: string; conclusionClass: string } {
+    if (findings.length === 0) {
+      return {
+        conclusion: 'No obvious defects were noted. No requirement of immediate attention or further investigation.',
+        conclusionClass: 'conclusion-good',
+      };
+    }
+
+    const hasUrgent = findings.some((f) => f.severity === 'urgent');
+    const hasMajor = findings.some((f) => f.severity === 'major');
+    const hasMinor = findings.some((f) => f.severity === 'minor');
+
+    if (hasUrgent) {
+      return {
+        conclusion: 'Significant defects noted. Immediate attention and specialist assessment recommended.',
+        conclusionClass: 'conclusion-urgent',
+      };
+    }
+
+    if (hasMajor) {
+      return {
+        conclusion: 'Items noted require attention. Recommend addressing within the next 3-6 months.',
+        conclusionClass: 'conclusion-attention',
+      };
+    }
+
+    if (hasMinor) {
+      return {
+        conclusion: 'Minor maintenance items noted as described. No requirement of immediate attention.',
+        conclusionClass: '',
+      };
+    }
+
+    return {
+      conclusion: 'Observations recorded. Routine maintenance recommended.',
+      conclusionClass: '',
+    };
+  }
+
+  /**
+   * Generate executive summary based on all findings.
+   */
+  private generateExecutiveSummary(findings: ReportFinding[], totalSections: number): string {
+    const urgentCount = findings.filter((f) => f.severity === 'urgent').length;
+    const majorCount = findings.filter((f) => f.severity === 'major').length;
+    const minorCount = findings.filter((f) => f.severity === 'minor').length;
+    const infoCount = findings.filter((f) => f.severity === 'info').length;
+
+    if (findings.length === 0) {
+      return `This property was inspected across ${totalSections} areas. No significant defects or issues were identified during the inspection. The property appears to be in good overall condition.`;
+    }
+
+    const parts: string[] = [];
+    parts.push(`This property was inspected across ${totalSections} areas.`);
+    parts.push(`A total of ${findings.length} item(s) were noted during the inspection.`);
+
+    if (urgentCount > 0) {
+      parts.push(`${urgentCount} urgent item(s) require immediate attention.`);
+    }
+    if (majorCount > 0) {
+      parts.push(`${majorCount} major item(s) should be addressed in the near term.`);
+    }
+    if (minorCount > 0) {
+      parts.push(`${minorCount} minor maintenance item(s) were observed.`);
+    }
+    if (infoCount > 0) {
+      parts.push(`${infoCount} informational observation(s) were recorded.`);
+    }
+
+    if (urgentCount > 0) {
+      parts.push('We recommend obtaining specialist assessments for urgent items before settlement.');
+    } else if (majorCount > 0) {
+      parts.push('We recommend addressing major items within 3-6 months.');
+    } else {
+      parts.push('Overall, the property is in acceptable condition with routine maintenance required.');
+    }
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Render HTML to PDF using Puppeteer.
+   */
+  private async renderPdf(html: string, outputPath: string, inspectionId: string): Promise<void> {
+    // Write HTML to temp file for debugging
+    const tempHtmlPath = path.join(this.outputDir, `${inspectionId}.html`);
+    writeFileSync(tempHtmlPath, html);
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    try {
+      const page = await browser.newPage();
+
+      // Set content and wait for images
+      await page.setContent(html, {
+        waitUntil: 'networkidle0',
+        timeout: 30000,
+      });
+
+      // Generate PDF
+      await page.pdf({
+        path: outputPath,
+        format: 'A4',
+        printBackground: true,
+        margin: {
+          top: '20mm',
+          right: '15mm',
+          bottom: '25mm',
+          left: '15mm',
+        },
+        displayHeaderFooter: true,
+        headerTemplate: `
+          <div style="font-size: 9px; width: 100%; padding: 0 15mm; display: flex; justify-content: space-between;">
+            <span>Pre-Purchase Inspection Report</span>
+            <span></span>
+          </div>
+        `,
+        footerTemplate: `
+          <div style="font-size: 9px; width: 100%; padding: 0 15mm; display: flex; justify-content: space-between;">
+            <span>Confidential</span>
+            <span>Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
+          </div>
+        `,
+      });
+    } finally {
+      await browser.close();
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,9 @@
         "@prisma/client": "^6.0.0",
         "cors": "^2.8.5",
         "express": "^4.21.0",
+        "handlebars": "^4.7.8",
         "helmet": "^8.0.0",
+        "puppeteer": "^24.37.3",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -374,6 +376,10 @@
       "resolved": "shared",
       "link": true
     },
+    "node_modules/@ai-inspection/web": {
+      "resolved": "web",
+      "link": true
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -417,6 +423,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -5460,6 +5467,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10333,10 +10341,6 @@
         }
       }
     },
-    "node_modules/web": {
-      "resolved": "web",
-      "link": true
-    },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
@@ -10646,6 +10650,7 @@
       }
     },
     "web": {
+      "name": "@ai-inspection/web",
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.6",


### PR DESCRIPTION
## Summary
Implements PDF report generation endpoint with Puppeteer.

## Changes
### Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/inspections/:id/report` | Generate PDF report |
| GET | `/api/inspections/:id/report` | Get latest report metadata |
| GET | `/api/inspections/:id/report/download` | Download PDF file |

### Key Features
- ReportService with generate, getLatest, findById, getFilePath
- PDF generation using Puppeteer with Handlebars templates
- Executive summary generated from findings
- Section conclusions based on severity (urgent/major/minor/info)
- Report records saved in database
- Returns 404 for non-existent inspection or report
- Template from `templates/reports/inspection-report.html`

## Tests
- ReportService: 9 unit tests

All 109 tests pass (API + MCP).

## Checklist
- [x] POST generates new PDF report
- [x] GET returns latest generated report
- [x] PDF includes all findings
- [x] Report record saved in database
- [x] Returns 404 if inspection not found
- [x] Returns 404 if no report generated yet (GET)

Closes #31