### PR TITLE
[Sam] fix(e2e): add auth support to E2E tests

### DIFF
--- a/web/e2e/finding-editor.spec.ts
+++ b/web/e2e/finding-editor.spec.ts
@@ -1,9 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { login } from './fixtures';
 
 test.describe('Finding Editor', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to an inspection with findings
-    await page.goto('/inspections');
+    // Login first
+    await login(page);
+    
+    // Wait for inspections list to load
     await page.waitForLoadState('networkidle');
 
     // Click on the first inspection

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,0 +1,33 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+/**
+ * E2E Test Fixtures — Issue #72
+ *
+ * Provides authenticated page fixture for tests requiring login.
+ */
+
+import { test as base, Page } from '@playwright/test';
+
+const TEST_PASSWORD = process.env.TEST_PASSWORD || 'test';
+
+/**
+ * Login helper - authenticates the page
+ */
+async function login(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.fill('input[type="password"]', TEST_PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('/inspections', { timeout: 10000 });
+}
+
+/**
+ * Extended test with authenticated page fixture
+ */
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ page }, use) => {
+    await login(page);
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';
+export { login };

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,13 +1,17 @@
 import { test, expect } from '@playwright/test';
+import { test as authTest } from './fixtures';
 
-test.describe('Home Page', () => {
+test.describe('Home Page (Unauthenticated)', () => {
   test('should display welcome message', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.getByRole('heading', { name: /ai inspection/i })).toBeVisible();
   });
+});
 
-  test('should have navigation to inspections', async ({ page }) => {
+authTest.describe('Home Page (Authenticated)', () => {
+  authTest('should have navigation to inspections', async ({ authenticatedPage: page }) => {
+    // Go back to home page
     await page.goto('/');
 
     // Should have a link to inspections

--- a/web/e2e/inspections.spec.ts
+++ b/web/e2e/inspections.spec.ts
@@ -1,24 +1,18 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Inspections List', () => {
-  test('should display inspections list page', async ({ page }) => {
-    await page.goto('/inspections');
-
-    // Should show the page title
+  test('should display inspections list page', async ({ authenticatedPage: page }) => {
+    // Already at /inspections after login
     await expect(page.getByRole('heading', { name: 'Inspections' })).toBeVisible();
   });
 
-  test('should show loading state initially', async ({ page }) => {
-    await page.goto('/inspections');
-
-    // Should show loading indicator or content
+  test('should show loading state initially', async ({ authenticatedPage: page }) => {
+    // Should show content
     const content = page.locator('main');
     await expect(content).toBeVisible();
   });
 
-  test('should navigate to inspection detail when clicking an inspection', async ({ page }) => {
-    await page.goto('/inspections');
-
+  test('should navigate to inspection detail when clicking an inspection', async ({ authenticatedPage: page }) => {
     // Wait for the list to load
     await page.waitForLoadState('networkidle');
 
@@ -38,9 +32,7 @@ test.describe('Inspections List', () => {
 });
 
 test.describe('Inspection Detail', () => {
-  test('should display inspection details', async ({ page }) => {
-    // Navigate to inspections first
-    await page.goto('/inspections');
+  test('should display inspection details', async ({ authenticatedPage: page }) => {
     await page.waitForLoadState('networkidle');
 
     // Click on the first inspection if exists
@@ -62,8 +54,7 @@ test.describe('Inspection Detail', () => {
     }
   });
 
-  test('should show findings grouped by section', async ({ page }) => {
-    await page.goto('/inspections');
+  test('should show findings grouped by section', async ({ authenticatedPage: page }) => {
     await page.waitForLoadState('networkidle');
 
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();
@@ -77,8 +68,7 @@ test.describe('Inspection Detail', () => {
     }
   });
 
-  test('should navigate back to list', async ({ page }) => {
-    await page.goto('/inspections');
+  test('should navigate back to list', async ({ authenticatedPage: page }) => {
     await page.waitForLoadState('networkidle');
 
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();


### PR DESCRIPTION
## Summary
Updates E2E tests to handle authentication after #41 was merged.

## Changes

### New Files
- **e2e/fixtures.ts** — Auth fixtures and helpers
  - `login(page)` — Helper function to login
  - `authenticatedPage` — Page fixture that's already logged in

### Updated Tests
- **inspections.spec.ts** — Uses `authenticatedPage` fixture
- **finding-editor.spec.ts** — Calls `login()` in beforeEach
- **home.spec.ts** — Separates auth/non-auth tests

## Usage
```typescript
// Using fixture
import { test, expect } from './fixtures';

test('my test', async ({ authenticatedPage: page }) => {
  // page is already logged in
});

// Using helper directly
import { login } from './fixtures';

test.beforeEach(async ({ page }) => {
  await login(page);
});
```

## Environment
Set `TEST_PASSWORD` env var for tests (default: `test`)

Fixes #72