### PR TITLE
[Alex] fix(api): enable trust proxy for Fly.io (#138)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,10 @@ import { logStartupDiagnostics } from './config/startup.js';
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Trust first proxy (Fly.io reverse proxy)
+// Required for express-rate-limit to work correctly with X-Forwarded-For header
+app.set('trust proxy', 1);
+
 // CORS configuration - generated from APP_DOMAIN env var
 const allowedOrigins = getAllowedOrigins();
 


### PR DESCRIPTION
Fixes #138

## Problem
`express-rate-limit` throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when `X-Forwarded-For` header is present but Express `trust proxy` is disabled.

## Solution
```typescript
app.set('trust proxy', 1);
```

Setting to `1` trusts the first proxy hop (Fly.io reverse proxy).

## Testing
- ✅ Unit tests pass (41/41)
- ✅ Build succeeds