### PR TITLE
[Alex] chore(api): fix lint warnings

### DIFF
--- a/api/src/__tests__/photos.test.ts
+++ b/api/src/__tests__/photos.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
 import {
   PhotoService,
   PhotoNotFoundError,

--- a/api/src/__tests__/reports.test.ts
+++ b/api/src/__tests__/reports.test.ts
@@ -5,7 +5,7 @@ import {
   InspectionNotFoundError,
 } from '../services/report.js';
 import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
-import type { Report, Inspection, Finding, Photo } from '@prisma/client';
+import type { Report, Inspection, Finding } from '@prisma/client';
 
 // Mock puppeteer
 vi.mock('puppeteer', () => ({

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -35,7 +35,7 @@ export function authMiddleware(
     const decoded = jwt.verify(token, JWT_SECRET) as { sub: string };
     req.userId = decoded.sub;
     next();
-  } catch (err) {
+  } catch {
     res.status(401).json({ error: 'Invalid or expired token' });
   }
 }

--- a/api/src/services/checklist.ts
+++ b/api/src/services/checklist.ts
@@ -43,6 +43,16 @@ export interface Checklist {
   conclusions?: Record<string, string>;
 }
 
+/** Raw section shape from YAML before normalization */
+interface RawSection {
+  id: string;
+  name: string;
+  prompt?: string;
+  items?: string[];
+  subareas?: RawSection[];
+  report_section?: number;
+}
+
 // ============================================================================
 // Checklist Service
 // ============================================================================
@@ -105,13 +115,13 @@ class ChecklistService {
   /**
    * Normalize sections to ensure consistent structure
    */
-  private normalizeSections(sections: any[]): ChecklistItem[] {
+  private normalizeSections(sections: RawSection[]): ChecklistItem[] {
     return sections.map(section => ({
       id: section.id,
       name: section.name,
       prompt: section.prompt || `Check ${section.name.toLowerCase()}.`,
       items: section.items || [],
-      subareas: section.subareas?.map((sub: any) => ({
+      subareas: section.subareas?.map((sub: RawSection) => ({
         id: sub.id,
         name: sub.name,
         prompt: sub.prompt || `Check ${sub.name.toLowerCase()}.`,

--- a/api/src/services/navigation.ts
+++ b/api/src/services/navigation.ts
@@ -3,7 +3,7 @@
  * Handles inspection workflow navigation and status.
  */
 
-import type { Inspection, Finding } from '@prisma/client';
+import type { Finding } from '@prisma/client';
 import type { IInspectionRepository } from '../repositories/interfaces/inspection.js';
 import { checklistService, type Checklist, type ChecklistItem } from './checklist.js';
 

--- a/api/src/services/photo.ts
+++ b/api/src/services/photo.ts
@@ -57,10 +57,8 @@ export class PhotoService {
     // Validate base64
     let buffer: Buffer;
     try {
-      // Check if it's valid base64 by verifying it can be decoded and re-encoded
+      // Check if it's valid base64 by decoding it
       buffer = Buffer.from(base64Data, 'base64');
-      const reEncoded = buffer.toString('base64');
-      // Allow some padding differences, but core content must match
       if (buffer.length === 0 || !this.isValidBase64(base64Data)) {
         throw new InvalidBase64Error();
       }

--- a/api/src/services/report.ts
+++ b/api/src/services/report.ts
@@ -4,7 +4,6 @@
  */
 
 import puppeteer from 'puppeteer';
-import * as fs from 'node:fs/promises';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import Handlebars from 'handlebars';


### PR DESCRIPTION
## Summary
Fixes all 9 lint warnings in the api/ workspace.

## Changes
- Remove unused imports (afterEach, path, Photo, fs, Inspection)
- Remove unused variable (reEncoded in photo service)
- Use catch without binding unused error in auth middleware
- Add RawSection interface to replace `any` types in checklist service

## Verification
- `npm run lint -w api` now shows 0 warnings
- All 41 tests pass

## Closes
- #109