### PR TITLE
[Alex] fix(fly): prevent auto-suspend of machines

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -14,9 +14,9 @@ primary_region = "syd"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = "suspend"
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = "connections"


### PR DESCRIPTION
Prevents Fly.io from auto-suspending API machines.

## Changes
- `auto_stop_machines = false` — disables auto-stop
- `min_machines_running = 1` — ensures at least one machine is always running

This eliminates cold start delays when the API hasn't been accessed recently.