### PR TITLE
[Alex] feat(api): implement navigation and status endpoints

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "handlebars": "^4.7.8",
     "helmet": "^8.0.0",
     "puppeteer": "^24.37.3",
+    "yaml": "^2.8.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/api/src/__tests__/navigation.test.ts
+++ b/api/src/__tests__/navigation.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  NavigationService,
+  InspectionNotFoundError,
+  InvalidSectionError,
+} from '../services/navigation.js';
+import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
+import type { Inspection, Finding } from '@prisma/client';
+
+// Mock checklist service
+vi.mock('../services/checklist.js', () => ({
+  checklistService: {
+    getChecklist: vi.fn().mockReturnValue({
+      id: 'nz-ppi',
+      name: 'NZ Pre-Purchase Inspection',
+      version: '1.0',
+      sections: [
+        { id: 'exterior', name: 'Exterior', prompt: 'Check exterior.', items: ['walls', 'roof'] },
+        { id: 'interior', name: 'Interior', prompt: 'Check interior.', items: ['floors', 'ceilings'] },
+        { id: 'roof', name: 'Roof', prompt: 'Check roof.', items: ['tiles', 'gutters'] },
+      ],
+    }),
+    getAllSections: vi.fn().mockReturnValue([
+      { id: 'exterior', name: 'Exterior' },
+      { id: 'interior', name: 'Interior' },
+      { id: 'roof', name: 'Roof' },
+    ]),
+  },
+}));
+
+// Mock repository
+const createMockRepository = (): IInspectionRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  createFinding: vi.fn(),
+  findFindingById: vi.fn(),
+  findFindingsByInspection: vi.fn(),
+  updateFinding: vi.fn(),
+  deleteFinding: vi.fn(),
+  createPhoto: vi.fn(),
+  findPhotoById: vi.fn(),
+  findPhotosByFinding: vi.fn(),
+  deletePhoto: vi.fn(),
+  createReport: vi.fn(),
+  findReportById: vi.fn(),
+  findReportsByInspection: vi.fn(),
+});
+
+const mockInspection: Inspection = {
+  id: 'insp-1',
+  address: '123 Test St',
+  clientName: 'Test Client',
+  inspectorName: 'Test Inspector',
+  checklistId: 'nz-ppi',
+  status: 'IN_PROGRESS',
+  currentSection: 'exterior',
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  completedAt: null,
+};
+
+const mockFinding: Finding = {
+  id: 'find-1',
+  inspectionId: 'insp-1',
+  section: 'exterior',
+  text: 'Crack in wall',
+  severity: 'MAJOR',
+  matchedComment: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('NavigationService', () => {
+  let repository: IInspectionRepository;
+  let service: NavigationService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new NavigationService(repository);
+    vi.clearAllMocks();
+  });
+
+  describe('navigate', () => {
+    it('should navigate to a valid section', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.update).mockResolvedValue({ ...mockInspection, currentSection: 'interior' });
+
+      const result = await service.navigate('insp-1', 'interior');
+
+      expect(repository.update).toHaveBeenCalledWith('insp-1', {
+        currentSection: 'interior',
+        status: 'IN_PROGRESS',
+      });
+      expect(result.previousSection).toBe('exterior');
+      expect(result.currentSection).toBe('interior');
+      expect(result.sectionName).toBe('Interior');
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.navigate('non-existent', 'interior')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+
+    it('should throw InvalidSectionError for invalid section', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+
+      await expect(service.navigate('insp-1', 'invalid-section')).rejects.toThrow(
+        InvalidSectionError
+      );
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return inspection status', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([mockFinding]);
+
+      const result = await service.getStatus('insp-1');
+
+      expect(result.inspectionId).toBe('insp-1');
+      expect(result.address).toBe('123 Test St');
+      expect(result.currentSection.id).toBe('exterior');
+      expect(result.totalFindings).toBe(1);
+      expect(result.progress.total).toBe(3);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.getStatus('non-existent')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+
+    it('should calculate progress correctly', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([
+        mockFinding,
+        { ...mockFinding, id: 'find-2', section: 'interior' },
+      ]);
+
+      const result = await service.getStatus('insp-1');
+
+      // 2 sections with findings out of 3 total
+      expect(result.progress.completed).toBe(2);
+      expect(result.progress.total).toBe(3);
+      expect(result.progress.percentage).toBe(67);
+    });
+  });
+
+  describe('suggest', () => {
+    it('should suggest next unvisited section', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([mockFinding]);
+
+      const result = await service.suggest('insp-1');
+
+      expect(result.inspectionId).toBe('insp-1');
+      expect(result.currentSection).toBe('exterior');
+      expect(result.nextSection?.id).toBe('interior');
+      expect(result.remainingSections).toBe(2);
+    });
+
+    it('should throw InspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.suggest('non-existent')).rejects.toThrow(
+        InspectionNotFoundError
+      );
+    });
+
+    it('should indicate canComplete when 50% visited', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockInspection);
+      vi.mocked(repository.findFindingsByInspection).mockResolvedValue([
+        mockFinding,
+        { ...mockFinding, id: 'find-2', section: 'interior' },
+      ]);
+
+      const result = await service.suggest('insp-1');
+
+      // 2 of 3 sections = 67% > 50%
+      expect(result.canComplete).toBe(true);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,7 @@ import { inspectionsRouter } from './routes/inspections.js';
 import { findingsRouter } from './routes/findings.js';
 import { photosRouter } from './routes/photos.js';
 import { reportsRouter } from './routes/reports.js';
