### PR TITLE
[Alex] fix(cd): add Prisma migrate step after API deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,13 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Run database migrations
+        run: |
+          echo "Running Prisma migrations..."
+          flyctl ssh console --app ai-inspection-api-test -C "cd /app && npx prisma migrate deploy"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
   wait-for-vercel:
     name: Wait for Vercel Auto-Deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add database migration step to CD workflow after API deployment.

## Problem
Database tables don't exist after fresh deploy because migrations haven't run.

Error:
```
The table 'public.Inspection' does not exist in the current database.
```

## Solution
Run `prisma migrate deploy` via `flyctl ssh` after deployment:
```yaml
- name: Run database migrations
  run: flyctl ssh console --app ai-inspection-api-test -C "cd /app && npx prisma migrate deploy"
```

## Testing
Will verify on next CD run after merge.

Fixes #129
Relates to #123