### PR TITLE
[Alex] fix(cd): add database seeding for E2E tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,6 +56,13 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Seed database (test data)
+        run: |
+          echo "Seeding test database..."
+          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx tsx prisma/seed.ts'"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
   wait-for-vercel:
     name: Wait for Vercel Auto-Deploy
     runs-on: ubuntu-latest

--- a/api/package.json
+++ b/api/package.json
@@ -17,6 +17,7 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
+    "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio"
   },
   "dependencies": {
@@ -51,5 +52,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,0 +1,72 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🌱 Seeding database...');
+
+  // Check if already seeded
+  const existing = await prisma.inspection.findFirst();
+  if (existing) {
+    console.log('✓ Database already seeded');
+    return;
+  }
+
+  // Create test inspection
+  const inspection = await prisma.inspection.create({
+    data: {
+      address: '123 Test Street, Auckland',
+      clientName: 'Test Client',
+      inspectorName: 'Test Inspector',
+      checklistId: 'standard-checklist',
+      status: 'IN_PROGRESS',
+      currentSection: 'exterior',
+      metadata: { type: 'residential' },
+    },
+  });
+
+  // Create test findings
+  await prisma.finding.createMany({
+    data: [
+      {
+        inspectionId: inspection.id,
+        section: 'exterior',
+        text: 'Cracks observed in exterior cladding near window frames',
+        severity: 'MAJOR',
+        matchedComment: 'Weather tightness issue',
+      },
+      {
+        inspectionId: inspection.id,
+        section: 'exterior',
+        text: 'Minor paint peeling on fascia boards',
+        severity: 'MINOR',
+      },
+      {
+        inspectionId: inspection.id,
+        section: 'interior',
+        text: 'Water staining on ceiling in master bedroom',
+        severity: 'MAJOR',
+        matchedComment: 'Possible roof leak',
+      },
+      {
+        inspectionId: inspection.id,
+        section: 'subfloor',
+        text: 'Subfloor ventilation adequate',
+        severity: 'INFO',
+      },
+    ],
+  });
+
+  console.log(`✓ Created inspection: ${inspection.id}`);
+  console.log('✓ Created 4 findings');
+  console.log('🌱 Seeding complete!');
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed error:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
Adds database seeding to CD pipeline so E2E tests have test data to work with.

## Changes
- `api/prisma/seed.ts` — creates test inspection with findings
- `api/package.json` — adds db:seed script and prisma seed config
- `.github/workflows/cd.yml` — runs seed after migrations

## Behavior
- Seed is idempotent (checks if data exists before creating)
- Creates 1 inspection with 4 findings across different sections/severities

## Closes
- #143