+import { navigationRouter } from './routes/navigation.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -21,6 +22,7 @@ app.use('/api/inspections', inspectionsRouter);
 app.use('/api', findingsRouter);
 app.use('/api', photosRouter);
 app.use('/api', reportsRouter);
+app.use('/api', navigationRouter);
 
 // Error handling
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -3,3 +3,4 @@ export * from './inspections.js';
 export * from './findings.js';
 export * from './photos.js';
 export * from './reports.js';
+export * from './navigation.js';

--- a/api/src/routes/navigation.ts
+++ b/api/src/routes/navigation.ts
@@ -1,0 +1,88 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import {
+  NavigationService,
+  InspectionNotFoundError,
+  InvalidSectionError,
+} from '../services/navigation.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new NavigationService(repository);
+
+export const navigationRouter = Router();
+
+// Validation schema
+const NavigateSchema = z.object({
+  section: z.string().min(1, 'Section is required'),
+});
+
+// POST /api/inspections/:inspectionId/navigate - Navigate to section
+navigationRouter.post(
+  '/inspections/:inspectionId/navigate',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = NavigateSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const result = await service.navigate(inspectionId, parsed.data.section);
+      res.json(result);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof InvalidSectionError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/inspections/:inspectionId/status - Get inspection status
+navigationRouter.get(
+  '/inspections/:inspectionId/status',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const status = await service.getStatus(inspectionId);
+      res.json(status);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/inspections/:inspectionId/suggest - Get next suggestion
+navigationRouter.get(
+  '/inspections/:inspectionId/suggest',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const suggestion = await service.suggest(inspectionId);
+      res.json(suggestion);
+    } catch (error) {
+      if (error instanceof InspectionNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/services/checklist.ts
+++ b/api/src/services/checklist.ts
@@ -1,0 +1,205 @@
+/**
+ * Checklist Service
+ * 
+ * Loads and manages inspection checklists from config files.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, basename, resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ChecklistItem {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+  subareas?: ChecklistSubarea[];
+  report_section?: number;
+}
+
+export interface ChecklistSubarea {
+  id: string;
+  name: string;
+  prompt: string;
+  items: string[];
+}
+
+export interface ChecklistMetadata {
+  required: string[];
+  optional: string[];
+}
+
+export interface Checklist {
+  id: string;
+  name: string;
+  version: string;
+  standard?: string;
+  metadata?: ChecklistMetadata;
+  sections: ChecklistItem[];
+  conclusions?: Record<string, string>;
+}
+
+// ============================================================================
+// Checklist Service
+// ============================================================================
+
+class ChecklistService {
+  private checklists: Map<string, Checklist> = new Map();
+  private configPath: string;
+  private loaded: boolean = false;
+
+  constructor(configPath?: string) {
+    // Default to config/checklists relative to monorepo root
+    const projectRoot = resolve(process.cwd(), '..');
+    this.configPath = configPath || join(projectRoot, 'config', 'checklists');
+  }
+
+  /**
+   * Load all checklists from config directory
+   */
+  loadChecklists(): void {
+    if (this.loaded) return;
+
+    if (!existsSync(this.configPath)) {
+      console.warn(`Checklist config path not found: ${this.configPath}`);
+      return;
+    }
+
+    const files = readdirSync(this.configPath).filter(
+      f => f.endsWith('.yaml') || f.endsWith('.yml')
+    );
+
+    for (const file of files) {
+      try {
+        const filePath = join(this.configPath, file);
+        const content = readFileSync(filePath, 'utf-8');
+        const data = parseYaml(content);
+        
+        // Generate ID from filename (e.g., nz-ppi.yaml -> nz-ppi)
+        const id = basename(file, '.yaml').replace('.yml', '');
+        
+        const checklist: Checklist = {
+          id,
+          name: data.name || id,
+          version: data.version || '1.0',
+          standard: data.standard,
+          metadata: data.metadata,
+          sections: this.normalizeSections(data.sections || []),
+          conclusions: data.conclusions,
+        };
+
+        this.checklists.set(id, checklist);
+        console.error(`Loaded checklist: ${id} (${checklist.sections.length} sections)`);
+      } catch (error) {
+        console.error(`Failed to load checklist ${file}:`, error);
+      }
+    }
+
+    this.loaded = true;
+  }
+
+  /**
+   * Normalize sections to ensure consistent structure
+   */
+  private normalizeSections(sections: any[]): ChecklistItem[] {
+    return sections.map(section => ({
+      id: section.id,
+      name: section.name,
+      prompt: section.prompt || `Check ${section.name.toLowerCase()}.`,
+      items: section.items || [],
+      subareas: section.subareas?.map((sub: any) => ({
+        id: sub.id,
+        name: sub.name,
+        prompt: sub.prompt || `Check ${sub.name.toLowerCase()}.`,
+        items: sub.items || [],
+      })),
+      report_section: section.report_section,
+    }));
+  }
+
+  /**
+   * Get a checklist by ID
+   */
+  getChecklist(id: string): Checklist | null {
+    this.loadChecklists();
+    return this.checklists.get(id) || null;
+  }
+
+  /**
+   * Get the default checklist (first one loaded, or 'nz-ppi' if available)
+   */
+  getDefaultChecklist(): Checklist | null {
+    this.loadChecklists();
+    
+    // Prefer nz-ppi as default
+    if (this.checklists.has('nz-ppi')) {
+      return this.checklists.get('nz-ppi')!;
+    }
+    
+    // Otherwise return first available
+    const first = this.checklists.values().next();
+    return first.value || null;
+  }
+
+  /**
+   * Get all available checklist IDs
+   */
+  getAvailableChecklists(): string[] {
+    this.loadChecklists();
+    return Array.from(this.checklists.keys());
+  }
+
+  /**
+   * Get the first section of a checklist
+   */
+  getFirstSection(checklistId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist || checklist.sections.length === 0) return null;
+    return checklist.sections[0];
+  }
+
+  /**
+   * Get a specific section by ID
+   */
+  getSection(checklistId: string, sectionId: string): ChecklistItem | null {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return null;
+    return checklist.sections.find(s => s.id === sectionId) || null;
+  }
+
+  /**
+   * Get all sections for a checklist (flattened, including subareas)
+   */
+  getAllSections(checklistId: string): Array<{ id: string; name: string }> {
+    const checklist = this.getChecklist(checklistId);
+    if (!checklist) return [];
+
+    const sections: Array<{ id: string; name: string }> = [];
+    
+    for (const section of checklist.sections) {
+      sections.push({ id: section.id, name: section.name });
+      
+      // Add subareas if present
+      if (section.subareas) {
+        for (const subarea of section.subareas) {
+          sections.push({ 
+            id: `${section.id}.${subarea.id}`, 
+            name: `${section.name} - ${subarea.name}` 
+          });
+        }
+      }
+    }
+
+    return sections;
+  }
+}
+
+// Export singleton instance
+export const checklistService = new ChecklistService();
+
+// Export class for testing with custom paths
+export { ChecklistService };

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -2,3 +2,5 @@ export { InspectionService, InspectionNotFoundError } from './inspection.js';
 export { FindingService, FindingNotFoundError } from './finding.js';
 export { PhotoService, PhotoNotFoundError, InvalidBase64Error, type UploadPhotoInput } from './photo.js';
 export { ReportService, ReportNotFoundError, ReportGenerationError } from './report.js';
+export { NavigationService, InvalidSectionError } from './navigation.js';
+export { checklistService, ChecklistService } from './checklist.js';

--- a/api/src/services/navigation.ts
+++ b/api/src/services/navigation.ts
@@ -1,0 +1,301 @@
+/**
+ * Navigation Service
+ * Handles inspection workflow navigation and status.
+ */
+
+import type { Inspection, Finding } from '@prisma/client';
+import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
+import { checklistService, type Checklist, type ChecklistItem } from './checklist.js';
+
+export class InspectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Inspection not found: ${id}`);
+    this.name = 'InspectionNotFoundError';
+  }
+}
+
+export class InvalidSectionError extends Error {
+  constructor(sectionId: string, checklistId: string) {
+    super(`Invalid section '${sectionId}' for checklist '${checklistId}'`);
+    this.name = 'InvalidSectionError';
+  }
+}
+
+export interface NavigationResult {
+  inspectionId: string;
+  previousSection: string;
+  currentSection: string;
+  sectionName: string;
+  prompt?: string;
+  items?: string[];
+}
+
+export interface InspectionProgress {
+  completed: number;
+  total: number;
+  percentage: number;
+}
+
+export interface SectionStatus {
+  id: string;
+  name: string;
+  findingsCount: number;
+  hasFindings: boolean;
+}
+
+export interface InspectionStatus {
+  inspectionId: string;
+  address: string;
+  clientName: string;
+  inspectorName?: string;
+  status: string;
+  currentSection: {
+    id: string;
+    name: string;
+    prompt?: string;
+    items?: string[];
+    findingsCount: number;
+  };
+  progress: InspectionProgress;
+  sections: SectionStatus[];
+  totalFindings: number;
+  canComplete: boolean;
+}
+
+export interface SuggestResult {
+  inspectionId: string;
+  currentSection: string;
+  nextSection?: {
+    id: string;
+    name: string;
+    prompt?: string;
+  };
+  remainingSections: number;
+  canComplete: boolean;
+  suggestion: string;
+}
+
+export class NavigationService {
+  constructor(private repository: IInspectionRepository) {}
+
+  /**
+   * Navigate to a specific section.
+   */
+  async navigate(inspectionId: string, sectionId: string): Promise<NavigationResult> {
+    // Get inspection
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+
+    // Validate section exists in checklist
+    const checklist = checklistService.getChecklist(inspection.checklistId);
+    if (!checklist) {
+      throw new InvalidSectionError(sectionId, inspection.checklistId);
+    }
+
+    const section = this.findSection(checklist, sectionId);
+    if (!section) {
+      throw new InvalidSectionError(sectionId, inspection.checklistId);
+    }
+
+    const previousSection = inspection.currentSection;
+
+    // Update inspection
+    await this.repository.update(inspectionId, {
+      currentSection: sectionId,
+      status: 'IN_PROGRESS',
+    });
+
+    return {
+      inspectionId,
+      previousSection,
+      currentSection: sectionId,
+      sectionName: section.name,
+      prompt: section.prompt,
+      items: section.items,
+    };
+  }
+
+  /**
+   * Get current inspection status.
+   */
+  async getStatus(inspectionId: string): Promise<InspectionStatus> {
+    // Get inspection
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+
+    // Get findings
+    const findings = await this.repository.findFindingsByInspection(inspectionId);
+
+    // Get checklist
+    const checklist = checklistService.getChecklist(inspection.checklistId);
+    const allSections = checklist ? checklistService.getAllSections(inspection.checklistId) : [];
+
+    // Count findings per section
+    const findingsBySection = this.groupFindingsBySection(findings);
+
+    // Build section statuses
+    const sectionStatuses: SectionStatus[] = allSections.map((s) => ({
+      id: s.id,
+      name: s.name,
+      findingsCount: findingsBySection.get(s.id) || 0,
+      hasFindings: (findingsBySection.get(s.id) || 0) > 0,
+    }));
+
+    // Calculate progress (sections with findings are considered visited)
+    const visitedSections = sectionStatuses.filter((s) => s.hasFindings).length;
+    const totalSections = sectionStatuses.length || 1;
+
+    // Get current section details
+    const currentSectionData = checklist
+      ? this.findSection(checklist, inspection.currentSection)
+      : null;
+
+    const currentFindingsCount = findingsBySection.get(inspection.currentSection) || 0;
+
+    // Can complete if at least 50% of sections visited
+    const canComplete = visitedSections >= Math.ceil(totalSections * 0.5);
+
+    return {
+      inspectionId,
+      address: inspection.address,
+      clientName: inspection.clientName,
+      inspectorName: inspection.inspectorName || undefined,
+      status: inspection.status,
+      currentSection: {
+        id: inspection.currentSection,
+        name: currentSectionData?.name || inspection.currentSection,
+        prompt: currentSectionData?.prompt,
+        items: currentSectionData?.items,
+        findingsCount: currentFindingsCount,
+      },
+      progress: {
+        completed: visitedSections,
+        total: totalSections,
+        percentage: Math.round((visitedSections / totalSections) * 100),
+      },
+      sections: sectionStatuses,
+      totalFindings: findings.length,
+      canComplete,
+    };
+  }
+
+  /**
+   * Get suggestion for next steps.
+   */
+  async suggest(inspectionId: string): Promise<SuggestResult> {
+    // Get inspection
+    const inspection = await this.repository.findById(inspectionId);
+    if (!inspection) {
+      throw new InspectionNotFoundError(inspectionId);
+    }
+
+    // Get findings to determine visited sections
+    const findings = await this.repository.findFindingsByInspection(inspectionId);
+    const findingsBySection = this.groupFindingsBySection(findings);
+    const visitedSectionIds = new Set(findingsBySection.keys());
+
+    // Get checklist
+    const checklist = checklistService.getChecklist(inspection.checklistId);
+    const allSections = checklist ? checklistService.getAllSections(inspection.checklistId) : [];
+
+    // Find next unvisited section
+    const currentIndex = allSections.findIndex((s) => s.id === inspection.currentSection);
+    let nextSection: { id: string; name: string; prompt?: string } | undefined;
+
+    // Look for next unvisited section after current
+    for (let i = currentIndex + 1; i < allSections.length; i++) {
+      const section = allSections[i];
+      if (section && !visitedSectionIds.has(section.id)) {
+        const sectionData = checklist ? this.findSection(checklist, section.id) : null;
+        nextSection = {
+          id: section.id,
+          name: section.name,
+          prompt: sectionData?.prompt,
+        };
+        break;
+      }
+    }
+
+    // If no unvisited section after current, look from beginning
+    if (!nextSection) {
+      for (let i = 0; i < currentIndex; i++) {
+        const section = allSections[i];
+        if (section && !visitedSectionIds.has(section.id)) {
+          const sectionData = checklist ? this.findSection(checklist, section.id) : null;
+          nextSection = {
+            id: section.id,
+            name: section.name,
+            prompt: sectionData?.prompt,
+          };
+          break;
+        }
+      }
+    }
+
+    const remainingSections = allSections.filter((s) => !visitedSectionIds.has(s.id)).length;
+    const canComplete = visitedSectionIds.size >= Math.ceil(allSections.length * 0.5);
+
+    // Generate suggestion text
+    let suggestion: string;
+    if (remainingSections === 0) {
+      suggestion = 'All sections have been visited. You can complete the inspection and generate a report.';
+    } else if (canComplete) {
+      suggestion = `You have visited ${visitedSectionIds.size} of ${allSections.length} sections. You can complete now or continue with ${remainingSections} remaining section(s).`;
+    } else {
+      suggestion = `Continue inspection. ${remainingSections} section(s) remaining. Visit at least ${Math.ceil(allSections.length * 0.5) - visitedSectionIds.size} more section(s) before completing.`;
+    }
+
+    return {
+      inspectionId,
+      currentSection: inspection.currentSection,
+      nextSection,
+      remainingSections,
+      canComplete,
+      suggestion,
+    };
+  }
+
+  /**
+   * Find a section in checklist (handles nested subareas).
+   */
+  private findSection(checklist: Checklist, sectionId: string): ChecklistItem | null {
+    // Check top-level sections
+    const section = checklist.sections.find((s) => s.id === sectionId);
+    if (section) return section;
+
+    // Check subareas (format: "section.subarea")
+    if (sectionId.includes('.')) {
+      const [parentId, subareaId] = sectionId.split('.');
+      const parent = checklist.sections.find((s) => s.id === parentId);
+      if (parent?.subareas) {
+        const subarea = parent.subareas.find((sub) => sub.id === subareaId);
+        if (subarea) {
+          return {
+            id: sectionId,
+            name: `${parent.name} - ${subarea.name}`,
+            prompt: subarea.prompt,
+            items: subarea.items,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Group findings by section.
+   */
+  private groupFindingsBySection(findings: Finding[]): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const finding of findings) {
+      const count = map.get(finding.section) || 0;
+      map.set(finding.section, count + 1);
+    }
+    return map;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "handlebars": "^4.7.8",
         "helmet": "^8.0.0",
         "puppeteer": "^24.37.3",
+        "yaml": "^2.8.2",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -10549,7 +10550,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
## Summary
Implements navigation and status endpoints for inspection workflow.

## Changes
### Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/inspections/:id/navigate` | Move to section |
| GET | `/api/inspections/:id/status` | Get current status |
| GET | `/api/inspections/:id/suggest` | Get next suggestion |

### Key Features
- NavigationService with navigate, getStatus, suggest
- ChecklistService copied from MCP (loads YAML configs)
- Navigate updates `currentSection` field
- Status returns: currentSection, progress (x/y sections), findings count
- Suggest returns: next unvisited section, can_complete flag
- Invalid section name returns 400
- Non-existent inspection returns 404

## Tests
- NavigationService: 9 unit tests

All 127 tests pass (API + MCP).

## Checklist
- [x] Navigate updates currentSection field
- [x] Status returns: currentSection, progress, findings count
- [x] Suggest returns: next items to check, can_complete flag
- [x] Invalid section name returns 400
- [x] Non-existent inspection returns 404

Closes #32