### PR TITLE
[Alex] fix(api): relax rate limit for test environment

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -15,10 +15,11 @@ const AUTH_PASSWORD = process.env.AUTH_PASSWORD;
 
 export const authRouter = Router();
 
-// Rate limiting: 5 attempts per IP per minute
+// Rate limiting: stricter in production, relaxed for test environment
+const isTestEnv = process.env.NODE_ENV === 'test';
 const loginLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 5, // 5 attempts
+  max: isTestEnv ? 100 : 5, // 100 attempts in test, 5 in production
   message: { error: 'Too many login attempts, please try again later' },
   standardHeaders: true,
   legacyHeaders: false,


### PR DESCRIPTION
## Summary
Relaxes login rate limit in test environment to allow E2E tests to run.

## Problem
E2E tests fail after 5 tests due to rate limit (5 requests/min). With 14 tests each calling login, tests 6+ are rate limited.

## Solution
- Check `NODE_ENV` at startup
- Test env: 100 requests/min (allows all E2E tests)
- Production: 5 requests/min (unchanged security)

## Closes
- #121