### PR TITLE
[Alex] feat(ci): add Prisma migration drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
         if: matrix.workspace == 'api'
         run: npm run db:generate --workspace=api
 
+      - name: Check Prisma migration drift (api only)
+        if: matrix.workspace == 'api'
+        run: |
+          cd api
+          npx prisma migrate diff \
+            --from-migrations ./prisma/migrations \
+            --to-schema-datamodel ./prisma/schema.prisma \
+            --exit-code
+        continue-on-error: false
+
       - name: Build shared (for dependents)
         if: matrix.workspace == 'web'
         run: npm run build --workspace=shared


### PR DESCRIPTION
## Summary
Add CI check to detect when Prisma schema drifts from migrations.

## How It Works
```bash
npx prisma migrate diff \
  --from-migrations ./prisma/migrations \
  --to-schema-datamodel ./prisma/schema.prisma \
  --exit-code
```

- Exit 0 = schema matches migrations ✅
- Exit non-zero = drift detected ❌

## When It Runs
- In CI lint-and-test job for api workspace
- After Prisma client generation

## Dependencies
⚠️ **Merge #131 first** — this PR requires migrations to exist.

Closes #132