### PR TITLE
[Alex] fix(ci): update CD workflow to use custom domain URLs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Fixed URLs for test environment
-  API_URL: https://ai-inspection-api-test.fly.dev
-  WEB_URL: https://ai-inspection-git-develop-chenyang-apexpherecos-projects.vercel.app
+  # Custom domain URLs for test environment (same-site cookie support)
+  API_URL: https://api-test-ai-inspection.apexphere.co.nz
+  WEB_URL: https://app-test-ai-inspection.apexphere.co.nz
 
 jobs:
   # Only run CD if CI passes


### PR DESCRIPTION
## Summary
Updates CD workflow to use custom domain URLs instead of default Vercel/Fly.io URLs.

## Changes
- API_URL: `api-test-ai-inspection.apexphere.co.nz`
- WEB_URL: `app-test-ai-inspection.apexphere.co.nz`

## Why
Same-site cookies require both frontend and backend on same parent domain. Using custom domain URLs enables the auth fix from #116.

## Closes
- #119