### PR TITLE
[Alex] refactor(api): unify domain config with APP_DOMAIN

### DIFF
--- a/api/src/config/domain.ts
+++ b/api/src/config/domain.ts
@@ -1,0 +1,32 @@
+/**
+ * Domain configuration from APP_DOMAIN env var
+ * 
+ * Usage: Set APP_DOMAIN=apexphere.co.nz in production
+ * This generates cookie domain and CORS origins automatically.
+ */
+
+const APP_DOMAIN = process.env.APP_DOMAIN; // e.g., 'apexphere.co.nz'
+
+/**
+ * Cookie domain with leading dot for subdomain sharing
+ * e.g., '.apexphere.co.nz'
+ */
+export const cookieDomain = APP_DOMAIN ? `.${APP_DOMAIN}` : undefined;
+
+/**
+ * Generate allowed CORS origins from APP_DOMAIN
+ */
+export function getAllowedOrigins(): (string | RegExp)[] {
+  const origins: (string | RegExp)[] = [
+    'http://localhost:3001',
+    /^https:\/\/ai-inspection.*\.vercel\.app$/,  // Vercel preview/production URLs
+  ];
+
+  if (APP_DOMAIN) {
+    // Add custom domain origins
+    origins.push(`https://app-ai-inspection.${APP_DOMAIN}`);      // Production
+    origins.push(`https://app-test-ai-inspection.${APP_DOMAIN}`); // Test
+  }
+
+  return origins;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,17 +10,13 @@ import { photosRouter } from './routes/photos.js';
 import { reportsRouter } from './routes/reports.js';
 import { navigationRouter } from './routes/navigation.js';
 import { authMiddleware } from './middleware/auth.js';
+import { getAllowedOrigins } from './config/domain.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// CORS configuration - allow localhost, Vercel, and custom domains
-const allowedOrigins = [
-  'http://localhost:3001',
-  /^https:\/\/ai-inspection.*\.vercel\.app$/,  // Vercel preview/production URLs
-  'https://app-ai-inspection.apexphere.co.nz',      // Production frontend
-  'https://app-test-ai-inspection.apexphere.co.nz', // Test frontend
-];
+// CORS configuration - generated from APP_DOMAIN env var
+const allowedOrigins = getAllowedOrigins();
 
 // Middleware
 app.use(helmet());

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -9,6 +9,7 @@ import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import jwt from 'jsonwebtoken';
 import { generateToken, verifyPassword } from '../middleware/auth.js';
+import { cookieDomain } from '../config/domain.js';
 
 const AUTH_PASSWORD = process.env.AUTH_PASSWORD;
 
@@ -93,8 +94,8 @@ authRouter.post('/logout', (req: Request, res: Response) => {
     sameSite: 'strict',
   };
 
-  if (COOKIE_DOMAIN) {
-    clearOptions.domain = COOKIE_DOMAIN;
+  if (cookieDomain) {
+    clearOptions.domain = cookieDomain;
   }
 
   res.clearCookie('token', clearOptions);
@@ -122,9 +123,6 @@ authRouter.get('/check', (req: Request, res: Response) => {
   }
 });
 
-// Cookie domain for same-site auth across subdomains
-const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN; // e.g., '.apexphere.co.nz'
-
 function setTokenCookie(res: Response, token: string): void {
   const isProduction = process.env.NODE_ENV === 'production';
   
@@ -141,9 +139,9 @@ function setTokenCookie(res: Response, token: string): void {
     maxAge: 24 * 60 * 60 * 1000, // 24 hours
   };
 
-  // Set domain for cross-subdomain cookies (e.g., .apexphere.co.nz)
-  if (COOKIE_DOMAIN) {
-    cookieOptions.domain = COOKIE_DOMAIN;
+  // Set domain for cross-subdomain cookies (from APP_DOMAIN)
+  if (cookieDomain) {
+    cookieOptions.domain = cookieDomain;
   }
 
   res.cookie('token', token, cookieOptions);


### PR DESCRIPTION
## Summary
Replace `COOKIE_DOMAIN` with unified `APP_DOMAIN` env var.

## Changes
- New `api/src/config/domain.ts` generates cookie domain and CORS origins
- Cookie domain: `.{APP_DOMAIN}` (e.g., `.apexphere.co.nz`)
- CORS origins: `https://app-*.{APP_DOMAIN}`

## Environment Variable
```bash
# Fly.io (replaces COOKIE_DOMAIN)
fly secrets set APP_DOMAIN=apexphere.co.nz
fly secrets unset COOKIE_DOMAIN
```

## Benefits
- Single source of truth for domain config
- Easier to change domains
- Less env vars to manage