### PR TITLE
[Alex] feat(api): add SiteInspection entity and API endpoints

### DIFF
--- a/api/prisma/migrations/20260219010000_add_site_inspection/migration.sql
+++ b/api/prisma/migrations/20260219010000_add_site_inspection/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "InspectionType" AS ENUM ('SIMPLE', 'CLAUSE_REVIEW');
 
 -- CreateEnum
-CREATE TYPE "InspectionStage" AS ENUM ('INS_01', 'INS_02', 'INS_03', 'INS_04', 'INS_05', 'INS_06', 'INS_07', 'INS_07A', 'INS_08', 'INS_09', 'INS_10', 'INS_11', 'COA', 'CCC_GA', 'S_AND_S');
+CREATE TYPE "InspectionStage" AS ENUM ('INS_01', 'INS_02', 'INS_03', 'INS_04', 'INS_05', 'INS_06', 'INS_07', 'INS_07A', 'INS_08', 'INS_09', 'INS_10', 'INS_11', 'COA', 'CCC_GA', 'S_AND_S', 'TFA', 'DMG');
 
 -- CreateEnum
 CREATE TYPE "InspectionStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED');

--- a/api/prisma/migrations/20260219010000_add_site_inspection/migration.sql
+++ b/api/prisma/migrations/20260219010000_add_site_inspection/migration.sql
@@ -1,0 +1,50 @@
+-- CreateEnum
+CREATE TYPE "InspectionType" AS ENUM ('SIMPLE', 'CLAUSE_REVIEW');
+
+-- CreateEnum
+CREATE TYPE "InspectionStage" AS ENUM ('INS_01', 'INS_02', 'INS_03', 'INS_04', 'INS_05', 'INS_06', 'INS_07', 'INS_07A', 'INS_08', 'INS_09', 'INS_10', 'INS_11', 'COA', 'CCC_GA', 'S_AND_S');
+
+-- CreateEnum
+CREATE TYPE "InspectionStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED');
+
+-- CreateEnum
+CREATE TYPE "InspectionOutcome" AS ENUM ('PASS', 'FAIL', 'REPEAT_REQUIRED');
+
+-- CreateTable
+CREATE TABLE "SiteInspection" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "type" "InspectionType" NOT NULL,
+    "stage" "InspectionStage" NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "status" "InspectionStatus" NOT NULL DEFAULT 'DRAFT',
+    "weather" TEXT,
+    "personsPresent" TEXT,
+    "equipment" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "methodology" TEXT,
+    "areasNotAccessed" TEXT,
+    "inspectorName" TEXT NOT NULL,
+    "lbpOnSite" BOOLEAN,
+    "lbpLicenseSighted" BOOLEAN,
+    "lbpLicenseNumber" TEXT,
+    "lbpExpiryDate" TIMESTAMP(3),
+    "outcome" "InspectionOutcome",
+    "signatureData" TEXT,
+    "signatureDate" TIMESTAMP(3),
+    "currentSection" TEXT,
+    "currentClauseId" TEXT,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SiteInspection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SiteInspection_projectId_idx" ON "SiteInspection"("projectId");
+
+-- CreateIndex
+CREATE INDEX "SiteInspection_status_idx" ON "SiteInspection"("status");
+
+-- AddForeignKey
+ALTER TABLE "SiteInspection" ADD CONSTRAINT "SiteInspection_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -89,6 +89,8 @@ model Project {
   client      Client        @relation(fields: [clientId], references: [id])
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
+  
+  siteInspections SiteInspection[]
 }
 
 model Property {
@@ -154,4 +156,91 @@ enum TerritorialAuthority {
   WDC
   RDC
   OTHER
+}
+
+// ============================================
+// Site Inspection Entities
+// ============================================
+
+model SiteInspection {
+  id                String              @id @default(uuid())
+  projectId         String
+  project           Project             @relation(fields: [projectId], references: [id])
+  
+  type              InspectionType
+  stage             InspectionStage
+  date              DateTime
+  status            InspectionStatus    @default(DRAFT)
+  
+  // Context
+  weather           String?
+  personsPresent    String?
+  equipment         String[]            @default([])
+  methodology       String?
+  areasNotAccessed  String?
+  
+  // Inspector (string for now, will reference Personnel later)
+  inspectorName     String
+  
+  // LBP Verification (Simple mode)
+  lbpOnSite         Boolean?
+  lbpLicenseSighted Boolean?
+  lbpLicenseNumber  String?
+  lbpExpiryDate     DateTime?
+  
+  // Outcome
+  outcome           InspectionOutcome?
+  signatureData     String?
+  signatureDate     DateTime?
+  
+  // WhatsApp navigation
+  currentSection    String?
+  currentClauseId   String?
+  
+  // Soft delete
+  deletedAt         DateTime?
+  
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+  
+  @@index([projectId])
+  @@index([status])
+}
+
+enum InspectionType {
+  SIMPLE
+  CLAUSE_REVIEW
+}
+
+enum InspectionStage {
+  INS_01
+  INS_02
+  INS_03
+  INS_04
+  INS_05
+  INS_06
+  INS_07
+  INS_07A
+  INS_08
+  INS_09
+  INS_10
+  INS_11
+  COA
+  CCC_GA
+  S_AND_S
+  TFA
+  DMG
+}
+
+enum InspectionStatus {
+  DRAFT
+  IN_PROGRESS
+  REVIEW
+  COMPLETED
+}
+
+enum InspectionOutcome {
+  PASS
+  FAIL
+  REPEAT_REQUIRED
 }

--- a/api/src/__tests__/site-inspection.test.ts
+++ b/api/src/__tests__/site-inspection.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  SiteInspectionService,
+  SiteInspectionNotFoundError,
+} from '../services/site-inspection.js';
+import type { ISiteInspectionRepository } from '../repositories/interfaces/site-inspection.js';
+import type { SiteInspection } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): ISiteInspectionRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByProjectId: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  softDelete: vi.fn(),
+  restore: vi.fn(),
+  hardDelete: vi.fn(),
+});
+
+const mockSiteInspection: SiteInspection = {
+  id: 'insp-1',
+  projectId: 'proj-1',
+  type: 'SIMPLE',
+  stage: 'INS_05',
+  date: new Date('2026-02-19'),
+  status: 'DRAFT',
+  weather: 'Fine',
+  personsPresent: 'John Builder',
+  equipment: ['Moisture meter'],
+  methodology: null,
+  areasNotAccessed: null,
+  inspectorName: 'Test Inspector',
+  lbpOnSite: null,
+  lbpLicenseSighted: null,
+  lbpLicenseNumber: null,
+  lbpExpiryDate: null,
+  outcome: null,
+  signatureData: null,
+  signatureDate: null,
+  currentSection: null,
+  currentClauseId: null,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('SiteInspectionService', () => {
+  let repository: ISiteInspectionRepository;
+  let service: SiteInspectionService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new SiteInspectionService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a site inspection', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockSiteInspection);
+
+      const result = await service.create({
+        projectId: 'proj-1',
+        type: 'SIMPLE',
+        stage: 'INS_05',
+        date: new Date('2026-02-19'),
+        inspectorName: 'Test Inspector',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockSiteInspection);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return inspection by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+
+      const result = await service.findById('insp-1');
+      expect(result).toEqual(mockSiteInspection);
+    });
+
+    it('should throw SiteInspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        SiteInspectionNotFoundError
+      );
+    });
+  });
+
+  describe('findByProjectId', () => {
+    it('should return all inspections for project', async () => {
+      vi.mocked(repository.findByProjectId).mockResolvedValue([mockSiteInspection]);
+
+      const result = await service.findByProjectId('proj-1');
+      expect(result).toEqual([mockSiteInspection]);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all inspections', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockSiteInspection]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([mockSiteInspection]);
+    });
+
+    it('should filter by status', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockSiteInspection]);
+
+      await service.findAll({ status: 'DRAFT' });
+      expect(repository.findAll).toHaveBeenCalledWith({ status: 'DRAFT' });
+    });
+
+    it('should filter by type', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockSiteInspection]);
+
+      await service.findAll({ type: 'SIMPLE' });
+      expect(repository.findAll).toHaveBeenCalledWith({ type: 'SIMPLE' });
+    });
+  });
+
+  describe('update', () => {
+    it('should update inspection', async () => {
+      const updatedInspection = { ...mockSiteInspection, status: 'IN_PROGRESS' as const };
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+      vi.mocked(repository.update).mockResolvedValue(updatedInspection);
+
+      const result = await service.update('insp-1', { status: 'IN_PROGRESS' });
+      expect(result.status).toBe('IN_PROGRESS');
+    });
+
+    it('should throw SiteInspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { status: 'IN_PROGRESS' })
+      ).rejects.toThrow(SiteInspectionNotFoundError);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('should soft delete existing inspection', async () => {
+      const deletedInspection = { ...mockSiteInspection, deletedAt: new Date() };
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+      vi.mocked(repository.softDelete).mockResolvedValue(deletedInspection);
+
+      const result = await service.softDelete('insp-1');
+      expect(result.deletedAt).not.toBeNull();
+      expect(repository.softDelete).toHaveBeenCalledWith('insp-1');
+    });
+
+    it('should throw SiteInspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.softDelete('non-existent')).rejects.toThrow(
+        SiteInspectionNotFoundError
+      );
+    });
+  });
+
+  describe('restore', () => {
+    it('should restore soft-deleted inspection', async () => {
+      const deletedInspection = { ...mockSiteInspection, deletedAt: new Date() };
+      const restoredInspection = { ...mockSiteInspection, deletedAt: null };
+      vi.mocked(repository.findById).mockResolvedValue(deletedInspection);
+      vi.mocked(repository.restore).mockResolvedValue(restoredInspection);
+
+      const result = await service.restore('insp-1');
+      expect(result.deletedAt).toBeNull();
+    });
+
+    it('should throw error when inspection is not deleted', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+
+      await expect(service.restore('insp-1')).rejects.toThrow(
+        'Site inspection insp-1 is not deleted'
+      );
+    });
+
+    it('should throw SiteInspectionNotFoundError for non-existent inspection', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.restore('non-existent')).rejects.toThrow(
+        SiteInspectionNotFoundError
+      );
+    });
+  });
+
+  describe('complete', () => {
+    it('should mark inspection as completed', async () => {
+      const completedInspection = { ...mockSiteInspection, status: 'COMPLETED' as const };
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+      vi.mocked(repository.update).mockResolvedValue(completedInspection);
+
+      const result = await service.complete('insp-1');
+      expect(result.status).toBe('COMPLETED');
+    });
+  });
+
+  describe('navigate', () => {
+    it('should update current section and set status to in_progress', async () => {
+      const navigatedInspection = {
+        ...mockSiteInspection,
+        currentSection: 'interior',
+        status: 'IN_PROGRESS' as const,
+      };
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+      vi.mocked(repository.update).mockResolvedValue(navigatedInspection);
+
+      const result = await service.navigate('insp-1', 'interior');
+      expect(result.currentSection).toBe('interior');
+      expect(result.status).toBe('IN_PROGRESS');
+    });
+
+    it('should update current clause for clause review', async () => {
+      const navigatedInspection = {
+        ...mockSiteInspection,
+        type: 'CLAUSE_REVIEW' as const,
+        currentSection: 'B1',
+        currentClauseId: 'clause-b1',
+        status: 'IN_PROGRESS' as const,
+      };
+      vi.mocked(repository.findById).mockResolvedValue(mockSiteInspection);
+      vi.mocked(repository.update).mockResolvedValue(navigatedInspection);
+
+      const result = await service.navigate('insp-1', 'B1', 'clause-b1');
+      expect(result.currentSection).toBe('B1');
+      expect(result.currentClauseId).toBe('clause-b1');
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,6 +12,7 @@ import { navigationRouter } from './routes/navigation.js';
 import { projectsRouter } from './routes/projects.js';
 import { propertiesRouter } from './routes/properties.js';
 import { clientsRouter } from './routes/clients.js';
+import { siteInspectionsRouter } from './routes/site-inspections.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -62,6 +63,7 @@ app.use('/api', authMiddleware, navigationRouter);
 app.use('/api/projects', authMiddleware, projectsRouter);
 app.use('/api/properties', authMiddleware, propertiesRouter);
 app.use('/api/clients', authMiddleware, clientsRouter);
+app.use('/api', authMiddleware, siteInspectionsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/site-inspection.ts
+++ b/api/src/repositories/interfaces/site-inspection.ts
@@ -1,0 +1,61 @@
+import type {
+  SiteInspection,
+  InspectionType,
+  InspectionStage,
+  InspectionStatus,
+  InspectionOutcome,
+} from '@prisma/client';
+
+export interface CreateSiteInspectionInput {
+  projectId: string;
+  type: InspectionType;
+  stage: InspectionStage;
+  date: Date;
+  inspectorName: string;
+  weather?: string;
+  personsPresent?: string;
+  equipment?: string[];
+  methodology?: string;
+  areasNotAccessed?: string;
+}
+
+export interface UpdateSiteInspectionInput {
+  type?: InspectionType;
+  stage?: InspectionStage;
+  date?: Date;
+  status?: InspectionStatus;
+  weather?: string;
+  personsPresent?: string;
+  equipment?: string[];
+  methodology?: string;
+  areasNotAccessed?: string;
+  inspectorName?: string;
+  lbpOnSite?: boolean;
+  lbpLicenseSighted?: boolean;
+  lbpLicenseNumber?: string;
+  lbpExpiryDate?: Date;
+  outcome?: InspectionOutcome;
+  signatureData?: string;
+  signatureDate?: Date;
+  currentSection?: string;
+  currentClauseId?: string;
+}
+
+export interface SiteInspectionSearchParams {
+  projectId?: string;
+  type?: InspectionType;
+  stage?: InspectionStage;
+  status?: InspectionStatus;
+  includeDeleted?: boolean;
+}
+
+export interface ISiteInspectionRepository {
+  create(input: CreateSiteInspectionInput): Promise<SiteInspection>;
+  findById(id: string, includeDeleted?: boolean): Promise<SiteInspection | null>;
+  findByProjectId(projectId: string, includeDeleted?: boolean): Promise<SiteInspection[]>;
+  findAll(params?: SiteInspectionSearchParams): Promise<SiteInspection[]>;
+  update(id: string, input: UpdateSiteInspectionInput): Promise<SiteInspection>;
+  softDelete(id: string): Promise<SiteInspection>;
+  restore(id: string): Promise<SiteInspection>;
+  hardDelete(id: string): Promise<void>;
+}

--- a/api/src/repositories/prisma/site-inspection.ts
+++ b/api/src/repositories/prisma/site-inspection.ts
@@ -1,0 +1,128 @@
+import { PrismaClient, type SiteInspection } from '@prisma/client';
+import type {
+  ISiteInspectionRepository,
+  CreateSiteInspectionInput,
+  UpdateSiteInspectionInput,
+  SiteInspectionSearchParams,
+} from '../interfaces/site-inspection.js';
+
+export class PrismaSiteInspectionRepository implements ISiteInspectionRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateSiteInspectionInput): Promise<SiteInspection> {
+    return this.prisma.siteInspection.create({
+      data: input,
+      include: {
+        project: {
+          include: {
+            property: true,
+            client: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findById(id: string, includeDeleted = false): Promise<SiteInspection | null> {
+    return this.prisma.siteInspection.findFirst({
+      where: {
+        id,
+        ...(includeDeleted ? {} : { deletedAt: null }),
+      },
+      include: {
+        project: {
+          include: {
+            property: true,
+            client: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findByProjectId(projectId: string, includeDeleted = false): Promise<SiteInspection[]> {
+    return this.prisma.siteInspection.findMany({
+      where: {
+        projectId,
+        ...(includeDeleted ? {} : { deletedAt: null }),
+      },
+      include: {
+        project: {
+          include: {
+            property: true,
+            client: true,
+          },
+        },
+      },
+      orderBy: { date: 'desc' },
+    });
+  }
+
+  async findAll(params?: SiteInspectionSearchParams): Promise<SiteInspection[]> {
+    const where: Record<string, unknown> = {};
+
+    if (!params?.includeDeleted) {
+      where.deletedAt = null;
+    }
+    if (params?.projectId) {
+      where.projectId = params.projectId;
+    }
+    if (params?.type) {
+      where.type = params.type;
+    }
+    if (params?.stage) {
+      where.stage = params.stage;
+    }
+    if (params?.status) {
+      where.status = params.status;
+    }
+
+    return this.prisma.siteInspection.findMany({
+      where,
+      include: {
+        project: {
+          include: {
+            property: true,
+            client: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async update(id: string, input: UpdateSiteInspectionInput): Promise<SiteInspection> {
+    return this.prisma.siteInspection.update({
+      where: { id },
+      data: input,
+      include: {
+        project: {
+          include: {
+            property: true,
+            client: true,
+          },
+        },
+      },
+    });
+  }
+
+  async softDelete(id: string): Promise<SiteInspection> {
+    return this.prisma.siteInspection.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async restore(id: string): Promise<SiteInspection> {
+    return this.prisma.siteInspection.update({
+      where: { id },
+      data: { deletedAt: null },
+    });
+  }
+
+  async hardDelete(id: string): Promise<void> {
+    await this.prisma.siteInspection.delete({
+      where: { id },
+    });
+  }
+}

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -7,3 +7,4 @@ export * from './navigation.js';
 export * from './projects.js';
 export * from './properties.js';
 export * from './clients.js';
+export * from './site-inspections.js';

--- a/api/src/routes/site-inspections.ts
+++ b/api/src/routes/site-inspections.ts
@@ -1,0 +1,194 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaSiteInspectionRepository } from '../repositories/prisma/site-inspection.js';
+import { SiteInspectionService, SiteInspectionNotFoundError } from '../services/site-inspection.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaSiteInspectionRepository(prisma);
+const service = new SiteInspectionService(repository);
+
+export const siteInspectionsRouter = Router();
+
+// Inspection type and stage enums
+const inspectionTypes = ['SIMPLE', 'CLAUSE_REVIEW'] as const;
+const inspectionStages = [
+  'INS_01', 'INS_02', 'INS_03', 'INS_04', 'INS_05', 'INS_06', 'INS_07',
+  'INS_07A', 'INS_08', 'INS_09', 'INS_10', 'INS_11', 'COA', 'CCC_GA',
+  'S_AND_S', 'TFA', 'DMG'
+] as const;
+const inspectionStatuses = ['DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED'] as const;
+const inspectionOutcomes = ['PASS', 'FAIL', 'REPEAT_REQUIRED'] as const;
+
+// Validation schemas
+const CreateSiteInspectionSchema = z.object({
+  projectId: z.string().uuid('Invalid project ID'),
+  type: z.enum(inspectionTypes),
+  stage: z.enum(inspectionStages),
+  date: z.string().datetime().or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)),
+  inspectorName: z.string().min(1, 'Inspector name is required'),
+  weather: z.string().optional(),
+  personsPresent: z.string().optional(),
+  equipment: z.array(z.string()).optional(),
+  methodology: z.string().optional(),
+  areasNotAccessed: z.string().optional(),
+});
+
+const UpdateSiteInspectionSchema = z.object({
+  type: z.enum(inspectionTypes).optional(),
+  stage: z.enum(inspectionStages).optional(),
+  date: z.string().datetime().or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).optional(),
+  status: z.enum(inspectionStatuses).optional(),
+  weather: z.string().optional(),
+  personsPresent: z.string().optional(),
+  equipment: z.array(z.string()).optional(),
+  methodology: z.string().optional(),
+  areasNotAccessed: z.string().optional(),
+  inspectorName: z.string().min(1).optional(),
+  lbpOnSite: z.boolean().optional(),
+  lbpLicenseSighted: z.boolean().optional(),
+  lbpLicenseNumber: z.string().optional(),
+  lbpExpiryDate: z.string().datetime().optional(),
+  outcome: z.enum(inspectionOutcomes).optional(),
+  signatureData: z.string().optional(),
+  signatureDate: z.string().datetime().optional(),
+  currentSection: z.string().optional(),
+  currentClauseId: z.string().optional(),
+});
+
+// Helper to parse date strings
+function parseDate(dateStr: string): Date {
+  return new Date(dateStr);
+}
+
+// POST /api/projects/:projectId/inspections - Create inspection for project
+siteInspectionsRouter.post('/projects/:projectId/inspections', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const projectId = req.params.projectId as string;
+    const body = { ...req.body, projectId };
+    const parsed = CreateSiteInspectionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const inspection = await service.create({
+      ...parsed.data,
+      date: parseDate(parsed.data.date),
+    });
+    res.status(201).json(inspection);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/projects/:projectId/inspections - List inspections for project
+siteInspectionsRouter.get('/projects/:projectId/inspections', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const projectId = req.params.projectId as string;
+    const inspections = await service.findByProjectId(projectId);
+    res.json(inspections);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/site-inspections - List all site inspections with filters
+siteInspectionsRouter.get('/site-inspections', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { projectId, type, stage, status, includeDeleted } = req.query;
+
+    const inspections = await service.findAll({
+      projectId: projectId as string | undefined,
+      type: type as typeof inspectionTypes[number] | undefined,
+      stage: stage as typeof inspectionStages[number] | undefined,
+      status: status as typeof inspectionStatuses[number] | undefined,
+      includeDeleted: includeDeleted === 'true',
+    });
+    res.json(inspections);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/site-inspections/:id - Get inspection by ID
+siteInspectionsRouter.get('/site-inspections/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const inspection = await service.findById(id);
+    res.json(inspection);
+  } catch (error) {
+    if (error instanceof SiteInspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// PUT /api/site-inspections/:id - Update inspection
+siteInspectionsRouter.put('/site-inspections/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateSiteInspectionSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    // Convert date strings to Date objects
+    const updateData = {
+      ...parsed.data,
+      date: parsed.data.date ? parseDate(parsed.data.date) : undefined,
+      lbpExpiryDate: parsed.data.lbpExpiryDate ? parseDate(parsed.data.lbpExpiryDate) : undefined,
+      signatureDate: parsed.data.signatureDate ? parseDate(parsed.data.signatureDate) : undefined,
+    };
+
+    const inspection = await service.update(id, updateData);
+    res.json(inspection);
+  } catch (error) {
+    if (error instanceof SiteInspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/site-inspections/:id - Soft delete inspection
+siteInspectionsRouter.delete('/site-inspections/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.softDelete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof SiteInspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// POST /api/site-inspections/:id/restore - Restore soft-deleted inspection
+siteInspectionsRouter.post('/site-inspections/:id/restore', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const inspection = await service.restore(id);
+    res.json(inspection);
+  } catch (error) {
+    if (error instanceof SiteInspectionNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/services/site-inspection.ts
+++ b/api/src/services/site-inspection.ts
@@ -1,0 +1,79 @@
+import type { SiteInspection } from '@prisma/client';
+import type {
+  ISiteInspectionRepository,
+  CreateSiteInspectionInput,
+  UpdateSiteInspectionInput,
+  SiteInspectionSearchParams,
+} from '../repositories/interfaces/site-inspection.js';
+
+export class SiteInspectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Site inspection not found: ${id}`);
+    this.name = 'SiteInspectionNotFoundError';
+  }
+}
+
+export class SiteInspectionDeletedError extends Error {
+  constructor(id: string) {
+    super(`Site inspection has been deleted: ${id}`);
+    this.name = 'SiteInspectionDeletedError';
+  }
+}
+
+export class SiteInspectionService {
+  constructor(private repository: ISiteInspectionRepository) {}
+
+  async create(input: CreateSiteInspectionInput): Promise<SiteInspection> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: SiteInspectionSearchParams): Promise<SiteInspection[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<SiteInspection> {
+    const inspection = await this.repository.findById(id);
+    if (!inspection) {
+      throw new SiteInspectionNotFoundError(id);
+    }
+    return inspection;
+  }
+
+  async findByProjectId(projectId: string): Promise<SiteInspection[]> {
+    return this.repository.findByProjectId(projectId);
+  }
+
+  async update(id: string, input: UpdateSiteInspectionInput): Promise<SiteInspection> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async softDelete(id: string): Promise<SiteInspection> {
+    await this.findById(id);
+    return this.repository.softDelete(id);
+  }
+
+  async restore(id: string): Promise<SiteInspection> {
+    // For restore, we need to find including deleted
+    const inspection = await this.repository.findById(id, true);
+    if (!inspection) {
+      throw new SiteInspectionNotFoundError(id);
+    }
+    if (!inspection.deletedAt) {
+      throw new Error(`Site inspection ${id} is not deleted`);
+    }
+    return this.repository.restore(id);
+  }
+
+  async complete(id: string): Promise<SiteInspection> {
+    return this.update(id, { status: 'COMPLETED' });
+  }
+
+  async navigate(id: string, section: string, clauseId?: string): Promise<SiteInspection> {
+    return this.update(id, {
+      currentSection: section,
+      currentClauseId: clauseId,
+      status: 'IN_PROGRESS',
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Implements the SiteInspection entity with full CRUD APIs, supporting both Simple and ClauseReview inspection modes.

## Changes
- **Prisma Schema**: Added SiteInspection model with enums (InspectionType, InspectionStage, InspectionStatus, InspectionOutcome)
- **Repository Layer**: Interface + Prisma implementation with soft delete support
- **Service Layer**: Business logic with navigation and completion helpers
- **Routes**: REST endpoints for inspection management
- **Tests**: 17 unit tests for service layer

## API Endpoints

### Create/List by Project
- `POST /api/projects/:projectId/inspections` - Create inspection for project
- `GET /api/projects/:projectId/inspections` - List inspections for project

### CRUD Operations
- `GET /api/site-inspections` - List all (with filters: projectId, type, stage, status)
- `GET /api/site-inspections/:id` - Get inspection
- `PUT /api/site-inspections/:id` - Update inspection
- `DELETE /api/site-inspections/:id` - Soft delete
- `POST /api/site-inspections/:id/restore` - Restore deleted

## Inspection Types
- **SIMPLE** - Council-style pass/fail checklist
- **CLAUSE_REVIEW** - Building Code clause-by-clause analysis

## Inspection Stages
INS_01 through INS_11, plus COA, CCC_GA, S_AND_S, TFA, DMG

## Features
- Links to Project entity (#180)
- Soft delete with restore capability
- Weather, equipment, persons present metadata
- LBP verification fields (Simple mode)
- Outcome and signature fields
- WhatsApp navigation support (currentSection, currentClauseId)

## Acceptance Criteria
- [x] Create inspection with type and stage
- [x] Link inspection to project
- [x] Record inspection metadata (weather, equipment, etc.)
- [x] Update inspection status
- [x] Delete inspection (soft delete)
- [x] Validate required fields

Closes #161

Ref: docs/design/004-inspection-checklist-system.md