### PR TITLE
[Alex] fix(ci): use migrate deploy in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: npm run db:generate --workspace=api
 
       - name: Run database migrations
-        run: npm run db:push --workspace=api
+        run: npx prisma migrate deploy --schema=api/prisma/schema.prisma
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/ai_inspection_test
 


### PR DESCRIPTION
## Summary
Change integration tests to use `migrate deploy` instead of `db:push`.

## Problem
CI and CD used different database setup:
- CI: `db:push` (creates tables from schema)
- CD: `migrate deploy` (needs migration files)

This mismatch meant #129 (missing migrations) passed CI but failed CD.

## Solution
```yaml
# Before
run: npm run db:push --workspace=api

# After
run: npx prisma migrate deploy --schema=api/prisma/schema.prisma
```

## Dependencies
⚠️ **Merge #131 first** — requires migrations to exist.

Fixes #135