### PR TITLE
[Alex] fix(cd): use sh -c for Prisma migrate command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run database migrations
         run: |
           echo "Running Prisma migrations..."
-          flyctl ssh console --app ai-inspection-api-test -C "cd /app && npx prisma migrate deploy"
+          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx prisma migrate deploy'"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Summary
Fix Prisma migrate step failing in CD workflow.

## Problem
`flyctl ssh console -C` doesn't use a shell, so `cd` command not found:
```
exec: "cd": executable file not found in $PATH
```

## Solution
Wrap command in `sh -c`:
```yaml
flyctl ssh console -C "sh -c 'cd /app && npx prisma migrate deploy'"
```

Fixes #129