### PR TITLE
[Sam] test(web): add E2E tests with Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ __pycache__/
 
 # OS
 .DS_Store
+
+# Playwright
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2176,6 +2176,23 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "6.19.2",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
@@ -8520,6 +8537,53 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10658,6 +10722,7 @@
         "react-dom": "19.2.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",

--- a/web/e2e/finding-editor.spec.ts
+++ b/web/e2e/finding-editor.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Finding Editor', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to an inspection with findings
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+
+    // Click on the first inspection
+    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+    if (await inspectionLink.isVisible()) {
+      await inspectionLink.click();
+      await page.waitForLoadState('networkidle');
+    }
+  });
+
+  test('should show edit button on finding hover', async ({ page }) => {
+    // Find a finding card
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      // Hover over the finding card
+      await findingCard.hover();
+
+      // Edit button should be visible
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      await expect(editButton).toBeVisible();
+    }
+  });
+
+  test('should open editor modal when clicking edit', async ({ page }) => {
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      await findingCard.hover();
+
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      if (await editButton.isVisible()) {
+        await editButton.click();
+
+        // Modal should open
+        await expect(page.getByRole('heading', { name: 'Edit Finding' })).toBeVisible();
+
+        // Should show form fields
+        await expect(page.locator('textarea')).toBeVisible();
+        await expect(page.locator('select')).toBeVisible();
+
+        // Should show action buttons
+        await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+      }
+    }
+  });
+
+  test('should close editor when clicking cancel', async ({ page }) => {
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      await findingCard.hover();
+
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      if (await editButton.isVisible()) {
+        await editButton.click();
+
+        // Wait for modal
+        await expect(page.getByRole('heading', { name: 'Edit Finding' })).toBeVisible();
+
+        // Click cancel
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        // Modal should close
+        await expect(page.getByRole('heading', { name: 'Edit Finding' })).not.toBeVisible();
+      }
+    }
+  });
+
+  test('should show severity dropdown with all options', async ({ page }) => {
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      await findingCard.hover();
+
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      if (await editButton.isVisible()) {
+        await editButton.click();
+
+        // Check severity dropdown
+        const severitySelect = page.locator('select');
+        await expect(severitySelect).toBeVisible();
+
+        // Should have all severity options
+        await expect(severitySelect.locator('option')).toHaveCount(4);
+        await expect(severitySelect.locator('option', { hasText: 'Info' })).toBeVisible();
+        await expect(severitySelect.locator('option', { hasText: 'Minor' })).toBeVisible();
+        await expect(severitySelect.locator('option', { hasText: 'Major' })).toBeVisible();
+        await expect(severitySelect.locator('option', { hasText: 'Urgent' })).toBeVisible();
+      }
+    }
+  });
+
+  test('should show delete confirmation when clicking delete', async ({ page }) => {
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      await findingCard.hover();
+
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      if (await editButton.isVisible()) {
+        await editButton.click();
+
+        // Click delete finding
+        await page.getByRole('button', { name: 'Delete Finding' }).click();
+
+        // Should show confirmation
+        await expect(page.getByText('Delete this finding?')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+      }
+    }
+  });
+
+  test('should show photo upload button', async ({ page }) => {
+    const findingCard = page.locator('.group').first();
+
+    if (await findingCard.isVisible()) {
+      await findingCard.hover();
+
+      const editButton = findingCard.getByRole('button', { name: /edit/i });
+      if (await editButton.isVisible()) {
+        await editButton.click();
+
+        // Should show add photo button
+        await expect(page.getByRole('button', { name: 'Add Photo' })).toBeVisible();
+      }
+    }
+  });
+});

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home Page', () => {
+  test('should display welcome message', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: /ai inspection/i })).toBeVisible();
+  });
+
+  test('should have navigation to inspections', async ({ page }) => {
+    await page.goto('/');
+
+    // Should have a link to inspections
+    const inspectionsLink = page.getByRole('link', { name: /inspections/i });
+    await expect(inspectionsLink).toBeVisible();
+
+    // Click and verify navigation
+    await inspectionsLink.click();
+    await expect(page).toHaveURL('/inspections');
+  });
+});

