### PR TITLE
fix(api): Prevent Fly.io auto-suspend

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -16,7 +16,7 @@ primary_region = "syd"
   force_https = true
   auto_stop_machines = "suspend"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1  # Keep at least 1 machine running to prevent cold starts
 
   [http_service.concurrency]
     type = "connections"


### PR DESCRIPTION
## Summary
Prevents Fly.io from auto-suspending the test API machine.

## Change
```toml
min_machines_running = 1  # was 0
```

## Why
- Prevents cold start delays
- E2E tests don't timeout waiting for machine to wake
- Better developer experience when testing

## Trade-off
Machine runs 24/7 — uses more free tier hours. Acceptable for test env.