### PR TITLE
[Alex] chore(ci): add E2E test job to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,5 +61,56 @@ jobs:
           working-directory: ./web
           vercel-args: '--prod'
 
-  # E2E tests job will be added by #82
+  e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    needs: [deploy-api, deploy-web]
+    defaults:
+      run:
+        working-directory: ./web
+    env:
+      API_URL: https://ai-inspection-api-test.fly.dev
+      BASE_URL: https://ai-inspection-test.vercel.app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Wait for API to be ready
+        run: |
+          echo "Waiting for API to be ready..."
+          timeout 120 bash -c 'until curl -sf $API_URL/health; do echo "Waiting..."; sleep 5; done'
+          echo "API is ready!"
+
+      - name: Wait for Web to be ready
+        run: |
+          echo "Waiting for Web to be ready..."
+          timeout 120 bash -c 'until curl -sf $BASE_URL; do echo "Waiting..."; sleep 5; done'
+          echo "Web is ready!"
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+        env:
+          CI: true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7
+
   # Discord notifications will be added by #83

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.BASE_URL || 'http://localhost:3001';
+const isDeployed = baseURL.startsWith('https://');
+
 /**
  * Playwright configuration for E2E tests
  * @see https://playwright.dev/docs/test-configuration
@@ -10,10 +13,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? 'github' : 'html',
 
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3001',
+    baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -25,8 +28,8 @@ export default defineConfig({
     },
   ],
 
-  /* Run local dev server before starting tests */
-  webServer: {
+  /* Run local dev server before starting tests (skip for deployed envs) */
+  webServer: isDeployed ? undefined : {
     command: 'npm run dev',
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary
Adds E2E test job to CD pipeline that runs Playwright tests against deployed environment.

## Changes
- Add `e2e-tests` job to CD workflow
- Wait for API and Web deployments to be healthy before running tests
- Run Playwright tests with deployed URLs
- Upload test artifacts for debugging
- Update playwright.config.ts to skip local dev server when testing deployed environment
- Use GitHub reporter in CI for better integration

## Testing
- E2E tests will run against:
  - API: `https://ai-inspection-api-test.fly.dev`
  - Web: `https://ai-inspection-test.vercel.app`

## Dependencies
- Requires #79 (Fly.io) and #80 (Vercel) environments to be set up

## Closes
- #82