### PR TITLE
fix(cd): Add Vercel protection bypass for E2E tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,9 +129,11 @@ jobs:
           echo "API is ready!"
 
       - name: Wait for Web to be ready
+        env:
+          VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           echo "Waiting for Web at $BASE_URL..."
-          timeout 120 bash -c 'until curl -sf $BASE_URL; do echo "Waiting..."; sleep 5; done'
+          timeout 120 bash -c 'until curl -sf -H "x-vercel-protection-bypass: $VERCEL_BYPASS" "$BASE_URL"; do echo "Waiting..."; sleep 5; done'
           echo "Web is ready!"
 
       - name: Install Playwright browsers
@@ -141,6 +143,7 @@ jobs:
         run: npx playwright test
         env:
           CI: true
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.BASE_URL || 'http://localhost:3001';
 const isDeployed = baseURL.startsWith('https://');
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 
 /**
  * Playwright configuration for E2E tests
@@ -19,6 +20,10 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // Bypass Vercel deployment protection in CI
+    extraHTTPHeaders: bypassSecret ? {
+      'x-vercel-protection-bypass': bypassSecret,
+    } : undefined,
   },
 
   projects: [


### PR DESCRIPTION
## Summary
Adds Vercel protection bypass header to E2E tests, allowing CD pipeline to access protected deployments.

## Changes

### cd.yml
- Pass `VERCEL_AUTOMATION_BYPASS_SECRET` to E2E job
- Add `x-vercel-protection-bypass` header to curl health check

### playwright.config.ts
- Add `extraHTTPHeaders` with bypass header when secret is present
- Only applies when `VERCEL_AUTOMATION_BYPASS_SECRET` env var is set

## How it works
```
Vercel deployment (protected)
    ↓
E2E tests send: x-vercel-protection-bypass: <secret>
    ↓
Vercel allows request through
    ↓
Tests run against protected deployment ✅
```

## Checklist
- [x] CD workflow passes bypass secret to E2E job
- [x] Curl health check includes bypass header
- [x] Playwright config sends bypass header

Fixes #101