### PR TITLE
[Alex] feat(api): add custom domain support for same-site cookies

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -14,10 +14,12 @@ import { authMiddleware } from './middleware/auth.js';
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// CORS configuration - allow localhost and Vercel deployments
+// CORS configuration - allow localhost, Vercel, and custom domains
 const allowedOrigins = [
   'http://localhost:3001',
-  /^https:\/\/ai-inspection.*\.vercel\.app$/,  // All Vercel preview/production URLs
+  /^https:\/\/ai-inspection.*\.vercel\.app$/,  // Vercel preview/production URLs
+  'https://app-ai-inspection.apexphere.co.nz',      // Production frontend
+  'https://app-test-ai-inspection.apexphere.co.nz', // Test frontend
 ];
 
 // Middleware


### PR DESCRIPTION
## Summary
Add support for custom domains under `apexphere.co.nz` to enable same-site cookie authentication.

## Changes
- **Cookie domain**: Added `COOKIE_DOMAIN` env var (e.g., `.apexphere.co.nz`) for cross-subdomain cookies
- **SameSite**: Changed back to `strict` (more secure now that frontend/backend are same-site)
- **CORS**: Added `app-ai-inspection.apexphere.co.nz` and `app-test-ai-inspection.apexphere.co.nz`

## Environment Variable
Set in Fly.io:
```bash
fly secrets set COOKIE_DOMAIN=.apexphere.co.nz
```

## Verification
After merge + deploy:
1. Login at `https://app-test-ai-inspection.apexphere.co.nz`
2. Cookie should be set with `Domain=.apexphere.co.nz`
3. Subsequent API calls should include the cookie

## Coordination
Taylor needs to set `VITE_API_URL` in Vercel:
- Production: `https://api-ai-inspection.apexphere.co.nz`
- Preview: `https://api-test-ai-inspection.apexphere.co.nz`

Closes #115