### PR TITLE
[Sam] feat(web): update E2E tests to handle authentication

### DIFF
--- a/web/e2e/finding-editor.spec.ts
+++ b/web/e2e/finding-editor.spec.ts
@@ -1,20 +1,25 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+/**
+ * Helper to navigate to first inspection detail page
+ */
+async function navigateToInspectionDetail(page: import('@playwright/test').Page): Promise<boolean> {
+  await page.goto('/inspections');
+  await page.waitForLoadState('networkidle');
+
+  const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+  if (await inspectionLink.isVisible()) {
+    await inspectionLink.click();
+    await page.waitForLoadState('networkidle');
+    return true;
+  }
+  return false;
+}
 
 test.describe('Finding Editor', () => {
-  test.beforeEach(async ({ page }) => {
-    // Navigate to an inspection with findings
-    await page.goto('/inspections');
-    await page.waitForLoadState('networkidle');
+  test('should show edit button on finding hover', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
 
-    // Click on the first inspection
-    const inspectionLink = page.locator('a[href^="/inspections/"]').first();
-    if (await inspectionLink.isVisible()) {
-      await inspectionLink.click();
-      await page.waitForLoadState('networkidle');
-    }
-  });
-
-  test('should show edit button on finding hover', async ({ page }) => {
     // Find a finding card
     const findingCard = page.locator('.group').first();
 
@@ -28,7 +33,9 @@ test.describe('Finding Editor', () => {
     }
   });
 
-  test('should open editor modal when clicking edit', async ({ page }) => {
+  test('should open editor modal when clicking edit', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
+
     const findingCard = page.locator('.group').first();
 
     if (await findingCard.isVisible()) {
@@ -52,7 +59,9 @@ test.describe('Finding Editor', () => {
     }
   });
 
-  test('should close editor when clicking cancel', async ({ page }) => {
+  test('should close editor when clicking cancel', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
+
     const findingCard = page.locator('.group').first();
 
     if (await findingCard.isVisible()) {
@@ -74,7 +83,9 @@ test.describe('Finding Editor', () => {
     }
   });
 
-  test('should show severity dropdown with all options', async ({ page }) => {
+  test('should show severity dropdown with all options', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
+
     const findingCard = page.locator('.group').first();
 
     if (await findingCard.isVisible()) {
@@ -98,7 +109,9 @@ test.describe('Finding Editor', () => {
     }
   });
 
-  test('should show delete confirmation when clicking delete', async ({ page }) => {
+  test('should show delete confirmation when clicking delete', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
+
     const findingCard = page.locator('.group').first();
 
     if (await findingCard.isVisible()) {
@@ -118,7 +131,9 @@ test.describe('Finding Editor', () => {
     }
   });
 
-  test('should show photo upload button', async ({ page }) => {
+  test('should show photo upload button', async ({ authenticatedPage: page }) => {
+    await navigateToInspectionDetail(page);
+
     const findingCard = page.locator('.group').first();
 
     if (await findingCard.isVisible()) {

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,0 +1,43 @@
+/**
+ * E2E Test Fixtures - Issue #72
+ *
+ * Provides authenticated page fixture for tests that need auth.
+ */
+
+import { test as base, Page } from '@playwright/test';
+
+// Default test password - override with TEST_PASSWORD env var
+const TEST_PASSWORD = process.env.TEST_PASSWORD || 'test-password-123';
+
+/**
+ * Login helper - performs authentication and waits for redirect
+ */
+async function loginAs(page: Page, password: string = TEST_PASSWORD): Promise<void> {
+  await page.goto('/login');
+
+  // Fill password and submit
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+
+  // Wait for redirect to inspections page
+  await page.waitForURL('/inspections', { timeout: 10000 });
+}
+
+/**
+ * Extended test fixtures with authentication support
+ */
+export const test = base.extend<{
+  authenticatedPage: Page;
+}>({
+  /**
+   * Pre-authenticated page fixture.
+   * Use this for tests that access protected routes.
+   */
+  authenticatedPage: async ({ page }, runTest) => {
+    await loginAs(page);
+    await runTest(page);
+  },
+});
+
+export { expect } from '@playwright/test';
+export { loginAs };

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { test as authTest } from './fixtures';
 
 test.describe('Home Page', () => {
   test('should display welcome message', async ({ page }) => {
@@ -7,14 +8,15 @@ test.describe('Home Page', () => {
     await expect(page.getByRole('heading', { name: /ai inspection/i })).toBeVisible();
   });
 
-  test('should have navigation to inspections', async ({ page }) => {
+  // This test needs auth since /inspections is protected
+  authTest('should have navigation to inspections', async ({ authenticatedPage: page }) => {
     await page.goto('/');
 
     // Should have a link to inspections
     const inspectionsLink = page.getByRole('link', { name: /inspections/i });
     await expect(inspectionsLink).toBeVisible();
 
-    // Click and verify navigation
+    // Click and verify navigation (already authenticated)
     await inspectionsLink.click();
     await expect(page).toHaveURL('/inspections');
   });

--- a/web/e2e/inspections.spec.ts
+++ b/web/e2e/inspections.spec.ts
@@ -1,14 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Inspections List', () => {
-  test('should display inspections list page', async ({ page }) => {
+  test('should display inspections list page', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
 
     // Should show the page title
     await expect(page.getByRole('heading', { name: 'Inspections' })).toBeVisible();
   });
 
-  test('should show loading state initially', async ({ page }) => {
+  test('should show loading state initially', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
 
     // Should show loading indicator or content
@@ -16,7 +16,7 @@ test.describe('Inspections List', () => {
     await expect(content).toBeVisible();
   });
 
-  test('should navigate to inspection detail when clicking an inspection', async ({ page }) => {
+  test('should navigate to inspection detail when clicking an inspection', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
 
     // Wait for the list to load
@@ -24,13 +24,13 @@ test.describe('Inspections List', () => {
 
     // Click on the first inspection link if exists
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();
-    
+
     if (await inspectionLink.isVisible()) {
       await inspectionLink.click();
-      
+
       // Should navigate to detail page
       await expect(page).toHaveURL(/\/inspections\/.+/);
-      
+
       // Should show back link
       await expect(page.getByText('← Back to Inspections')).toBeVisible();
     }
@@ -38,14 +38,14 @@ test.describe('Inspections List', () => {
 });
 
 test.describe('Inspection Detail', () => {
-  test('should display inspection details', async ({ page }) => {
+  test('should display inspection details', async ({ authenticatedPage: page }) => {
     // Navigate to inspections first
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
 
     // Click on the first inspection if exists
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();
-    
+
     if (await inspectionLink.isVisible()) {
       await inspectionLink.click();
       await page.waitForLoadState('networkidle');
@@ -54,7 +54,9 @@ test.describe('Inspection Detail', () => {
       await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
       // Should show status badge
-      await expect(page.locator('span').filter({ hasText: /(Started|In Progress|Completed)/ }).first()).toBeVisible();
+      await expect(
+        page.locator('span').filter({ hasText: /(Started|In Progress|Completed)/ }).first()
+      ).toBeVisible();
 
       // Should show summary section
       await expect(page.getByText('Summary')).toBeVisible();
@@ -62,12 +64,12 @@ test.describe('Inspection Detail', () => {
     }
   });
 
-  test('should show findings grouped by section', async ({ page }) => {
+  test('should show findings grouped by section', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
 
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();
-    
+
     if (await inspectionLink.isVisible()) {
       await inspectionLink.click();
       await page.waitForLoadState('networkidle');
@@ -77,12 +79,12 @@ test.describe('Inspection Detail', () => {
     }
   });
 
-  test('should navigate back to list', async ({ page }) => {
+  test('should navigate back to list', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
 
     const inspectionLink = page.locator('a[href^="/inspections/"]').first();
-    
+
     if (await inspectionLink.isVisible()) {
       await inspectionLink.click();
       await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
Add auth fixtures for E2E tests so they work with password-protected routes.

## Changes
- Add `fixtures.ts` with `authenticatedPage` fixture and `loginAs` helper
- Update `home.spec.ts` - use auth fixture for navigation test
- Update `inspections.spec.ts` - use auth fixture for all tests  
- Update `finding-editor.spec.ts` - use auth fixture for all tests

## Testing
- `npm run lint` ✅
- `npm run build` ✅
- Test password configurable via `TEST_PASSWORD` env var

## Acceptance Criteria
- [x] E2E tests login before accessing protected routes
- [x] Test password configurable via env var
- [ ] All tests pass (needs API running with auth)

Closes #72