### PR TITLE
[Alex] feat(ci): add Prisma migration drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,22 @@ jobs:
         if: matrix.workspace == 'api'
         run: npm run db:generate --workspace=api
 
+      - name: Check Prisma migration drift (api only)
+        if: matrix.workspace == 'api'
+        run: |
+          cd api
+          if [ -d "prisma/migrations" ]; then
+            npx prisma migrate diff \
+              --from-migrations ./prisma/migrations \
+              --to-schema-datamodel ./prisma/schema.prisma \
+              --exit-code || {
+                echo "::error::Schema drift detected! Run 'npx prisma migrate dev' to create migration."
+                exit 1
+              }
+          else
+            echo "::warning::No migrations directory found. Consider running 'npx prisma migrate dev --name init' to create initial migration."
+          fi
+
       - name: Build shared (for dependents)
         if: matrix.workspace == 'web'
         run: npm run build --workspace=shared


### PR DESCRIPTION
## Summary
Adds CI check to detect when Prisma schema changes aren't captured in migrations.

## Changes
- Check runs during api workspace CI
- Warns if no migrations directory exists
- Fails with clear error if schema drifts from migrations

## Note
Currently the project has no migrations directory. This check will warn until initial migration is created with `npx prisma migrate dev --name init`.

## Closes
- #132