### PR TITLE
[Taylor] fix(cd): add Vercel protection bypass for E2E tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -131,8 +131,10 @@ jobs:
       - name: Wait for Web to be ready
         run: |
           echo "Waiting for Web at $BASE_URL..."
-          timeout 120 bash -c 'until curl -sf $BASE_URL; do echo "Waiting..."; sleep 5; done'
+          timeout 120 bash -c 'until curl -sf -H "x-vercel-protection-bypass: $VERCEL_BYPASS" $BASE_URL; do echo "Waiting..."; sleep 5; done'
           echo "Web is ready!"
+        env:
+          VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
@@ -141,6 +143,7 @@ jobs:
         run: npx playwright test
         env:
           CI: true
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.BASE_URL || 'http://localhost:3001';
 const isDeployed = baseURL.startsWith('https://');
+const vercelBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 
 /**
  * Playwright configuration for E2E tests
@@ -19,6 +20,10 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // Add Vercel bypass header for protected deployments
+    extraHTTPHeaders: vercelBypassSecret ? {
+      'x-vercel-protection-bypass': vercelBypassSecret,
+    } : undefined,
   },
 
   projects: [


### PR DESCRIPTION
## Summary
Add Vercel automation bypass secret support to allow E2E tests to access protected deployments.

## Changes

### CD Workflow
- Pass `VERCEL_AUTOMATION_BYPASS_SECRET` to E2E test step
- Add bypass header to curl health check

### Playwright Config
- Add `extraHTTPHeaders` with bypass secret when available
- Allows all Playwright requests to bypass Vercel protection

## How It Works
Vercel's "Protection Bypass for Automation" feature allows CI tools to access protected deployments by sending a secret header:
```
x-vercel-protection-bypass: <secret>
```

This keeps deployment protection enabled for browsers while allowing automated tests to access the deployment.

## Security
- Secret stored in GitHub encrypted secrets
- Never logged or exposed
- Only used in CI environment

Fixes #101