### PR TITLE
feat(ci): Publish Playwright reports to GitHub Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -131,6 +131,39 @@ jobs:
           path: web/playwright-report/
           retention-days: 7
 
+  publish-report:
+    name: Publish Playwright Report
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: always()
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload to Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: playwright-report/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Add report link to summary
+        run: |
+          echo "## 📊 Playwright Test Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View the full report: https://apexphere.github.io/ai-inspection/" >> $GITHUB_STEP_SUMMARY
+
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Publishes Playwright test reports to GitHub Pages for easy viewing without downloading artifacts.

## Changes
- Add `publish-report` job to CD workflow
- Runs after e2e-tests (always, even on failure)
- Deploys report to GitHub Pages
- Adds report link to workflow summary

## After Merge
Report will be viewable at: `https://apexphere.github.io/ai-inspection/`

## Prerequisites
GitHub Pages needs to be enabled on the repo:
1. Settings → Pages → Source: GitHub Actions

## Checklist
- [x] Downloads playwright-report artifact
- [x] Deploys to GitHub Pages
- [x] Adds link to workflow summary

Closes #125