### PR TITLE
[Alex] feat(api): add BuildingCodeClause entity for NZ Building Code reference

### DIFF
--- a/api/prisma/migrations/20260219030000_add_building_code_clause/migration.sql
+++ b/api/prisma/migrations/20260219030000_add_building_code_clause/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "ClauseCategory" AS ENUM ('B', 'C', 'D', 'E', 'F', 'G', 'H');
+
+-- CreateEnum
+CREATE TYPE "DurabilityPeriod" AS ENUM ('FIFTY_YEARS', 'FIFTEEN_YEARS', 'FIVE_YEARS', 'NA');
+
+-- CreateTable
+CREATE TABLE "BuildingCodeClause" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "category" "ClauseCategory" NOT NULL,
+    "objective" TEXT,
+    "functionalReq" TEXT,
+    "performanceText" TEXT NOT NULL,
+    "durabilityPeriod" "DurabilityPeriod",
+    "typicalEvidence" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "parentId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BuildingCodeClause_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BuildingCodeClause_code_key" ON "BuildingCodeClause"("code");
+
+-- CreateIndex
+CREATE INDEX "BuildingCodeClause_category_idx" ON "BuildingCodeClause"("category");
+
+-- CreateIndex
+CREATE INDEX "BuildingCodeClause_parentId_idx" ON "BuildingCodeClause"("parentId");
+
+-- AddForeignKey
+ALTER TABLE "BuildingCodeClause" ADD CONSTRAINT "BuildingCodeClause_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "BuildingCodeClause"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -280,3 +280,47 @@ enum InspectionOutcome {
   FAIL
   REPEAT_REQUIRED
 }
+
+// ============================================
+// Building Code Reference Data
+// ============================================
+
+model BuildingCodeClause {
+  id                String              @id @default(uuid())
+  code              String              @unique
+  title             String
+  category          ClauseCategory
+  objective         String?
+  functionalReq     String?
+  performanceText   String
+  durabilityPeriod  DurabilityPeriod?
+  typicalEvidence   String[]            @default([])
+  sortOrder         Int                 @default(0)
+  
+  parentId          String?
+  parent            BuildingCodeClause? @relation("ClauseHierarchy", fields: [parentId], references: [id])
+  children          BuildingCodeClause[] @relation("ClauseHierarchy")
+  
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+  
+  @@index([category])
+  @@index([parentId])
+}
+
+enum ClauseCategory {
+  B
+  C
+  D
+  E
+  F
+  G
+  H
+}
+
+enum DurabilityPeriod {
+  FIFTY_YEARS
+  FIFTEEN_YEARS
+  FIVE_YEARS
+  NA
+}

