### PR TITLE
[Alex] feat(api): add ChecklistItem entity for Simple Checklist mode

### DIFF
--- a/api/prisma/migrations/20260219020000_add_checklist_item/migration.sql
+++ b/api/prisma/migrations/20260219020000_add_checklist_item/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "ChecklistCategory" AS ENUM ('EXTERIOR', 'INTERIOR', 'DECKS', 'SERVICES', 'SITE');
+
+-- CreateEnum
+CREATE TYPE "Decision" AS ENUM ('PASS', 'FAIL', 'NA');
+
+-- CreateTable
+CREATE TABLE "ChecklistItem" (
+    "id" TEXT NOT NULL,
+    "inspectionId" TEXT NOT NULL,
+    "category" "ChecklistCategory" NOT NULL,
+    "item" TEXT NOT NULL,
+    "decision" "Decision" NOT NULL,
+    "notes" TEXT,
+    "photoIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChecklistItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ChecklistItem_inspectionId_category_idx" ON "ChecklistItem"("inspectionId", "category");
+
+-- AddForeignKey
+ALTER TABLE "ChecklistItem" ADD CONSTRAINT "ChecklistItem_inspectionId_fkey" FOREIGN KEY ("inspectionId") REFERENCES "SiteInspection"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -203,8 +203,44 @@ model SiteInspection {
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt
   
+  // Relations
+  checklistItems    ChecklistItem[]
+  
   @@index([projectId])
   @@index([status])
+}
+
+model ChecklistItem {
+  id              String          @id @default(uuid())
+  inspectionId    String
+  inspection      SiteInspection  @relation(fields: [inspectionId], references: [id], onDelete: Cascade)
+  
+  category        ChecklistCategory
+  item            String
+  decision        Decision
+  notes           String?
+  
+  photoIds        String[]        @default([])
+  
+  sortOrder       Int             @default(0)
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+  
+  @@index([inspectionId, category])
+}
+
+enum ChecklistCategory {
+  EXTERIOR
+  INTERIOR
+  DECKS
+  SERVICES
+  SITE
+}
+
+enum Decision {
+  PASS
+  FAIL
+  NA
 }
 
 enum InspectionType {

--- a/api/src/__tests__/checklist-item.test.ts
+++ b/api/src/__tests__/checklist-item.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ChecklistItemService,
+  ChecklistItemNotFoundError,
+} from '../services/checklist-item.js';
+import type { IChecklistItemRepository } from '../repositories/interfaces/checklist-item.js';
+import type { ChecklistItem } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): IChecklistItemRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByInspectionId: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  bulkCreate: vi.fn(),
+  reorder: vi.fn(),
+});
+
+const mockChecklistItem: ChecklistItem = {
+  id: 'item-1',
+  inspectionId: 'insp-1',
+  category: 'EXTERIOR',
+  item: 'Roof cladding / flashings',
+  decision: 'PASS',
+  notes: null,
+  photoIds: [],
+  sortOrder: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('ChecklistItemService', () => {
+  let repository: IChecklistItemRepository;
+  let service: ChecklistItemService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new ChecklistItemService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a checklist item', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockChecklistItem);
+
+      const result = await service.create({
+        inspectionId: 'insp-1',
+        category: 'EXTERIOR',
+        item: 'Roof cladding / flashings',
+        decision: 'PASS',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockChecklistItem);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return item by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockChecklistItem);
+
+      const result = await service.findById('item-1');
+      expect(result).toEqual(mockChecklistItem);
+    });
+
+    it('should throw ChecklistItemNotFoundError for non-existent item', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        ChecklistItemNotFoundError
+      );
+    });
+  });
+
+  describe('findByInspectionId', () => {
+    it('should return all items for inspection', async () => {
+      vi.mocked(repository.findByInspectionId).mockResolvedValue([mockChecklistItem]);
+
+      const result = await service.findByInspectionId('insp-1');
+      expect(result).toEqual([mockChecklistItem]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update checklist item', async () => {
+      const updatedItem = { ...mockChecklistItem, decision: 'FAIL' as const, notes: 'Damage found' };
+      vi.mocked(repository.findById).mockResolvedValue(mockChecklistItem);
+      vi.mocked(repository.update).mockResolvedValue(updatedItem);
+
+      const result = await service.update('item-1', { decision: 'FAIL', notes: 'Damage found' });
+      expect(result.decision).toBe('FAIL');
+      expect(result.notes).toBe('Damage found');
+    });
+
+    it('should throw ChecklistItemNotFoundError for non-existent item', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { decision: 'FAIL' })
+      ).rejects.toThrow(ChecklistItemNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing item', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockChecklistItem);
+      vi.mocked(repository.delete).mockResolvedValue();
+
+      await expect(service.delete('item-1')).resolves.toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith('item-1');
+    });
+
+    it('should throw ChecklistItemNotFoundError for non-existent item', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        ChecklistItemNotFoundError
+      );
+    });
+  });
+
+  describe('bulkCreate', () => {
+    it('should create multiple items', async () => {
+      const items = [mockChecklistItem, { ...mockChecklistItem, id: 'item-2', item: 'Wall cladding' }];
+      vi.mocked(repository.bulkCreate).mockResolvedValue(items);
+
+      const result = await service.bulkCreate([
+        { inspectionId: 'insp-1', category: 'EXTERIOR', item: 'Roof cladding', decision: 'PASS' },
+        { inspectionId: 'insp-1', category: 'EXTERIOR', item: 'Wall cladding', decision: 'PASS' },
+      ]);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should calculate summary correctly', async () => {
+      const items: ChecklistItem[] = [
+        { ...mockChecklistItem, id: 'item-1', decision: 'PASS' },
+        { ...mockChecklistItem, id: 'item-2', decision: 'PASS' },
+        { ...mockChecklistItem, id: 'item-3', decision: 'FAIL', notes: 'Issue found' },
+        { ...mockChecklistItem, id: 'item-4', decision: 'NA' },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(items);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.total).toBe(4);
+      expect(summary.passed).toBe(2);
+      expect(summary.failed).toBe(1);
+      expect(summary.na).toBe(1);
+      expect(summary.overallResult).toBe('FAIL');
+      expect(summary.failedItemsWithoutNotes).toHaveLength(0);
+    });
+
+    it('should return PASS when all items pass or NA', async () => {
+      const items: ChecklistItem[] = [
+        { ...mockChecklistItem, id: 'item-1', decision: 'PASS' },
+        { ...mockChecklistItem, id: 'item-2', decision: 'PASS' },
+        { ...mockChecklistItem, id: 'item-3', decision: 'NA' },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(items);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.overallResult).toBe('PASS');
+    });
+
+    it('should track failed items without notes', async () => {
+      const items: ChecklistItem[] = [
+        { ...mockChecklistItem, id: 'item-1', decision: 'FAIL', notes: null },
+        { ...mockChecklistItem, id: 'item-2', decision: 'FAIL', notes: '' },
+        { ...mockChecklistItem, id: 'item-3', decision: 'FAIL', notes: 'Has notes' },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(items);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.failedItemsWithoutNotes).toContain('item-1');
+      expect(summary.failedItemsWithoutNotes).toContain('item-2');
+      expect(summary.failedItemsWithoutNotes).not.toContain('item-3');
+    });
+
+    it('should return INCOMPLETE when no items', async () => {
+      vi.mocked(repository.findByInspectionId).mockResolvedValue([]);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.overallResult).toBe('INCOMPLETE');
+    });
+
+    it('should group by category', async () => {
+      const items: ChecklistItem[] = [
+        { ...mockChecklistItem, id: 'item-1', category: 'EXTERIOR', decision: 'PASS' },
+        { ...mockChecklistItem, id: 'item-2', category: 'EXTERIOR', decision: 'FAIL', notes: 'Issue' },
+        { ...mockChecklistItem, id: 'item-3', category: 'INTERIOR', decision: 'PASS' },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(items);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.byCategory['EXTERIOR']).toEqual({ passed: 1, failed: 1, na: 0 });
+      expect(summary.byCategory['INTERIOR']).toEqual({ passed: 1, failed: 0, na: 0 });
+    });
+  });
+
+  describe('getGroupedByCategory', () => {
+    it('should group items by category', async () => {
+      const items: ChecklistItem[] = [
+        { ...mockChecklistItem, id: 'item-1', category: 'EXTERIOR' },
+        { ...mockChecklistItem, id: 'item-2', category: 'EXTERIOR' },
+        { ...mockChecklistItem, id: 'item-3', category: 'INTERIOR' },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(items);
+
+      const grouped = await service.getGroupedByCategory('insp-1');
+
+      expect(grouped['EXTERIOR']).toHaveLength(2);
+      expect(grouped['INTERIOR']).toHaveLength(1);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,6 +13,7 @@ import { projectsRouter } from './routes/projects.js';
 import { propertiesRouter } from './routes/properties.js';
 import { clientsRouter } from './routes/clients.js';
 import { siteInspectionsRouter } from './routes/site-inspections.js';
+import { checklistItemsRouter } from './routes/checklist-items.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -64,6 +65,7 @@ app.use('/api/projects', authMiddleware, projectsRouter);
 app.use('/api/properties', authMiddleware, propertiesRouter);
 app.use('/api/clients', authMiddleware, clientsRouter);
 app.use('/api', authMiddleware, siteInspectionsRouter);
+app.use('/api', authMiddleware, checklistItemsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/checklist-item.ts
+++ b/api/src/repositories/interfaces/checklist-item.ts
@@ -1,0 +1,37 @@
+import type { ChecklistItem, ChecklistCategory, Decision } from '@prisma/client';
+
+export interface CreateChecklistItemInput {
+  inspectionId: string;
+  category: ChecklistCategory;
+  item: string;
+  decision: Decision;
+  notes?: string;
+  photoIds?: string[];
+  sortOrder?: number;
+}
+
+export interface UpdateChecklistItemInput {
+  category?: ChecklistCategory;
+  item?: string;
+  decision?: Decision;
+  notes?: string;
+  photoIds?: string[];
+  sortOrder?: number;
+}
+
+export interface ChecklistItemSearchParams {
+  inspectionId?: string;
+  category?: ChecklistCategory;
+  decision?: Decision;
+}
+
+export interface IChecklistItemRepository {
+  create(input: CreateChecklistItemInput): Promise<ChecklistItem>;
+  findById(id: string): Promise<ChecklistItem | null>;
+  findByInspectionId(inspectionId: string): Promise<ChecklistItem[]>;
+  findAll(params?: ChecklistItemSearchParams): Promise<ChecklistItem[]>;
+  update(id: string, input: UpdateChecklistItemInput): Promise<ChecklistItem>;
+  delete(id: string): Promise<void>;
+  bulkCreate(items: CreateChecklistItemInput[]): Promise<ChecklistItem[]>;
+  reorder(inspectionId: string, itemIds: string[]): Promise<void>;
+}

--- a/api/src/repositories/prisma/checklist-item.ts
+++ b/api/src/repositories/prisma/checklist-item.ts
@@ -1,0 +1,90 @@
+import { PrismaClient, type ChecklistItem } from '@prisma/client';
+import type {
+  IChecklistItemRepository,
+  CreateChecklistItemInput,
+  UpdateChecklistItemInput,
+  ChecklistItemSearchParams,
+} from '../interfaces/checklist-item.js';
+
+export class PrismaChecklistItemRepository implements IChecklistItemRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateChecklistItemInput): Promise<ChecklistItem> {
+    return this.prisma.checklistItem.create({
+      data: input,
+    });
+  }
+
+  async findById(id: string): Promise<ChecklistItem | null> {
+    return this.prisma.checklistItem.findUnique({
+      where: { id },
+    });
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<ChecklistItem[]> {
+    return this.prisma.checklistItem.findMany({
+      where: { inspectionId },
+      orderBy: [
+        { category: 'asc' },
+        { sortOrder: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+  }
+
+  async findAll(params?: ChecklistItemSearchParams): Promise<ChecklistItem[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.inspectionId) {
+      where.inspectionId = params.inspectionId;
+    }
+    if (params?.category) {
+      where.category = params.category;
+    }
+    if (params?.decision) {
+      where.decision = params.decision;
+    }
+
+    return this.prisma.checklistItem.findMany({
+      where,
+      orderBy: [
+        { category: 'asc' },
+        { sortOrder: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+  }
+
+  async update(id: string, input: UpdateChecklistItemInput): Promise<ChecklistItem> {
+    return this.prisma.checklistItem.update({
+      where: { id },
+      data: input,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.checklistItem.delete({
+      where: { id },
+    });
+  }
+
+  async bulkCreate(items: CreateChecklistItemInput[]): Promise<ChecklistItem[]> {
+    // Use transaction for bulk create
+    return this.prisma.$transaction(
+      items.map((item) =>
+        this.prisma.checklistItem.create({ data: item })
+      )
+    );
+  }
+
+  async reorder(inspectionId: string, itemIds: string[]): Promise<void> {
+    await this.prisma.$transaction(
+      itemIds.map((id, index) =>
+        this.prisma.checklistItem.update({
+          where: { id },
+          data: { sortOrder: index },
+        })
+      )
+    );
+  }
+}

--- a/api/src/routes/checklist-items.ts
+++ b/api/src/routes/checklist-items.ts
@@ -1,0 +1,226 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaChecklistItemRepository } from '../repositories/prisma/checklist-item.js';
+import { ChecklistItemService, ChecklistItemNotFoundError } from '../services/checklist-item.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaChecklistItemRepository(prisma);
+const service = new ChecklistItemService(repository);
+
+export const checklistItemsRouter = Router();
+
+// Enums
+const checklistCategories = ['EXTERIOR', 'INTERIOR', 'DECKS', 'SERVICES', 'SITE'] as const;
+const decisions = ['PASS', 'FAIL', 'NA'] as const;
+
+// Validation schemas
+const CreateChecklistItemSchema = z.object({
+  category: z.enum(checklistCategories),
+  item: z.string().min(1, 'Item text is required'),
+  decision: z.enum(decisions),
+  notes: z.string().optional(),
+  photoIds: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+const UpdateChecklistItemSchema = z.object({
+  category: z.enum(checklistCategories).optional(),
+  item: z.string().min(1).optional(),
+  decision: z.enum(decisions).optional(),
+  notes: z.string().optional(),
+  photoIds: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+const BulkCreateSchema = z.object({
+  items: z.array(CreateChecklistItemSchema),
+});
+
+const ReorderSchema = z.object({
+  itemIds: z.array(z.string().uuid()),
+});
+
+// POST /api/site-inspections/:inspectionId/checklist-items - Create item
+checklistItemsRouter.post(
+  '/site-inspections/:inspectionId/checklist-items',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = CreateChecklistItemSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const item = await service.create({
+        ...parsed.data,
+        inspectionId,
+      });
+      res.status(201).json(item);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/site-inspections/:inspectionId/checklist-items/bulk - Bulk create
+checklistItemsRouter.post(
+  '/site-inspections/:inspectionId/checklist-items/bulk',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = BulkCreateSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const items = await service.bulkCreate(
+        parsed.data.items.map((item) => ({
+          ...item,
+          inspectionId,
+        }))
+      );
+      res.status(201).json(items);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/site-inspections/:inspectionId/checklist-items - List items
+checklistItemsRouter.get(
+  '/site-inspections/:inspectionId/checklist-items',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const { category, decision, grouped } = req.query;
+
+      if (grouped === 'true') {
+        const groupedItems = await service.getGroupedByCategory(inspectionId);
+        res.json(groupedItems);
+        return;
+      }
+
+      const items = await service.findAll({
+        inspectionId,
+        category: category as typeof checklistCategories[number] | undefined,
+        decision: decision as typeof decisions[number] | undefined,
+      });
+      res.json(items);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/site-inspections/:inspectionId/checklist-summary - Get summary
+checklistItemsRouter.get(
+  '/site-inspections/:inspectionId/checklist-summary',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const summary = await service.getSummary(inspectionId);
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// PUT /api/site-inspections/:inspectionId/checklist-items/reorder - Reorder items
+checklistItemsRouter.put(
+  '/site-inspections/:inspectionId/checklist-items/reorder',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = ReorderSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      await service.reorder(inspectionId, parsed.data.itemIds);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/checklist-items/:id - Get item by ID
+checklistItemsRouter.get(
+  '/checklist-items/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const item = await service.findById(id);
+      res.json(item);
+    } catch (error) {
+      if (error instanceof ChecklistItemNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// PUT /api/checklist-items/:id - Update item
+checklistItemsRouter.put(
+  '/checklist-items/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const parsed = UpdateChecklistItemSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const item = await service.update(id, parsed.data);
+      res.json(item);
+    } catch (error) {
+      if (error instanceof ChecklistItemNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/checklist-items/:id - Delete item
+checklistItemsRouter.delete(
+  '/checklist-items/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      await service.delete(id);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof ChecklistItemNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -8,3 +8,4 @@ export * from './projects.js';
 export * from './properties.js';
 export * from './clients.js';
 export * from './site-inspections.js';
+export * from './checklist-items.js';

--- a/api/src/services/checklist-item.ts
+++ b/api/src/services/checklist-item.ts
@@ -1,0 +1,135 @@
+import type { ChecklistItem, ChecklistCategory } from '@prisma/client';
+import type {
+  IChecklistItemRepository,
+  CreateChecklistItemInput,
+  UpdateChecklistItemInput,
+  ChecklistItemSearchParams,
+} from '../repositories/interfaces/checklist-item.js';
+
+export class ChecklistItemNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Checklist item not found: ${id}`);
+    this.name = 'ChecklistItemNotFoundError';
+  }
+}
+
+export interface ChecklistSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  na: number;
+  byCategory: Record<string, { passed: number; failed: number; na: number }>;
+  failedItemsWithoutNotes: string[];
+  overallResult: 'PASS' | 'FAIL' | 'INCOMPLETE';
+}
+
+export class ChecklistItemService {
+  constructor(private repository: IChecklistItemRepository) {}
+
+  async create(input: CreateChecklistItemInput): Promise<ChecklistItem> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: ChecklistItemSearchParams): Promise<ChecklistItem[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<ChecklistItem> {
+    const item = await this.repository.findById(id);
+    if (!item) {
+      throw new ChecklistItemNotFoundError(id);
+    }
+    return item;
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<ChecklistItem[]> {
+    return this.repository.findByInspectionId(inspectionId);
+  }
+
+  async update(id: string, input: UpdateChecklistItemInput): Promise<ChecklistItem> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+
+  async bulkCreate(items: CreateChecklistItemInput[]): Promise<ChecklistItem[]> {
+    return this.repository.bulkCreate(items);
+  }
+
+  async reorder(inspectionId: string, itemIds: string[]): Promise<void> {
+    return this.repository.reorder(inspectionId, itemIds);
+  }
+
+  async getSummary(inspectionId: string): Promise<ChecklistSummary> {
+    const items = await this.findByInspectionId(inspectionId);
+
+    const summary: ChecklistSummary = {
+      total: items.length,
+      passed: 0,
+      failed: 0,
+      na: 0,
+      byCategory: {},
+      failedItemsWithoutNotes: [],
+      overallResult: 'INCOMPLETE',
+    };
+
+    for (const item of items) {
+      // Count by decision
+      if (item.decision === 'PASS') {
+        summary.passed++;
+      } else if (item.decision === 'FAIL') {
+        summary.failed++;
+        // Track failed items without notes
+        if (!item.notes || item.notes.trim() === '') {
+          summary.failedItemsWithoutNotes.push(item.id);
+        }
+      } else if (item.decision === 'NA') {
+        summary.na++;
+      }
+
+      // Count by category
+      const category = item.category;
+      if (!summary.byCategory[category]) {
+        summary.byCategory[category] = { passed: 0, failed: 0, na: 0 };
+      }
+      if (item.decision === 'PASS') {
+        summary.byCategory[category].passed++;
+      } else if (item.decision === 'FAIL') {
+        summary.byCategory[category].failed++;
+      } else if (item.decision === 'NA') {
+        summary.byCategory[category].na++;
+      }
+    }
+
+    // Calculate overall result
+    if (items.length === 0) {
+      summary.overallResult = 'INCOMPLETE';
+    } else if (summary.failed > 0) {
+      summary.overallResult = 'FAIL';
+    } else if (summary.passed + summary.na === items.length) {
+      summary.overallResult = 'PASS';
+    } else {
+      summary.overallResult = 'INCOMPLETE';
+    }
+
+    return summary;
+  }
+
+  async getGroupedByCategory(inspectionId: string): Promise<Record<ChecklistCategory, ChecklistItem[]>> {
+    const items = await this.findByInspectionId(inspectionId);
+    
+    const grouped: Record<string, ChecklistItem[]> = {};
+    for (const item of items) {
+      if (!grouped[item.category]) {
+        grouped[item.category] = [];
+      }
+      grouped[item.category].push(item);
+    }
+    
+    return grouped as Record<ChecklistCategory, ChecklistItem[]>;
+  }
+}


### PR DESCRIPTION
## Summary
Implements ChecklistItem entity for the Simple Checklist inspection mode (Pass/Fail inspections).

## Changes
- **Prisma Schema**: Added ChecklistItem model with ChecklistCategory and Decision enums
- **Repository Layer**: Interface + Prisma implementation with bulk create and reorder
- **Service Layer**: Business logic with summary calculation, category grouping, and warnings
- **Routes**: Full REST API for checklist item management
- **Tests**: 15 unit tests for service layer

## API Endpoints

### Per-Inspection Operations
- `POST /api/site-inspections/:id/checklist-items` - Create item
- `POST /api/site-inspections/:id/checklist-items/bulk` - Bulk create
- `GET /api/site-inspections/:id/checklist-items` - List items (supports `?grouped=true`)
- `GET /api/site-inspections/:id/checklist-summary` - Get summary with stats
- `PUT /api/site-inspections/:id/checklist-items/reorder` - Reorder items

### Item Operations
- `GET /api/checklist-items/:id` - Get item
- `PUT /api/checklist-items/:id` - Update item
- `DELETE /api/checklist-items/:id` - Delete item

## Categories
EXTERIOR, INTERIOR, DECKS, SERVICES, SITE

## Decisions
PASS, FAIL, NA

## Summary Response
```json
{
  "total": 10,
  "passed": 7,
  "failed": 2,
  "na": 1,
  "byCategory": { "EXTERIOR": { "passed": 3, "failed": 1, "na": 0 } },
  "failedItemsWithoutNotes": ["item-uuid-1"],
  "overallResult": "FAIL"
}
```

## Acceptance Criteria
- [x] Create checklist items grouped by category
- [x] Mark items Pass/Fail/N/A
- [x] Add notes per item
- [x] Attach photos to items (photoIds array)
- [x] Calculate overall inspection result
- [x] Warn if Fail items have no notes

Closes #162

Ref: docs/design/004-inspection-checklist-system.md