### PR TITLE
[Sam] fix(e2e): require TEST_PASSWORD in CI, error if missing

### DIFF
--- a/web/e2e/auth.setup.ts
+++ b/web/e2e/auth.setup.ts
@@ -2,16 +2,33 @@
  * Auth Setup - runs once before all tests to create authenticated state
  */
 
-import { test as setup, expect } from '@playwright/test';
+import { test as setup } from '@playwright/test';
 
-const TEST_PASSWORD = process.env.TEST_PASSWORD || 'test-password-123';
+// In CI, TEST_PASSWORD must be explicitly set — fail fast if missing
+const isCI = process.env.CI === 'true';
+const TEST_PASSWORD = process.env.TEST_PASSWORD;
+
+if (!TEST_PASSWORD) {
+  if (isCI) {
+    throw new Error(
+      'TEST_PASSWORD environment variable is required in CI. ' +
+      'Set it to match the deployed API AUTH_PASSWORD.'
+    );
+  }
+  console.warn(
+    '⚠️  TEST_PASSWORD not set. Using default "test-password-123". ' +
+    'Set TEST_PASSWORD to match your local API AUTH_PASSWORD.'
+  );
+}
+
+const password = TEST_PASSWORD || 'test-password-123';
 const AUTH_FILE = 'e2e/.auth/user.json';
 
 setup('authenticate', async ({ page }) => {
   await page.goto('/login');
   
   // Fill password and submit
-  await page.fill('input[type="password"]', TEST_PASSWORD);
+  await page.fill('input[type="password"]', password);
   await page.click('button[type="submit"]');
   
   // Wait for redirect to inspections page (confirms login worked)


### PR DESCRIPTION
## Summary
Fail fast in CI when TEST_PASSWORD is not set, instead of silently using wrong default.

## Changes
- Check if `CI=true` (GitHub Actions environment)
- If in CI and `TEST_PASSWORD` missing: throw clear error
- If local dev: warn but use default for convenience

## Context
CD workflow was missing TEST_PASSWORD env var, causing E2E tests to silently fail with wrong password.

**Before:** Uses `test-password-123` default → silent auth failure
**After:** Throws error in CI → fail fast with clear message

## Testing
- Lint ✅
- Typecheck ✅