### PR TITLE
[Alex] feat(api): add Project, Property, and Client entities

### DIFF
--- a/api/prisma/migrations/20260219000000_add_project_property_client/migration.sql
+++ b/api/prisma/migrations/20260219000000_add_project_property_client/migration.sql
@@ -1,11 +1,11 @@
 -- CreateEnum
-CREATE TYPE "ReportType" AS ENUM ('COA', 'CCC', 'PRE_PURCHASE', 'WEATHERTIGHTNESS', 'GENERAL');
+CREATE TYPE "ReportType" AS ENUM ('COA', 'CCC_GAP', 'PPI', 'SAFE_SANITARY', 'TFA');
 
 -- CreateEnum
-CREATE TYPE "ProjectStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+CREATE TYPE "ProjectStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED');
 
 -- CreateEnum
-CREATE TYPE "TerritorialAuthority" AS ENUM ('AUCKLAND', 'WELLINGTON', 'CHRISTCHURCH', 'HAMILTON', 'TAURANGA', 'DUNEDIN', 'OTHER');
+CREATE TYPE "TerritorialAuthority" AS ENUM ('AKL', 'WCC', 'CCC', 'HDC', 'TCC', 'DCC', 'HCC', 'PCC', 'NCC', 'ICC', 'NPDC', 'WDC', 'RDC', 'OTHER');
 
 -- CreateTable
 CREATE TABLE "Client" (
@@ -13,7 +13,9 @@ CREATE TABLE "Client" (
     "name" TEXT NOT NULL,
     "email" TEXT,
     "phone" TEXT,
+    "mobile" TEXT,
     "address" TEXT,
+    "contactPerson" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/api/prisma/migrations/20260219000000_add_project_property_client/migration.sql
+++ b/api/prisma/migrations/20260219000000_add_project_property_client/migration.sql
@@ -1,0 +1,65 @@
+-- CreateEnum
+CREATE TYPE "ReportType" AS ENUM ('COA', 'CCC', 'PRE_PURCHASE', 'WEATHERTIGHTNESS', 'GENERAL');
+
+-- CreateEnum
+CREATE TYPE "ProjectStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "TerritorialAuthority" AS ENUM ('AUCKLAND', 'WELLINGTON', 'CHRISTCHURCH', 'HAMILTON', 'TAURANGA', 'DUNEDIN', 'OTHER');
+
+-- CreateTable
+CREATE TABLE "Client" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "address" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Client_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Property" (
+    "id" TEXT NOT NULL,
+    "streetAddress" TEXT NOT NULL,
+    "suburb" TEXT,
+    "city" TEXT,
+    "postcode" TEXT,
+    "lotDp" TEXT,
+    "councilPropertyId" TEXT,
+    "territorialAuthority" "TerritorialAuthority" NOT NULL,
+    "bcNumber" TEXT,
+    "yearBuilt" INTEGER,
+    "siteData" JSONB,
+    "construction" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Property_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" TEXT NOT NULL,
+    "jobNumber" TEXT NOT NULL,
+    "activity" TEXT NOT NULL,
+    "reportType" "ReportType" NOT NULL,
+    "status" "ProjectStatus" NOT NULL DEFAULT 'DRAFT',
+    "propertyId" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_jobNumber_key" ON "Project"("jobNumber");
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_propertyId_fkey" FOREIGN KEY ("propertyId") REFERENCES "Property"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -72,3 +72,86 @@ enum Severity {
   MAJOR
   URGENT
 }
+
+// ============================================
+// Project Management Entities
+// ============================================
+
+model Project {
+  id          String        @id @default(uuid())
+  jobNumber   String        @unique
+  activity    String
+  reportType  ReportType
+  status      ProjectStatus @default(DRAFT)
+  propertyId  String
+  property    Property      @relation(fields: [propertyId], references: [id])
+  clientId    String
+  client      Client        @relation(fields: [clientId], references: [id])
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+}
+
+model Property {
+  id                   String               @id @default(uuid())
+  streetAddress        String
+  suburb               String?
+  city                 String?
+  postcode             String?
+  lotDp                String?
+  councilPropertyId    String?
+  territorialAuthority TerritorialAuthority
+  bcNumber             String?
+  yearBuilt            Int?
+  siteData             Json?
+  construction         Json?
+  createdAt            DateTime             @default(now())
+  updatedAt            DateTime             @updatedAt
+  
+  projects             Project[]
+}
+
+model Client {
+  id            String    @id @default(uuid())
+  name          String
+  email         String?
+  phone         String?
+  mobile        String?
+  address       String?
+  contactPerson String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  
+  projects      Project[]
+}
+
+enum ReportType {
+  COA
+  CCC_GAP
+  PPI
+  SAFE_SANITARY
+  TFA
+}
+
+enum ProjectStatus {
+  DRAFT
+  IN_PROGRESS
+  REVIEW
+  COMPLETED
+}
+
+enum TerritorialAuthority {
+  AKL
+  WCC
+  CCC
+  HDC
+  TCC
+  DCC
+  HCC
+  PCC
+  NCC
+  ICC
+  NPDC
+  WDC
+  RDC
+  OTHER
+}

--- a/api/src/__tests__/project.test.ts
+++ b/api/src/__tests__/project.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ProjectService,
+  PropertyService,
+  ClientService,
+  ProjectNotFoundError,
+  PropertyNotFoundError,
+  ClientNotFoundError,
+} from '../services/project.js';
+import type {
+  IProjectRepository,
+  IPropertyRepository,
+  IClientRepository,
+} from '../repositories/interfaces/project.js';
+import type { Project, Property, Client } from '@prisma/client';
+
+// Mock repositories
+const createMockProjectRepository = (): IProjectRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByJobNumber: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  generateJobNumber: vi.fn(),
+});
+
+const createMockPropertyRepository = (): IPropertyRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+});
+
+const createMockClientRepository = (): IClientRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+});
+
+const mockProperty: Property = {
+  id: 'prop-1',
+  streetAddress: '123 Test St',
+  suburb: 'Henderson',
+  city: 'Auckland',
+  postcode: '0612',
+  lotDp: 'Lot 1 DP 12345',
+  councilPropertyId: null,
+  territorialAuthority: 'AKL',
+  bcNumber: null,
+  yearBuilt: 2000,
+  siteData: null,
+  construction: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockClient: Client = {
+  id: 'client-1',
+  name: 'John Smith',
+  email: 'john@example.com',
+  phone: '09 123 4567',
+  mobile: '021 123 4567',
+  address: '456 Other St',
+  contactPerson: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockProject: Project = {
+  id: 'proj-1',
+  jobNumber: '260219-001',
+  activity: 'Bathroom renovation',
+  reportType: 'COA',
+  status: 'DRAFT',
+  propertyId: 'prop-1',
+  clientId: 'client-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('ProjectService', () => {
+  let repository: IProjectRepository;
+  let service: ProjectService;
+
+  beforeEach(() => {
+    repository = createMockProjectRepository();
+    service = new ProjectService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a project with auto-generated job number', async () => {
+      vi.mocked(repository.generateJobNumber).mockResolvedValue('260219-001');
+      vi.mocked(repository.create).mockResolvedValue(mockProject);
+
+      const result = await service.create({
+        activity: 'Bathroom renovation',
+        reportType: 'COA',
+        propertyId: 'prop-1',
+        clientId: 'client-1',
+      });
+
+      expect(repository.generateJobNumber).toHaveBeenCalled();
+      expect(repository.create).toHaveBeenCalledWith({
+        activity: 'Bathroom renovation',
+        reportType: 'COA',
+        propertyId: 'prop-1',
+        clientId: 'client-1',
+        jobNumber: '260219-001',
+      });
+      expect(result).toEqual(mockProject);
+    });
+
+    it('should create a project with manual job number', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockProject);
+
+      const result = await service.create({
+        jobNumber: 'MANUAL-001',
+        activity: 'Bathroom renovation',
+        reportType: 'COA',
+        propertyId: 'prop-1',
+        clientId: 'client-1',
+      });
+
+      expect(repository.generateJobNumber).not.toHaveBeenCalled();
+      expect(repository.create).toHaveBeenCalledWith({
+        jobNumber: 'MANUAL-001',
+        activity: 'Bathroom renovation',
+        reportType: 'COA',
+        propertyId: 'prop-1',
+        clientId: 'client-1',
+      });
+      expect(result).toEqual(mockProject);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return project by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockProject);
+
+      const result = await service.findById('proj-1');
+      expect(result).toEqual(mockProject);
+    });
+
+    it('should throw ProjectNotFoundError for non-existent project', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        ProjectNotFoundError
+      );
+    });
+  });
+
+  describe('findByJobNumber', () => {
+    it('should return project by job number', async () => {
+      vi.mocked(repository.findByJobNumber).mockResolvedValue(mockProject);
+
+      const result = await service.findByJobNumber('260219-001');
+      expect(result).toEqual(mockProject);
+    });
+
+    it('should throw ProjectNotFoundError for non-existent job number', async () => {
+      vi.mocked(repository.findByJobNumber).mockResolvedValue(null);
+
+      await expect(service.findByJobNumber('non-existent')).rejects.toThrow(
+        ProjectNotFoundError
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all projects', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockProject]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([mockProject]);
+    });
+
+    it('should filter projects by status', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockProject]);
+
+      await service.findAll({ status: 'DRAFT' });
+      expect(repository.findAll).toHaveBeenCalledWith({ status: 'DRAFT' });
+    });
+  });
+
+  describe('update', () => {
+    it('should update project', async () => {
+      const updatedProject = { ...mockProject, status: 'IN_PROGRESS' as const };
+      vi.mocked(repository.findById).mockResolvedValue(mockProject);
+      vi.mocked(repository.update).mockResolvedValue(updatedProject);
+
+      const result = await service.update('proj-1', { status: 'IN_PROGRESS' });
+      expect(result.status).toBe('IN_PROGRESS');
+    });
+
+    it('should throw ProjectNotFoundError for non-existent project', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { status: 'IN_PROGRESS' })
+      ).rejects.toThrow(ProjectNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing project', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockProject);
+      vi.mocked(repository.delete).mockResolvedValue();
+
+      await expect(service.delete('proj-1')).resolves.toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('should throw ProjectNotFoundError for non-existent project', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        ProjectNotFoundError
+      );
+    });
+  });
+});
+
+describe('PropertyService', () => {
+  let repository: IPropertyRepository;
+  let service: PropertyService;
+
+  beforeEach(() => {
+    repository = createMockPropertyRepository();
+    service = new PropertyService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a property', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockProperty);
+
+      const result = await service.create({
+        streetAddress: '123 Test St',
+        territorialAuthority: 'AKL',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockProperty);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return property by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockProperty);
+
+      const result = await service.findById('prop-1');
+      expect(result).toEqual(mockProperty);
+    });
+
+    it('should throw PropertyNotFoundError for non-existent property', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        PropertyNotFoundError
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all properties', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockProperty]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([mockProperty]);
+    });
+
+    it('should filter properties by address', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockProperty]);
+
+      await service.findAll({ address: 'Test' });
+      expect(repository.findAll).toHaveBeenCalledWith({ address: 'Test' });
+    });
+  });
+
+  describe('update', () => {
+    it('should update property', async () => {
+      const updatedProperty = { ...mockProperty, suburb: 'Te Atatu' };
+      vi.mocked(repository.findById).mockResolvedValue(mockProperty);
+      vi.mocked(repository.update).mockResolvedValue(updatedProperty);
+
+      const result = await service.update('prop-1', { suburb: 'Te Atatu' });
+      expect(result.suburb).toBe('Te Atatu');
+    });
+
+    it('should throw PropertyNotFoundError for non-existent property', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { suburb: 'Te Atatu' })
+      ).rejects.toThrow(PropertyNotFoundError);
+    });
+  });
+});
+
+describe('ClientService', () => {
+  let repository: IClientRepository;
+  let service: ClientService;
+
+  beforeEach(() => {
+    repository = createMockClientRepository();
+    service = new ClientService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a client', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockClient);
+
+      const result = await service.create({
+        name: 'John Smith',
+        email: 'john@example.com',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockClient);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return client by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockClient);
+
+      const result = await service.findById('client-1');
+      expect(result).toEqual(mockClient);
+    });
+
+    it('should throw ClientNotFoundError for non-existent client', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        ClientNotFoundError
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all clients', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockClient]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([mockClient]);
+    });
+
+    it('should filter clients by name', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockClient]);
+
+      await service.findAll({ name: 'John' });
+      expect(repository.findAll).toHaveBeenCalledWith({ name: 'John' });
+    });
+  });
+
+  describe('update', () => {
+    it('should update client', async () => {
+      const updatedClient = { ...mockClient, phone: '09 987 6543' };
+      vi.mocked(repository.findById).mockResolvedValue(mockClient);
+      vi.mocked(repository.update).mockResolvedValue(updatedClient);
+
+      const result = await service.update('client-1', { phone: '09 987 6543' });
+      expect(result.phone).toBe('09 987 6543');
+    });
+
+    it('should throw ClientNotFoundError for non-existent client', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { phone: '09 987 6543' })
+      ).rejects.toThrow(ClientNotFoundError);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,9 @@ import { findingsRouter } from './routes/findings.js';
 import { photosRouter } from './routes/photos.js';
 import { reportsRouter } from './routes/reports.js';
 import { navigationRouter } from './routes/navigation.js';
+import { projectsRouter } from './routes/projects.js';
+import { propertiesRouter } from './routes/properties.js';
+import { clientsRouter } from './routes/clients.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -56,6 +59,9 @@ app.use('/api', authMiddleware, findingsRouter);
 app.use('/api', authMiddleware, photosRouter);
 app.use('/api', authMiddleware, reportsRouter);
 app.use('/api', authMiddleware, navigationRouter);
+app.use('/api/projects', authMiddleware, projectsRouter);
+app.use('/api/properties', authMiddleware, propertiesRouter);
+app.use('/api/clients', authMiddleware, clientsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/project.ts
+++ b/api/src/repositories/interfaces/project.ts
@@ -1,0 +1,112 @@
+import type { Project, Property, Client, ReportType, ProjectStatus, TerritorialAuthority, Prisma } from '@prisma/client';
+
+// Project interfaces
+export interface CreateProjectInput {
+  jobNumber?: string; // Optional - auto-generate if not provided
+  activity: string;
+  reportType: ReportType;
+  propertyId: string;
+  clientId: string;
+}
+
+export interface UpdateProjectInput {
+  jobNumber?: string;
+  activity?: string;
+  reportType?: ReportType;
+  status?: ProjectStatus;
+  propertyId?: string;
+  clientId?: string;
+}
+
+export interface ProjectSearchParams {
+  jobNumber?: string;
+  address?: string;
+  clientName?: string;
+  status?: ProjectStatus;
+  reportType?: ReportType;
+}
+
+// Property interfaces
+export interface CreatePropertyInput {
+  streetAddress: string;
+  suburb?: string;
+  city?: string;
+  postcode?: string;
+  lotDp?: string;
+  councilPropertyId?: string;
+  territorialAuthority: TerritorialAuthority;
+  bcNumber?: string;
+  yearBuilt?: number;
+  siteData?: Prisma.InputJsonValue;
+  construction?: Prisma.InputJsonValue;
+}
+
+export interface UpdatePropertyInput {
+  streetAddress?: string;
+  suburb?: string;
+  city?: string;
+  postcode?: string;
+  lotDp?: string;
+  councilPropertyId?: string;
+  territorialAuthority?: TerritorialAuthority;
+  bcNumber?: string;
+  yearBuilt?: number;
+  siteData?: Prisma.InputJsonValue;
+  construction?: Prisma.InputJsonValue;
+}
+
+export interface PropertySearchParams {
+  address?: string;
+  suburb?: string;
+  city?: string;
+  territorialAuthority?: TerritorialAuthority;
+}
+
+// Client interfaces
+export interface CreateClientInput {
+  name: string;
+  email?: string;
+  phone?: string;
+  mobile?: string;
+  address?: string;
+  contactPerson?: string;
+}
+
+export interface UpdateClientInput {
+  name?: string;
+  email?: string;
+  phone?: string;
+  mobile?: string;
+  address?: string;
+  contactPerson?: string;
+}
+
+export interface ClientSearchParams {
+  name?: string;
+  email?: string;
+}
+
+// Repository interfaces
+export interface IProjectRepository {
+  create(input: CreateProjectInput & { jobNumber: string }): Promise<Project>;
+  findById(id: string): Promise<Project | null>;
+  findByJobNumber(jobNumber: string): Promise<Project | null>;
+  findAll(params?: ProjectSearchParams): Promise<Project[]>;
+  update(id: string, input: UpdateProjectInput): Promise<Project>;
+  delete(id: string): Promise<void>;
+  generateJobNumber(): Promise<string>;
+}
+
+export interface IPropertyRepository {
+  create(input: CreatePropertyInput): Promise<Property>;
+  findById(id: string): Promise<Property | null>;
+  findAll(params?: PropertySearchParams): Promise<Property[]>;
+  update(id: string, input: UpdatePropertyInput): Promise<Property>;
+}
+
+export interface IClientRepository {
+  create(input: CreateClientInput): Promise<Client>;
+  findById(id: string): Promise<Client | null>;
+  findAll(params?: ClientSearchParams): Promise<Client[]>;
+  update(id: string, input: UpdateClientInput): Promise<Client>;
+}

--- a/api/src/repositories/prisma/project.ts
+++ b/api/src/repositories/prisma/project.ts
@@ -1,0 +1,214 @@
+import { PrismaClient, type Project, type Property, type Client } from '@prisma/client';
+import type {
+  IProjectRepository,
+  IPropertyRepository,
+  IClientRepository,
+  CreateProjectInput,
+  UpdateProjectInput,
+  ProjectSearchParams,
+  CreatePropertyInput,
+  UpdatePropertyInput,
+  PropertySearchParams,
+  CreateClientInput,
+  UpdateClientInput,
+  ClientSearchParams,
+} from '../interfaces/project.js';
+
+export class PrismaProjectRepository implements IProjectRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateProjectInput & { jobNumber: string }): Promise<Project> {
+    return this.prisma.project.create({
+      data: input,
+      include: {
+        property: true,
+        client: true,
+      },
+    });
+  }
+
+  async findById(id: string): Promise<Project | null> {
+    return this.prisma.project.findUnique({
+      where: { id },
+      include: {
+        property: true,
+        client: true,
+      },
+    });
+  }
+
+  async findByJobNumber(jobNumber: string): Promise<Project | null> {
+    return this.prisma.project.findUnique({
+      where: { jobNumber },
+      include: {
+        property: true,
+        client: true,
+      },
+    });
+  }
+
+  async findAll(params?: ProjectSearchParams): Promise<Project[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.jobNumber) {
+      where.jobNumber = { contains: params.jobNumber, mode: 'insensitive' };
+    }
+    if (params?.status) {
+      where.status = params.status;
+    }
+    if (params?.reportType) {
+      where.reportType = params.reportType;
+    }
+    if (params?.address) {
+      where.property = {
+        streetAddress: { contains: params.address, mode: 'insensitive' },
+      };
+    }
+    if (params?.clientName) {
+      where.client = {
+        name: { contains: params.clientName, mode: 'insensitive' },
+      };
+    }
+
+    return this.prisma.project.findMany({
+      where,
+      include: {
+        property: true,
+        client: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async update(id: string, input: UpdateProjectInput): Promise<Project> {
+    return this.prisma.project.update({
+      where: { id },
+      data: input,
+      include: {
+        property: true,
+        client: true,
+      },
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.project.delete({
+      where: { id },
+    });
+  }
+
+  async generateJobNumber(): Promise<string> {
+    const now = new Date();
+    const datePrefix = now.toISOString().slice(2, 10).replace(/-/g, '');
+    
+    // Find existing job numbers for today
+    const existingToday = await this.prisma.project.findMany({
+      where: {
+        jobNumber: { startsWith: datePrefix },
+      },
+      select: { jobNumber: true },
+      orderBy: { jobNumber: 'desc' },
+    });
+
+    let sequence = 1;
+    if (existingToday.length > 0) {
+      const lastNumber = existingToday[0]?.jobNumber;
+      if (lastNumber) {
+        const lastSequence = parseInt(lastNumber.split('-')[1] || '0', 10);
+        sequence = lastSequence + 1;
+      }
+    }
+
+    return `${datePrefix}-${sequence.toString().padStart(3, '0')}`;
+  }
+}
+
+export class PrismaPropertyRepository implements IPropertyRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreatePropertyInput): Promise<Property> {
+    return this.prisma.property.create({
+      data: input,
+    });
+  }
+
+  async findById(id: string): Promise<Property | null> {
+    return this.prisma.property.findUnique({
+      where: { id },
+      include: {
+        projects: true,
+      },
+    });
+  }
+
+  async findAll(params?: PropertySearchParams): Promise<Property[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.address) {
+      where.streetAddress = { contains: params.address, mode: 'insensitive' };
+    }
+    if (params?.suburb) {
+      where.suburb = { contains: params.suburb, mode: 'insensitive' };
+    }
+    if (params?.city) {
+      where.city = { contains: params.city, mode: 'insensitive' };
+    }
+    if (params?.territorialAuthority) {
+      where.territorialAuthority = params.territorialAuthority;
+    }
+
+    return this.prisma.property.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async update(id: string, input: UpdatePropertyInput): Promise<Property> {
+    return this.prisma.property.update({
+      where: { id },
+      data: input,
+    });
+  }
+}
+
+export class PrismaClientRepository implements IClientRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateClientInput): Promise<Client> {
+    return this.prisma.client.create({
+      data: input,
+    });
+  }
+
+  async findById(id: string): Promise<Client | null> {
+    return this.prisma.client.findUnique({
+      where: { id },
+      include: {
+        projects: true,
+      },
+    });
+  }
+
+  async findAll(params?: ClientSearchParams): Promise<Client[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.name) {
+      where.name = { contains: params.name, mode: 'insensitive' };
+    }
+    if (params?.email) {
+      where.email = { contains: params.email, mode: 'insensitive' };
+    }
+
+    return this.prisma.client.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async update(id: string, input: UpdateClientInput): Promise<Client> {
+    return this.prisma.client.update({
+      where: { id },
+      data: input,
+    });
+  }
+}

--- a/api/src/routes/clients.ts
+++ b/api/src/routes/clients.ts
@@ -1,0 +1,117 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientRepository } from '../repositories/prisma/project.js';
+import { ClientService, ClientNotFoundError } from '../services/project.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaClientRepository(prisma);
+const service = new ClientService(repository);
+
+export const clientsRouter = Router();
+
+// Validation schemas
+const CreateClientSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email').optional().or(z.literal('')),
+  phone: z.string().optional(),
+  mobile: z.string().optional(),
+  address: z.string().optional(),
+  contactPerson: z.string().optional(),
+});
+
+const UpdateClientSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email('Invalid email').optional().or(z.literal('')),
+  phone: z.string().optional(),
+  mobile: z.string().optional(),
+  address: z.string().optional(),
+  contactPerson: z.string().optional(),
+});
+
+// POST /api/clients - Create client
+clientsRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = CreateClientSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    // Convert empty string to undefined for email
+    const data = {
+      ...parsed.data,
+      email: parsed.data.email || undefined,
+    };
+
+    const client = await service.create(data);
+    res.status(201).json(client);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/clients - List clients with optional filters
+clientsRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { name, email } = req.query;
+
+    const clients = await service.findAll({
+      name: name as string | undefined,
+      email: email as string | undefined,
+    });
+    res.json(clients);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/clients/:id - Get client by ID
+clientsRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const client = await service.findById(id);
+    res.json(client);
+  } catch (error) {
+    if (error instanceof ClientNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// PUT /api/clients/:id - Update client
+clientsRouter.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateClientSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    // Convert empty string to undefined for email
+    const data = {
+      ...parsed.data,
+      email: parsed.data.email || undefined,
+    };
+
+    const client = await service.update(id, data);
+    res.json(client);
+  } catch (error) {
+    if (error instanceof ClientNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -4,3 +4,6 @@ export * from './findings.js';
 export * from './photos.js';
 export * from './reports.js';
 export * from './navigation.js';
+export * from './projects.js';
+export * from './properties.js';
+export * from './clients.js';

--- a/api/src/routes/projects.ts
+++ b/api/src/routes/projects.ts
@@ -1,0 +1,122 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaProjectRepository } from '../repositories/prisma/project.js';
+import { ProjectService, ProjectNotFoundError } from '../services/project.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaProjectRepository(prisma);
+const service = new ProjectService(repository);
+
+export const projectsRouter = Router();
+
+// Validation schemas
+const CreateProjectSchema = z.object({
+  jobNumber: z.string().min(1).optional(),
+  activity: z.string().min(1, 'Activity is required'),
+  reportType: z.enum(['COA', 'CCC_GAP', 'PPI', 'SAFE_SANITARY', 'TFA']),
+  propertyId: z.string().uuid('Invalid property ID'),
+  clientId: z.string().uuid('Invalid client ID'),
+});
+
+const UpdateProjectSchema = z.object({
+  jobNumber: z.string().min(1).optional(),
+  activity: z.string().min(1).optional(),
+  reportType: z.enum(['COA', 'CCC_GAP', 'PPI', 'SAFE_SANITARY', 'TFA']).optional(),
+  status: z.enum(['DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED']).optional(),
+  propertyId: z.string().uuid().optional(),
+  clientId: z.string().uuid().optional(),
+});
+
+// POST /api/projects - Create project
+projectsRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = CreateProjectSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const project = await service.create(parsed.data);
+    res.status(201).json(project);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/projects - List projects with optional filters
+projectsRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { jobNumber, address, clientName, status, reportType } = req.query;
+
+    const projects = await service.findAll({
+      jobNumber: jobNumber as string | undefined,
+      address: address as string | undefined,
+      clientName: clientName as string | undefined,
+      status: status as 'DRAFT' | 'IN_PROGRESS' | 'REVIEW' | 'COMPLETED' | undefined,
+      reportType: reportType as 'COA' | 'CCC_GAP' | 'PPI' | 'SAFE_SANITARY' | 'TFA' | undefined,
+    });
+    res.json(projects);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/projects/:id - Get project by ID
+projectsRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const project = await service.findById(id);
+    res.json(project);
+  } catch (error) {
+    if (error instanceof ProjectNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// PUT /api/projects/:id - Update project
+projectsRouter.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateProjectSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const project = await service.update(id, parsed.data);
+    res.json(project);
+  } catch (error) {
+    if (error instanceof ProjectNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/projects/:id - Delete project
+projectsRouter.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.delete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof ProjectNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/routes/properties.ts
+++ b/api/src/routes/properties.ts
@@ -1,0 +1,130 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient, type Prisma } from '@prisma/client';
+import { PrismaPropertyRepository } from '../repositories/prisma/project.js';
+import { PropertyService, PropertyNotFoundError } from '../services/project.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaPropertyRepository(prisma);
+const service = new PropertyService(repository);
+
+export const propertiesRouter = Router();
+
+// Territorial authority enum values
+const territorialAuthorities = [
+  'AKL', 'WCC', 'CCC', 'HDC', 'TCC', 'DCC', 'HCC', 'PCC', 'NCC', 'ICC', 'NPDC', 'WDC', 'RDC', 'OTHER'
+] as const;
+
+// Validation schemas
+const CreatePropertySchema = z.object({
+  streetAddress: z.string().min(1, 'Street address is required'),
+  suburb: z.string().optional(),
+  city: z.string().optional(),
+  postcode: z.string().optional(),
+  lotDp: z.string().optional(),
+  councilPropertyId: z.string().optional(),
+  territorialAuthority: z.enum(territorialAuthorities),
+  bcNumber: z.string().optional(),
+  yearBuilt: z.number().int().min(1800).max(2100).optional(),
+  siteData: z.any().optional(),
+  construction: z.any().optional(),
+});
+
+const UpdatePropertySchema = z.object({
+  streetAddress: z.string().min(1).optional(),
+  suburb: z.string().optional(),
+  city: z.string().optional(),
+  postcode: z.string().optional(),
+  lotDp: z.string().optional(),
+  councilPropertyId: z.string().optional(),
+  territorialAuthority: z.enum(territorialAuthorities).optional(),
+  bcNumber: z.string().optional(),
+  yearBuilt: z.number().int().min(1800).max(2100).optional(),
+  siteData: z.any().optional(),
+  construction: z.any().optional(),
+});
+
+// POST /api/properties - Create property
+propertiesRouter.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = CreatePropertySchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const property = await service.create({
+      ...parsed.data,
+      siteData: parsed.data.siteData as Prisma.InputJsonValue | undefined,
+      construction: parsed.data.construction as Prisma.InputJsonValue | undefined,
+    });
+    res.status(201).json(property);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/properties - List properties with optional filters
+propertiesRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { address, suburb, city, territorialAuthority } = req.query;
+
+    const properties = await service.findAll({
+      address: address as string | undefined,
+      suburb: suburb as string | undefined,
+      city: city as string | undefined,
+      territorialAuthority: territorialAuthority as typeof territorialAuthorities[number] | undefined,
+    });
+    res.json(properties);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/properties/:id - Get property by ID
+propertiesRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const property = await service.findById(id);
+    res.json(property);
+  } catch (error) {
+    if (error instanceof PropertyNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// PUT /api/properties/:id - Update property
+propertiesRouter.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdatePropertySchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const property = await service.update(id, {
+      ...parsed.data,
+      siteData: parsed.data.siteData as Prisma.InputJsonValue | undefined,
+      construction: parsed.data.construction as Prisma.InputJsonValue | undefined,
+    });
+    res.json(property);
+  } catch (error) {
+    if (error instanceof PropertyNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/services/project.ts
+++ b/api/src/services/project.ts
@@ -1,0 +1,125 @@
+import type { Project, Property, Client } from '@prisma/client';
+import type {
+  IProjectRepository,
+  IPropertyRepository,
+  IClientRepository,
+  CreateProjectInput,
+  UpdateProjectInput,
+  ProjectSearchParams,
+  CreatePropertyInput,
+  UpdatePropertyInput,
+  PropertySearchParams,
+  CreateClientInput,
+  UpdateClientInput,
+  ClientSearchParams,
+} from '../repositories/interfaces/project.js';
+
+export class ProjectNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Project not found: ${id}`);
+    this.name = 'ProjectNotFoundError';
+  }
+}
+
+export class PropertyNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Property not found: ${id}`);
+    this.name = 'PropertyNotFoundError';
+  }
+}
+
+export class ClientNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Client not found: ${id}`);
+    this.name = 'ClientNotFoundError';
+  }
+}
+
+export class ProjectService {
+  constructor(private repository: IProjectRepository) {}
+
+  async create(input: CreateProjectInput): Promise<Project> {
+    const jobNumber = input.jobNumber || await this.repository.generateJobNumber();
+    return this.repository.create({ ...input, jobNumber });
+  }
+
+  async findAll(params?: ProjectSearchParams): Promise<Project[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<Project> {
+    const project = await this.repository.findById(id);
+    if (!project) {
+      throw new ProjectNotFoundError(id);
+    }
+    return project;
+  }
+
+  async findByJobNumber(jobNumber: string): Promise<Project> {
+    const project = await this.repository.findByJobNumber(jobNumber);
+    if (!project) {
+      throw new ProjectNotFoundError(jobNumber);
+    }
+    return project;
+  }
+
+  async update(id: string, input: UpdateProjectInput): Promise<Project> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+}
+
+export class PropertyService {
+  constructor(private repository: IPropertyRepository) {}
+
+  async create(input: CreatePropertyInput): Promise<Property> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: PropertySearchParams): Promise<Property[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<Property> {
+    const property = await this.repository.findById(id);
+    if (!property) {
+      throw new PropertyNotFoundError(id);
+    }
+    return property;
+  }
+
+  async update(id: string, input: UpdatePropertyInput): Promise<Property> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+}
+
+export class ClientService {
+  constructor(private repository: IClientRepository) {}
+
+  async create(input: CreateClientInput): Promise<Client> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: ClientSearchParams): Promise<Client[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<Client> {
+    const client = await this.repository.findById(id);
+    if (!client) {
+      throw new ClientNotFoundError(id);
+    }
+    return client;
+  }
+
+  async update(id: string, input: UpdateClientInput): Promise<Client> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+}


### PR DESCRIPTION
## Summary
Implements Project, Property, and Client entities with full CRUD APIs.

## Changes
- **Prisma Schema**: Added Project, Property, Client models with enums (ReportType, ProjectStatus, TerritorialAuthority)
- **Repository Layer**: Created interfaces and Prisma implementations for all entities
- **Service Layer**: Added services with proper error handling (ProjectNotFoundError, etc.)
- **Routes**: REST endpoints for /api/projects, /api/properties, /api/clients
- **Tests**: 26 unit tests for all services

## API Endpoints

### Projects
- `POST /api/projects` - Create project (auto-generates job number)
- `GET /api/projects` - List/filter projects
- `GET /api/projects/:id` - Get project
- `PUT /api/projects/:id` - Update project
- `DELETE /api/projects/:id` - Delete project

### Properties
- `POST /api/properties` - Create property
- `GET /api/properties` - List/filter properties
- `GET /api/properties/:id` - Get property
- `PUT /api/properties/:id` - Update property

### Clients
- `POST /api/clients` - Create client
- `GET /api/clients` - List/filter clients
- `GET /api/clients/:id` - Get client
- `PUT /api/clients/:id` - Update client

## Job Number Format
Auto-generated: `YYMMDD-XXX` (e.g., 260219-001)

## Acceptance Criteria
### #175 - Project Entity
- [x] Create project with job number
- [x] Auto-generate job numbers
- [x] Link to property and client
- [x] Track status
- [x] Search/filter

### #176 - Property Entity
- [x] Create property with address
- [x] Record site data (zones - JSON)
- [x] Record construction details (JSON)
- [x] Search by address

### #177 - Client Entity
- [x] Create/edit clients
- [x] Link to projects
- [x] Search by name

Closes #175, closes #176, closes #177

Ref: docs/design/007-project-property-management.md