### PR TITLE
[Taylor] chore(cd): add E2E test job to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,5 +61,55 @@ jobs:
           working-directory: ./web
           vercel-args: '--prod'
 
-  # E2E tests job will be added by #82
+  e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    needs: [deploy-api, deploy-web]
+    defaults:
+      run:
+        working-directory: ./web
+    env:
+      API_URL: https://ai-inspection-api-test.fly.dev
+      BASE_URL: https://ai-inspection-test.vercel.app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for API to be healthy
+        run: |
+          echo "Waiting for API to be healthy..."
+          timeout 120 bash -c 'until curl -sf $API_URL/health; do echo "Waiting..."; sleep 5; done'
+          echo "API is healthy!"
+
+      - name: Wait for Web to be healthy
+        run: |
+          echo "Waiting for Web to be healthy..."
+          timeout 120 bash -c 'until curl -sf $BASE_URL; do echo "Waiting..."; sleep 5; done'
+          echo "Web is healthy!"
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7
+
   # Discord notifications will be added by #83


### PR DESCRIPTION
## Summary
Add E2E test job to the CD pipeline that runs Playwright tests against deployed environments.

## Changes
- **e2e-tests job** — runs after deploy-api and deploy-web
- **Health check polling** — waits for both services to be healthy (120s timeout)
- **Playwright tests** — runs against deployed environment
- **Artifact upload** — test report saved for 7 days

## Environment Variables
| Variable | Value |
|----------|-------|
| API_URL | https://ai-inspection-api-test.fly.dev |
| BASE_URL | https://ai-inspection-test.vercel.app |

## Flow
```
deploy-api ──┐
             ├──► e2e-tests ──► (notify on failure - #83)
deploy-web ──┘
```

## Testing
- E2E tests run after successful deployment
- Tests hit real deployed services
- Results uploaded as artifacts

Closes #82