### PR TITLE
[Alex] perf(e2e): add maxFailures for fail-fast in CI

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? '50%' : undefined,
   reporter: process.env.CI ? 'github' : 'html',
+  maxFailures: process.env.CI ? 3 : undefined,  // Fail-fast in CI
 
   use: {
     baseURL,


### PR DESCRIPTION
## Summary
Adds fail-fast behavior to E2E tests in CI - stops after 3 failures to save time on systemic issues.

## Changes
- Add `maxFailures: 3` for CI in playwright.config.ts
- Local runs unaffected (no limit)

## Closes
- #107