### PR TITLE
[Sam] feat(web): implement finding editor

### DIFF
--- a/web/components/finding-card.tsx
+++ b/web/components/finding-card.tsx
@@ -1,13 +1,14 @@
-import { Finding } from '@/lib/api';
+import { Finding, api } from '@/lib/api';
 import { SeverityBadge } from './status-badge';
 
 interface FindingCardProps {
   finding: Finding;
+  onEdit?: () => void;
 }
 
-export function FindingCard({ finding }: FindingCardProps): React.ReactElement {
+export function FindingCard({ finding, onEdit }: FindingCardProps): React.ReactElement {
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
+    <div className="bg-white border border-gray-200 rounded-lg p-4 group">
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
           <p className="text-sm font-medium text-gray-900">{finding.text}</p>
@@ -17,7 +18,31 @@ export function FindingCard({ finding }: FindingCardProps): React.ReactElement {
             </p>
           )}
         </div>
-        <SeverityBadge severity={finding.severity} />
+        <div className="flex items-center gap-2">
+          {onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="p-1.5 text-gray-400 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity rounded hover:bg-gray-100"
+              aria-label="Edit finding"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                />
+              </svg>
+            </button>
+          )}
+          <SeverityBadge severity={finding.severity} />
+        </div>
       </div>
 
       {finding.photos.length > 0 && (
@@ -29,7 +54,7 @@ export function FindingCard({ finding }: FindingCardProps): React.ReactElement {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={photo.path}
+                src={api.photos.getUrl(photo.id)}
                 alt={photo.filename}
                 className="w-full h-full object-cover"
               />

--- a/web/components/finding-editor.tsx
+++ b/web/components/finding-editor.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Finding, FindingSeverity, Photo, api, ApiError } from '@/lib/api';
+import { SeveritySelect } from './severity-select';
+import { PhotoUploader } from './photo-uploader';
+
+interface FindingEditorProps {
+  finding: Finding;
+  inspectionId: string;
+  onSave: (updatedFinding: Finding) => void;
+  onDelete: () => void;
+  onCancel: () => void;
+}
+
+export function FindingEditor({
+  finding,
+  inspectionId,
+  onSave,
+  onDelete,
+  onCancel,
+}: FindingEditorProps): React.ReactElement {
+  const [text, setText] = useState(finding.text);
+  const [severity, setSeverity] = useState<FindingSeverity>(finding.severity);
+  const [photos, setPhotos] = useState<Photo[]>(finding.photos);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasChanges =
+    text !== finding.text ||
+    severity !== finding.severity ||
+    photos.length !== finding.photos.length;
+
+  const handleSave = async (): Promise<void> => {
+    if (!text.trim()) {
+      setError('Finding text is required');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setError(null);
+
+      const updatedFinding = await api.findings.update(inspectionId, finding.id, {
+        text: text.trim(),
+        severity,
+      });
+
+      // Merge photos since the update endpoint doesn't return them
+      onSave({ ...updatedFinding, photos });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to save changes');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (): Promise<void> => {
+    try {
+      setDeleting(true);
+      setError(null);
+
+      await api.findings.delete(inspectionId, finding.id);
+      onDelete();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to delete finding');
+      }
+      setDeleting(false);
+    }
+  };
+
+  const handlePhotoUpload = useCallback(
+    async (base64Data: string, mimeType: string): Promise<void> => {
+      try {
+        setError(null);
+        const photo = await api.photos.upload(finding.id, base64Data, mimeType);
+        setPhotos((prev) => [...prev, photo]);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to upload photo');
+        }
+        throw err;
+      }
+    },
+    [finding.id]
+  );
+
+  const handlePhotoDelete = async (photoId: string): Promise<void> => {
+    try {
+      setError(null);
+      await api.photos.delete(photoId);
+      setPhotos((prev) => prev.filter((p) => p.id !== photoId));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to delete photo');
+      }
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Edit Finding</h2>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          {error && (
+            <div className="p-3 text-sm text-red-700 bg-red-100 rounded-lg">
+              {error}
+            </div>
+          )}
+
+          {/* Text */}
+          <div>
+            <label
+              htmlFor="finding-text"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Finding
+            </label>
+            <textarea
+              id="finding-text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={3}
+              disabled={saving || deleting}
+              className="block w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+              placeholder="Describe the finding..."
+            />
+          </div>
+
+          {/* Severity */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Severity
+            </label>
+            <SeveritySelect
+              value={severity}
+              onChange={setSeverity}
+              disabled={saving || deleting}
+            />
+          </div>
+
+          {/* Photos */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Photos
+            </label>
+            
+            {photos.length > 0 && (
+              <div className="grid grid-cols-3 gap-2 mb-3">
+                {photos.map((photo) => (
+                  <div key={photo.id} className="relative group">
+                    <div className="aspect-square bg-gray-100 rounded-lg overflow-hidden">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={api.photos.getUrl(photo.id)}
+                        alt={photo.filename}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handlePhotoDelete(photo.id)}
+                      disabled={saving || deleting}
+                      className="absolute top-1 right-1 p-1 bg-red-600 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50"
+                      aria-label="Delete photo"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <PhotoUploader
+              onUpload={handlePhotoUpload}
+              disabled={saving || deleting}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
+          {showDeleteConfirm ? (
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-700">Delete this finding?</span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={deleting}
+                  className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+                >
+                  {deleting ? 'Deleting...' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={saving || deleting}
+                className="px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+              >
+                Delete Finding
+              </button>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  disabled={saving || deleting}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving || deleting || !hasChanges}
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/index.ts
+++ b/web/components/index.ts
@@ -3,3 +3,6 @@ export { LoadingSpinner, LoadingPage } from './loading';
 export { ErrorMessage, ErrorPage } from './error';
 export { FindingCard } from './finding-card';
 export { SectionView, SectionList } from './section-view';
+export { SeveritySelect } from './severity-select';
+export { PhotoUploader } from './photo-uploader';
+export { FindingEditor } from './finding-editor';

--- a/web/components/photo-uploader.tsx
+++ b/web/components/photo-uploader.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+interface PhotoUploaderProps {
+  onUpload: (base64Data: string, mimeType: string) => Promise<void>;
+  disabled?: boolean;
+}
+
+export function PhotoUploader({
+  onUpload,
+  disabled = false,
+}: PhotoUploaderProps): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const handleClick = (): void => {
+    inputRef.current?.click();
+  };
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate file type
+    if (!file.type.startsWith('image/')) {
+      alert('Please select an image file');
+      return;
+    }
+
+    // Validate file size (max 10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      alert('Image must be less than 10MB');
+      return;
+    }
+
+    try {
+      setUploading(true);
+
+      // Convert to base64
+      const base64Data = await fileToBase64(file);
+
+      await onUpload(base64Data, file.type);
+
+      // Clear input
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    } catch (err) {
+      console.error('Upload failed:', err);
+      alert('Failed to upload photo');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleChange}
+        className="hidden"
+        disabled={disabled || uploading}
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || uploading}
+        className="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {uploading ? (
+          <>
+            <svg
+              className="w-4 h-4 mr-2 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Uploading...
+          </>
+        ) : (
+          <>
+            <svg
+              className="w-4 h-4 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Add Photo
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const result = reader.result as string;
+      // Remove data URL prefix (e.g., "data:image/png;base64,")
+      const base64 = result.split(',')[1];
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/web/components/section-view.tsx
+++ b/web/components/section-view.tsx
@@ -8,12 +8,14 @@ interface SectionViewProps {
   section: string;
   findings: Finding[];
   defaultOpen?: boolean;
+  onEditFinding?: (finding: Finding) => void;
 }
 
 export function SectionView({
   section,
   findings,
   defaultOpen = true,
+  onEditFinding,
 }: SectionViewProps): React.ReactElement {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
@@ -60,7 +62,11 @@ export function SectionView({
             <p className="text-sm text-gray-500 italic">No findings in this section</p>
           ) : (
             findings.map((finding) => (
-              <FindingCard key={finding.id} finding={finding} />
+              <FindingCard
+                key={finding.id}
+                finding={finding}
+                onEdit={onEditFinding ? () => onEditFinding(finding) : undefined}
+              />
             ))
           )}
         </div>
@@ -71,9 +77,10 @@ export function SectionView({
 
 interface SectionListProps {
   findings: Finding[];
+  onEditFinding?: (finding: Finding) => void;
 }
 
-export function SectionList({ findings }: SectionListProps): React.ReactElement {
+export function SectionList({ findings, onEditFinding }: SectionListProps): React.ReactElement {
   // Group findings by section
   const sections = findings.reduce<Record<string, Finding[]>>((acc, finding) => {
     const section = finding.section;
@@ -102,6 +109,7 @@ export function SectionList({ findings }: SectionListProps): React.ReactElement 
           section={section}
           findings={sections[section]}
           defaultOpen={index === 0}
+          onEditFinding={onEditFinding}
         />
       ))}
     </div>

--- a/web/components/severity-select.tsx
+++ b/web/components/severity-select.tsx
@@ -1,0 +1,35 @@
+import { FindingSeverity } from '@/lib/api';
+
+interface SeveritySelectProps {
+  value: FindingSeverity;
+  onChange: (severity: FindingSeverity) => void;
+  disabled?: boolean;
+}
+
+const severityOptions: { value: FindingSeverity; label: string; color: string }[] = [
+  { value: 'INFO', label: 'Info', color: 'bg-blue-100 text-blue-800' },
+  { value: 'MINOR', label: 'Minor', color: 'bg-gray-100 text-gray-800' },
+  { value: 'MAJOR', label: 'Major', color: 'bg-yellow-100 text-yellow-800' },
+  { value: 'URGENT', label: 'Urgent', color: 'bg-red-100 text-red-800' },
+];
+
+export function SeveritySelect({
+  value,
+  onChange,
+  disabled = false,
+}: SeveritySelectProps): React.ReactElement {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as FindingSeverity)}
+      disabled={disabled}
+      className="block w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {severityOptions.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -162,6 +162,21 @@ export const api = {
     generate: (inspectionId: string): Promise<{ url: string }> =>
       request(`/inspections/${inspectionId}/report`, { method: 'POST' }),
   },
+
+  // Photos
+  photos: {
+    upload: (findingId: string, base64Data: string, mimeType?: string): Promise<Photo> =>
+      request(`/findings/${findingId}/photos`, {
+        method: 'POST',
+        body: { base64Data, mimeType },
+      }),
+
+    delete: (photoId: string): Promise<void> =>
+      request(`/photos/${photoId}`, { method: 'DELETE' }),
+
+    getUrl: (photoId: string): string =>
+      `${API_URL}/photos/${photoId}`,
+  },
 };
 
 export { ApiError };


### PR DESCRIPTION
## Summary
Implements finding editor for inspection findings in Web UI.

## Changes
- **FindingEditor** — Modal component for editing findings
  - Edit finding text
  - Change severity level (INFO/MINOR/MAJOR/URGENT)
  - Photo gallery with delete on hover
  - Photo upload (file picker → base64 → API)
  - Delete finding with confirmation dialog
  - Save/Cancel buttons with loading states

- **SeveritySelect** — Dropdown component for severity selection

- **PhotoUploader** — File upload component
  - File type validation (images only)
  - Size limit (10MB)
  - Base64 conversion
  - Loading state during upload

- **API Client** — Added photo methods
  - `photos.upload(findingId, base64Data, mimeType)`
  - `photos.delete(photoId)`
  - `photos.getUrl(photoId)`

- **FindingCard** — Added edit button (visible on hover)

- **SectionList/SectionView** — Propagate edit handler to cards

- **Detail Page** — Integrated editor modal with state management

## Testing
- [x] Build passes
- [x] Lint passes
- [x] TypeScript compiles
- [ ] Manual testing (pending)

Closes #36