### PR TITLE
[Sam] feat(web): add Vercel deployment config

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,91 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AI Inspection Web UI
+
+Next.js frontend for the AI Inspection application.
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 20+
+- API server running (see `../api/`)
+
+### Development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+# From repository root
+npm install
+npm run dev --workspace=web
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3001](http://localhost:3001) to view the app.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Environment Variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NEXT_PUBLIC_API_URL` | Backend API URL | `http://localhost:3000` |
+
+For local development, the default points to the API running on port 3000.
+
+## Testing
+
+### E2E Tests (Playwright)
+
+```bash
+# Run E2E tests
+npm run test:e2e --workspace=web
+
+# Run with UI
+npm run test:e2e:ui --workspace=web
+
+# Run headed (visible browser)
+npm run test:e2e:headed --workspace=web
+```
+
+## Deployment
+
+### Vercel (Test Environment)
+
+The web app deploys to Vercel at `ai-inspection-test.vercel.app`.
+
+**Required Environment Variables:**
+
+```
+NEXT_PUBLIC_API_URL=https://ai-inspection-api-test.fly.dev
+```
+
+Set this in Vercel Dashboard → Project Settings → Environment Variables.
+
+**Configuration:**
+
+- `vercel.json` configures build settings and security headers
+- Framework auto-detected as Next.js
+- Region: Sydney (`syd1`) for proximity to API
+
+### Manual Deploy
+
+```bash
+# Install Vercel CLI
+npm i -g vercel
+
+# Deploy (from web/ directory)
+cd web
+vercel --prod
+```
+
+## Project Structure
+
+```
+web/
+├── app/           # Next.js App Router pages
+├── components/    # React components
+├── lib/           # Utilities (API client, auth)
+├── e2e/           # Playwright E2E tests
+├── public/        # Static assets
+└── vercel.json    # Vercel deployment config
+```
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Vercel Deployment](https://nextjs.org/docs/app/building-your-application/deploying)

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "framework": "nextjs",
+  "regions": ["syd1"],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add Vercel deployment configuration for the web app test environment.

## Changes
- Add `web/vercel.json` with:
  - Build settings (Next.js auto-detected)
  - Security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
  - Sydney region for API proximity
- Update `web/README.md` with:
  - Deployment instructions
  - Environment variable documentation (`NEXT_PUBLIC_API_URL`)
  - Project structure overview

## Manual Steps Required
After merge, the following manual setup is needed in Vercel Dashboard:
1. Create Vercel project linked to this repo
2. Set root directory to `web`
3. Add environment variable: `NEXT_PUBLIC_API_URL=https://ai-inspection-api-test.fly.dev`
4. Deploy and verify login flow works

## Testing
- [x] Lint passes
- [x] Typecheck passes
- [ ] Manual deploy verification (post-merge)

Closes #80