--- a/web/e2e/inspections.spec.ts
+++ b/web/e2e/inspections.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Inspections List', () => {
+  test('should display inspections list page', async ({ page }) => {
+    await page.goto('/inspections');
+
+    // Should show the page title
+    await expect(page.getByRole('heading', { name: 'Inspections' })).toBeVisible();
+  });
+
+  test('should show loading state initially', async ({ page }) => {
+    await page.goto('/inspections');
+
+    // Should show loading indicator or content
+    const content = page.locator('main');
+    await expect(content).toBeVisible();
+  });
+
+  test('should navigate to inspection detail when clicking an inspection', async ({ page }) => {
+    await page.goto('/inspections');
+
+    // Wait for the list to load
+    await page.waitForLoadState('networkidle');
+
+    // Click on the first inspection link if exists
+    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+    
+    if (await inspectionLink.isVisible()) {
+      await inspectionLink.click();
+      
+      // Should navigate to detail page
+      await expect(page).toHaveURL(/\/inspections\/.+/);
+      
+      // Should show back link
+      await expect(page.getByText('← Back to Inspections')).toBeVisible();
+    }
+  });
+});
+
+test.describe('Inspection Detail', () => {
+  test('should display inspection details', async ({ page }) => {
+    // Navigate to inspections first
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+
+    // Click on the first inspection if exists
+    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+    
+    if (await inspectionLink.isVisible()) {
+      await inspectionLink.click();
+      await page.waitForLoadState('networkidle');
+
+      // Should show address as heading
+      await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+      // Should show status badge
+      await expect(page.locator('span').filter({ hasText: /(Started|In Progress|Completed)/ }).first()).toBeVisible();
+
+      // Should show summary section
+      await expect(page.getByText('Summary')).toBeVisible();
+      await expect(page.getByText('Total Findings')).toBeVisible();
+    }
+  });
+
+  test('should show findings grouped by section', async ({ page }) => {
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+
+    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+    
+    if (await inspectionLink.isVisible()) {
+      await inspectionLink.click();
+      await page.waitForLoadState('networkidle');
+
+      // Should show Findings heading
+      await expect(page.getByRole('heading', { name: 'Findings' })).toBeVisible();
+    }
+  });
+
+  test('should navigate back to list', async ({ page }) => {
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+
+    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+    
+    if (await inspectionLink.isVisible()) {
+      await inspectionLink.click();
+      await page.waitForLoadState('networkidle');
+
+      // Click back link
+      await page.getByText('← Back to Inspections').click();
+
+      // Should be back on list page
+      await expect(page).toHaveURL('/inspections');
+    }
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,10 @@
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -16,6 +19,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for E2E tests
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run local dev server before starting tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary
Sets up Playwright E2E testing infrastructure for the Web UI.

## Changes

### Playwright Setup
- **playwright.config.ts** — Configuration with:
  - Test directory: `web/e2e/`
  - Chromium browser
  - Auto-start dev server
  - Screenshots on failure
  - Trace on first retry

### Test Suites

**home.spec.ts**
- Welcome message displays
- Navigation to inspections works

**inspections.spec.ts**
- Inspections list page loads
- Shows loading state
- Navigate to detail page
- Detail page shows address, status, summary
- Findings grouped by section
- Back navigation works

**finding-editor.spec.ts**
- Edit button visible on hover
- Editor modal opens on click
- Form fields present (textarea, severity select)
- Cancel closes modal
- All severity options available (Info/Minor/Major/Urgent)
- Delete confirmation flow
- Photo upload button present

### Scripts Added
- `npm run test:e2e` — Run tests headless
- `npm run test:e2e:ui` — Run with Playwright UI
- `npm run test:e2e:headed` — Run with visible browser

## Usage
```bash
# Start API and database first
docker-compose up -d api db

# Run E2E tests
cd web && npm run test:e2e
```

## Notes
- Tests are designed to be resilient when no data exists
- Full E2E flow (MCP → API → Web) requires docker-compose stack

Closes #38