### PR TITLE
[Sam] fix(auth): handle different-length passwords

### DIFF
--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -65,6 +65,12 @@ export async function verifyPassword(
   
   // Otherwise, do constant-time comparison for plain text (MVP mode)
   const crypto = await import('crypto');
+  
+  // timingSafeEqual requires same-length buffers
+  if (password.length !== expectedPassword.length) {
+    return false;
+  }
+  
   return crypto.timingSafeEqual(
     Buffer.from(password),
     Buffer.from(expectedPassword)


### PR DESCRIPTION
## Summary
Fixes 500 error when entering wrong password with different length.

## Problem
`crypto.timingSafeEqual()` throws `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH` when the two buffers have different lengths, causing a 500 instead of 401.

## Fix
Add length check before calling `timingSafeEqual`. If lengths differ, return `false` immediately.

## Testing
- Wrong password (different length) → 401
- Wrong password (same length) → 401
- Correct password → 200 + token

Fixes #63