--- a/api/src/__tests__/building-code.test.ts
+++ b/api/src/__tests__/building-code.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  BuildingCodeClauseService,
+  BuildingCodeClauseNotFoundError,
+} from '../services/building-code.js';
+import type { IBuildingCodeClauseRepository } from '../repositories/interfaces/building-code.js';
+import type { BuildingCodeClause } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): IBuildingCodeClauseRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByCode: vi.fn(),
+  findAll: vi.fn(),
+  findByCategory: vi.fn(),
+  findTopLevel: vi.fn(),
+  findChildren: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  bulkCreate: vi.fn(),
+});
+
+const mockClause: BuildingCodeClause = {
+  id: 'clause-1',
+  code: 'B1',
+  title: 'Structure',
+  category: 'B',
+  objective: 'Buildings shall be constructed to withstand loads',
+  functionalReq: null,
+  performanceText: 'Buildings shall withstand combination of loads...',
+  durabilityPeriod: 'FIFTY_YEARS',
+  typicalEvidence: ['PS1', 'PS3'],
+  sortOrder: 0,
+  parentId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('BuildingCodeClauseService', () => {
+  let repository: IBuildingCodeClauseRepository;
+  let service: BuildingCodeClauseService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new BuildingCodeClauseService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a building code clause', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockClause);
+
+      const result = await service.create({
+        code: 'B1',
+        title: 'Structure',
+        category: 'B',
+        performanceText: 'Buildings shall withstand...',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockClause);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return clause by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockClause);
+
+      const result = await service.findById('clause-1');
+      expect(result).toEqual(mockClause);
+    });
+
+    it('should throw BuildingCodeClauseNotFoundError for non-existent clause', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        BuildingCodeClauseNotFoundError
+      );
+    });
+  });
+
+  describe('findByCode', () => {
+    it('should return clause by code', async () => {
+      vi.mocked(repository.findByCode).mockResolvedValue(mockClause);
+
+      const result = await service.findByCode('B1');
+      expect(result).toEqual(mockClause);
+    });
+
+    it('should throw BuildingCodeClauseNotFoundError for non-existent code', async () => {
+      vi.mocked(repository.findByCode).mockResolvedValue(null);
+
+      await expect(service.findByCode('XX')).rejects.toThrow(
+        BuildingCodeClauseNotFoundError
+      );
+    });
+  });
+
+  describe('findByCategory', () => {
+    it('should return all clauses for category', async () => {
+      vi.mocked(repository.findByCategory).mockResolvedValue([mockClause]);
+
+      const result = await service.findByCategory('B');
+      expect(result).toEqual([mockClause]);
+    });
+  });
+
+  describe('findTopLevel', () => {
+    it('should return top-level clauses', async () => {
+      vi.mocked(repository.findTopLevel).mockResolvedValue([mockClause]);
+
+      const result = await service.findTopLevel();
+      expect(result).toEqual([mockClause]);
+    });
+  });
+
+  describe('findChildren', () => {
+    it('should return child clauses', async () => {
+      const childClause = { ...mockClause, id: 'clause-2', code: 'B1.1', parentId: 'clause-1' };
+      vi.mocked(repository.findChildren).mockResolvedValue([childClause]);
+
+      const result = await service.findChildren('clause-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].parentId).toBe('clause-1');
+    });
+  });
+
+  describe('update', () => {
+    it('should update clause', async () => {
+      const updatedClause = { ...mockClause, title: 'Updated Structure' };
+      vi.mocked(repository.findById).mockResolvedValue(mockClause);
+      vi.mocked(repository.update).mockResolvedValue(updatedClause);
+
+      const result = await service.update('clause-1', { title: 'Updated Structure' });
+      expect(result.title).toBe('Updated Structure');
+    });
+
+    it('should throw BuildingCodeClauseNotFoundError for non-existent clause', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { title: 'New Title' })
+      ).rejects.toThrow(BuildingCodeClauseNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing clause', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockClause);
+      vi.mocked(repository.delete).mockResolvedValue();
+
+      await expect(service.delete('clause-1')).resolves.toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith('clause-1');
+    });
+
+    it('should throw BuildingCodeClauseNotFoundError for non-existent clause', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        BuildingCodeClauseNotFoundError
+      );
+    });
+  });
+
+  describe('bulkCreate', () => {
+    it('should create multiple clauses', async () => {
+      const clauses = [mockClause, { ...mockClause, id: 'clause-2', code: 'B2' }];
+      vi.mocked(repository.bulkCreate).mockResolvedValue(clauses);
+
+      const result = await service.bulkCreate([
+        { code: 'B1', title: 'Structure', category: 'B', performanceText: 'Text 1' },
+        { code: 'B2', title: 'Durability', category: 'B', performanceText: 'Text 2' },
+      ]);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('search', () => {
+    it('should search clauses by keyword', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([mockClause]);
+
+      await service.search('structure');
+      expect(repository.findAll).toHaveBeenCalledWith({ keyword: 'structure' });
+    });
+  });
+
+  describe('getHierarchy', () => {
+    it('should return clauses grouped by category', async () => {
+      const clauseE = { ...mockClause, id: 'clause-e', code: 'E1', category: 'E' as const };
+      vi.mocked(repository.findTopLevel).mockResolvedValue([mockClause, clauseE]);
+
+      const hierarchy = await service.getHierarchy();
+
+      expect(hierarchy['B']).toHaveLength(1);
+      expect(hierarchy['E']).toHaveLength(1);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -14,6 +14,7 @@ import { propertiesRouter } from './routes/properties.js';
 import { clientsRouter } from './routes/clients.js';
 import { siteInspectionsRouter } from './routes/site-inspections.js';
 import { checklistItemsRouter } from './routes/checklist-items.js';
+import { buildingCodeRouter } from './routes/building-code.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -66,6 +67,7 @@ app.use('/api/properties', authMiddleware, propertiesRouter);
 app.use('/api/clients', authMiddleware, clientsRouter);
 app.use('/api', authMiddleware, siteInspectionsRouter);
 app.use('/api', authMiddleware, checklistItemsRouter);
+app.use('/api/building-code', authMiddleware, buildingCodeRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/building-code.ts
+++ b/api/src/repositories/interfaces/building-code.ts
@@ -1,0 +1,46 @@
+import type { BuildingCodeClause, ClauseCategory, DurabilityPeriod } from '@prisma/client';
+
+export interface CreateBuildingCodeClauseInput {
+  code: string;
+  title: string;
+  category: ClauseCategory;
+  objective?: string;
+  functionalReq?: string;
+  performanceText: string;
+  durabilityPeriod?: DurabilityPeriod;
+  typicalEvidence?: string[];
+  sortOrder?: number;
+  parentId?: string;
+}
+
+export interface UpdateBuildingCodeClauseInput {
+  code?: string;
+  title?: string;
+  category?: ClauseCategory;
+  objective?: string;
+  functionalReq?: string;
+  performanceText?: string;
+  durabilityPeriod?: DurabilityPeriod;
+  typicalEvidence?: string[];
+  sortOrder?: number;
+  parentId?: string;
+}
+
+export interface BuildingCodeClauseSearchParams {
+  category?: ClauseCategory;
+  keyword?: string;
+  parentId?: string | null;
+}
+
+export interface IBuildingCodeClauseRepository {
+  create(input: CreateBuildingCodeClauseInput): Promise<BuildingCodeClause>;
+  findById(id: string): Promise<BuildingCodeClause | null>;
+  findByCode(code: string): Promise<BuildingCodeClause | null>;
+  findAll(params?: BuildingCodeClauseSearchParams): Promise<BuildingCodeClause[]>;
+  findByCategory(category: ClauseCategory): Promise<BuildingCodeClause[]>;
+  findTopLevel(): Promise<BuildingCodeClause[]>;
+  findChildren(parentId: string): Promise<BuildingCodeClause[]>;
+  update(id: string, input: UpdateBuildingCodeClauseInput): Promise<BuildingCodeClause>;
+  delete(id: string): Promise<void>;
+  bulkCreate(clauses: CreateBuildingCodeClauseInput[]): Promise<BuildingCodeClause[]>;
+}

--- a/api/src/repositories/prisma/building-code.ts
+++ b/api/src/repositories/prisma/building-code.ts
@@ -1,0 +1,122 @@
+import { PrismaClient, type BuildingCodeClause, type ClauseCategory } from '@prisma/client';
+import type {
+  IBuildingCodeClauseRepository,
+  CreateBuildingCodeClauseInput,
+  UpdateBuildingCodeClauseInput,
+  BuildingCodeClauseSearchParams,
+} from '../interfaces/building-code.js';
+
+export class PrismaBuildingCodeClauseRepository implements IBuildingCodeClauseRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateBuildingCodeClauseInput): Promise<BuildingCodeClause> {
+    return this.prisma.buildingCodeClause.create({
+      data: input,
+      include: {
+        parent: true,
+        children: true,
+      },
+    });
+  }
+
+  async findById(id: string): Promise<BuildingCodeClause | null> {
+    return this.prisma.buildingCodeClause.findUnique({
+      where: { id },
+      include: {
+        parent: true,
+        children: {
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+  }
+
+  async findByCode(code: string): Promise<BuildingCodeClause | null> {
+    return this.prisma.buildingCodeClause.findUnique({
+      where: { code },
+      include: {
+        parent: true,
+        children: {
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+  }
+
+  async findAll(params?: BuildingCodeClauseSearchParams): Promise<BuildingCodeClause[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.category) {
+      where.category = params.category;
+    }
+    if (params?.parentId !== undefined) {
+      where.parentId = params.parentId;
+    }
+    if (params?.keyword) {
+      where.OR = [
+        { code: { contains: params.keyword, mode: 'insensitive' } },
+        { title: { contains: params.keyword, mode: 'insensitive' } },
+        { performanceText: { contains: params.keyword, mode: 'insensitive' } },
+      ];
+    }
+
+    return this.prisma.buildingCodeClause.findMany({
+      where,
+      include: {
+        parent: true,
+        children: {
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+      orderBy: [
+        { category: 'asc' },
+        { sortOrder: 'asc' },
+      ],
+    });
+  }
+
+  async findByCategory(category: ClauseCategory): Promise<BuildingCodeClause[]> {
+    return this.findAll({ category });
+  }
+
+  async findTopLevel(): Promise<BuildingCodeClause[]> {
+    return this.findAll({ parentId: null });
+  }
+
+  async findChildren(parentId: string): Promise<BuildingCodeClause[]> {
+    return this.findAll({ parentId });
+  }
+
+  async update(id: string, input: UpdateBuildingCodeClauseInput): Promise<BuildingCodeClause> {
+    return this.prisma.buildingCodeClause.update({
+      where: { id },
+      data: input,
+      include: {
+        parent: true,
+        children: {
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.buildingCodeClause.delete({
+      where: { id },
+    });
+  }
+
+  async bulkCreate(clauses: CreateBuildingCodeClauseInput[]): Promise<BuildingCodeClause[]> {
+    return this.prisma.$transaction(
+      clauses.map((clause) =>
+        this.prisma.buildingCodeClause.create({
+          data: clause,
+          include: {
+            parent: true,
+            children: true,
+          },
+        })
+      )
+    );
+  }
+}

--- a/api/src/routes/building-code.ts
+++ b/api/src/routes/building-code.ts
@@ -1,0 +1,193 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaBuildingCodeClauseRepository } from '../repositories/prisma/building-code.js';
+import { BuildingCodeClauseService, BuildingCodeClauseNotFoundError } from '../services/building-code.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaBuildingCodeClauseRepository(prisma);
+const service = new BuildingCodeClauseService(repository);
+
+export const buildingCodeRouter = Router();
+
+// Enums
+const clauseCategories = ['B', 'C', 'D', 'E', 'F', 'G', 'H'] as const;
+const durabilityPeriods = ['FIFTY_YEARS', 'FIFTEEN_YEARS', 'FIVE_YEARS', 'NA'] as const;
+
+// Validation schemas
+const CreateClauseSchema = z.object({
+  code: z.string().min(1, 'Code is required'),
+  title: z.string().min(1, 'Title is required'),
+  category: z.enum(clauseCategories),
+  objective: z.string().optional(),
+  functionalReq: z.string().optional(),
+  performanceText: z.string().min(1, 'Performance text is required'),
+  durabilityPeriod: z.enum(durabilityPeriods).optional(),
+  typicalEvidence: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().optional(),
+});
+
+const UpdateClauseSchema = z.object({
+  code: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  category: z.enum(clauseCategories).optional(),
+  objective: z.string().optional(),
+  functionalReq: z.string().optional(),
+  performanceText: z.string().min(1).optional(),
+  durabilityPeriod: z.enum(durabilityPeriods).optional(),
+  typicalEvidence: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().nullable().optional(),
+});
+
+// GET /api/building-code/clauses - List all clauses with filters
+buildingCodeRouter.get('/clauses', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { category, keyword, parentId, topLevel } = req.query;
+
+    if (topLevel === 'true') {
+      const clauses = await service.findTopLevel();
+      res.json(clauses);
+      return;
+    }
+
+    const clauses = await service.findAll({
+      category: category as typeof clauseCategories[number] | undefined,
+      keyword: keyword as string | undefined,
+      parentId: parentId === 'null' ? null : parentId as string | undefined,
+    });
+    res.json(clauses);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/building-code/clauses/hierarchy - Get clauses grouped by category
+buildingCodeRouter.get('/clauses/hierarchy', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const hierarchy = await service.getHierarchy();
+    res.json(hierarchy);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/building-code/clauses/:code - Get clause by code
+buildingCodeRouter.get('/clauses/:code', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const code = req.params.code as string;
+    
+    // Check if it's a UUID (id) or a code
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(code);
+    
+    let clause;
+    if (isUuid) {
+      clause = await service.findById(code);
+    } else {
+      clause = await service.findByCode(code);
+    }
+    
+    res.json(clause);
+  } catch (error) {
+    if (error instanceof BuildingCodeClauseNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// GET /api/building-code/clauses/:id/children - Get children of a clause
+buildingCodeRouter.get('/clauses/:id/children', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const children = await service.findChildren(id);
+    res.json(children);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/building-code/clauses - Create clause (admin)
+buildingCodeRouter.post('/clauses', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = CreateClauseSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const clause = await service.create(parsed.data);
+    res.status(201).json(clause);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/building-code/clauses/bulk - Bulk create (admin/seed)
+buildingCodeRouter.post('/clauses/bulk', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const clauses = z.array(CreateClauseSchema).safeParse(req.body);
+
+    if (!clauses.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: clauses.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const created = await service.bulkCreate(clauses.data);
+    res.status(201).json(created);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PUT /api/building-code/clauses/:id - Update clause (admin)
+buildingCodeRouter.put('/clauses/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const parsed = UpdateClauseSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const clause = await service.update(id, {
+      ...parsed.data,
+      parentId: parsed.data.parentId === null ? undefined : parsed.data.parentId,
+    });
+    res.json(clause);
+  } catch (error) {
+    if (error instanceof BuildingCodeClauseNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+
+// DELETE /api/building-code/clauses/:id - Delete clause (admin)
+buildingCodeRouter.delete('/clauses/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    await service.delete(id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof BuildingCodeClauseNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -9,3 +9,4 @@ export * from './properties.js';
 export * from './clients.js';
 export * from './site-inspections.js';
 export * from './checklist-items.js';
+export * from './building-code.js';

--- a/api/src/services/building-code.ts
+++ b/api/src/services/building-code.ts
@@ -1,0 +1,86 @@
+import type { BuildingCodeClause, ClauseCategory } from '@prisma/client';
+import type {
+  IBuildingCodeClauseRepository,
+  CreateBuildingCodeClauseInput,
+  UpdateBuildingCodeClauseInput,
+  BuildingCodeClauseSearchParams,
+} from '../repositories/interfaces/building-code.js';
+
+export class BuildingCodeClauseNotFoundError extends Error {
+  constructor(idOrCode: string) {
+    super(`Building code clause not found: ${idOrCode}`);
+    this.name = 'BuildingCodeClauseNotFoundError';
+  }
+}
+
+export class BuildingCodeClauseService {
+  constructor(private repository: IBuildingCodeClauseRepository) {}
+
+  async create(input: CreateBuildingCodeClauseInput): Promise<BuildingCodeClause> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: BuildingCodeClauseSearchParams): Promise<BuildingCodeClause[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<BuildingCodeClause> {
+    const clause = await this.repository.findById(id);
+    if (!clause) {
+      throw new BuildingCodeClauseNotFoundError(id);
+    }
+    return clause;
+  }
+
+  async findByCode(code: string): Promise<BuildingCodeClause> {
+    const clause = await this.repository.findByCode(code);
+    if (!clause) {
+      throw new BuildingCodeClauseNotFoundError(code);
+    }
+    return clause;
+  }
+
+  async findByCategory(category: ClauseCategory): Promise<BuildingCodeClause[]> {
+    return this.repository.findByCategory(category);
+  }
+
+  async findTopLevel(): Promise<BuildingCodeClause[]> {
+    return this.repository.findTopLevel();
+  }
+
+  async findChildren(parentId: string): Promise<BuildingCodeClause[]> {
+    return this.repository.findChildren(parentId);
+  }
+
+  async update(id: string, input: UpdateBuildingCodeClauseInput): Promise<BuildingCodeClause> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+
+  async bulkCreate(clauses: CreateBuildingCodeClauseInput[]): Promise<BuildingCodeClause[]> {
+    return this.repository.bulkCreate(clauses);
+  }
+
+  async search(keyword: string): Promise<BuildingCodeClause[]> {
+    return this.repository.findAll({ keyword });
+  }
+
+  async getHierarchy(): Promise<Record<ClauseCategory, BuildingCodeClause[]>> {
+    const clauses = await this.findTopLevel();
+    const grouped: Record<string, BuildingCodeClause[]> = {};
+    
+    for (const clause of clauses) {
+      if (!grouped[clause.category]) {
+        grouped[clause.category] = [];
+      }
+      grouped[clause.category].push(clause);
+    }
+    
+    return grouped as Record<ClauseCategory, BuildingCodeClause[]>;
+  }
+}


### PR DESCRIPTION
## Summary
Implements BuildingCodeClause entity for NZ Building Code reference data. This is foundational data for COA/CCC reports and clause reviews.

## Changes
- **Prisma Schema**: Added BuildingCodeClause model with ClauseCategory and DurabilityPeriod enums
- **Repository Layer**: Interface + Prisma implementation with hierarchy support
- **Service Layer**: Business logic with search, hierarchy grouping
- **Routes**: Full REST API for clause management
- **Tests**: 15 unit tests for service layer

## API Endpoints

### Read Operations
- `GET /api/building-code/clauses` - List all (filters: category, keyword, parentId, topLevel)
- `GET /api/building-code/clauses/hierarchy` - Grouped by category
- `GET /api/building-code/clauses/:code` - Get by code or UUID
- `GET /api/building-code/clauses/:id/children` - Get child clauses

### Admin/Seed Operations
- `POST /api/building-code/clauses` - Create clause
- `POST /api/building-code/clauses/bulk` - Bulk create (for seeding)
- `PUT /api/building-code/clauses/:id` - Update clause
- `DELETE /api/building-code/clauses/:id` - Delete clause

## Clause Categories
- B: Stability
- C: Fire
- D: Access
- E: Moisture
- F: Safety
- G: Services
- H: Energy

## Durability Periods
- FIFTY_YEARS (structure, cladding)
- FIFTEEN_YEARS (linings, services)
- FIVE_YEARS (seals, minor elements)
- NA

## Features
- Hierarchical clauses (B1 → B1.1 → B1.1.1)
- Typical evidence tracking per clause
- Performance text for reports
- Category-based filtering
- Keyword search

## Acceptance Criteria
- [x] Store all Building Code clauses
- [x] Support clause hierarchy
- [x] Filter by category
- [x] Search by keyword

Closes #169

Ref: docs/design/005-building-code-reference.md