### PR TITLE
[Sam] fix(web): improve text contrast for WCAG 2.1 AA compliance

### DIFF
--- a/web/app/inspections/[id]/page.tsx
+++ b/web/app/inspections/[id]/page.tsx
@@ -113,7 +113,7 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
         <div className="flex items-start justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">{inspection.address}</h1>
-            <p className="text-gray-500 mt-1">
+            <p className="text-gray-600 mt-1">
               Client: {inspection.clientName}
               {inspection.inspectorName && ` • Inspector: ${inspection.inspectorName}`}
             </p>

--- a/web/components/finding-card.tsx
+++ b/web/components/finding-card.tsx
@@ -23,7 +23,7 @@ export function FindingCard({ finding, onEdit }: FindingCardProps): React.ReactE
             <button
               type="button"
               onClick={onEdit}
-              className="p-1.5 text-gray-400 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity rounded hover:bg-gray-100"
+              className="p-1.5 text-gray-500 hover:text-gray-700 opacity-0 group-hover:opacity-100 transition-opacity rounded hover:bg-gray-100"
               aria-label="Edit finding"
             >
               <svg
@@ -63,7 +63,7 @@ export function FindingCard({ finding, onEdit }: FindingCardProps): React.ReactE
         </div>
       )}
 
-      <div className="mt-2 text-xs text-gray-400">
+      <div className="mt-2 text-xs text-gray-600">
         {new Date(finding.createdAt).toLocaleString()}
       </div>
     </div>

--- a/web/components/section-view.tsx
+++ b/web/components/section-view.tsx
@@ -47,7 +47,7 @@ export function SectionView({
           )}
         </div>
         <svg
-          className={`w-5 h-5 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          className={`w-5 h-5 text-gray-500 transition-transform ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"


### PR DESCRIPTION
## Summary
Fix accessibility text contrast issues on inspection detail page.

## Changes
- `text-gray-400` → `text-gray-500/600` for better contrast
- Finding card timestamp: `gray-400` → `gray-600` (7:1 ratio)
- Edit button icon: `gray-400` → `gray-500` (4.6:1 ratio)
- Section chevron: `gray-400` → `gray-500` (4.6:1 ratio)
- Client info text: `gray-500` → `gray-600` (7:1 ratio)

## WCAG Compliance
All text now meets WCAG 2.1 AA minimum contrast ratio of 4.5:1.

## Testing
- [x] Lint passes
- [x] Typecheck passes

Closes #147