### PR TITLE
[Alex] feat(api): add ClauseReview entity for Clause Review mode (COA/CCC)

### DIFF
--- a/api/prisma/migrations/20260219040000_add_clause_review/migration.sql
+++ b/api/prisma/migrations/20260219040000_add_clause_review/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "Applicability" AS ENUM ('APPLICABLE', 'NA');
+
+-- CreateTable
+CREATE TABLE "ClauseReview" (
+    "id" TEXT NOT NULL,
+    "inspectionId" TEXT NOT NULL,
+    "clauseId" TEXT NOT NULL,
+    "applicability" "Applicability" NOT NULL,
+    "naReason" TEXT,
+    "observations" TEXT,
+    "photoIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "docIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "docsRequired" TEXT,
+    "remedialWorks" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ClauseReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ClauseReview_inspectionId_idx" ON "ClauseReview"("inspectionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClauseReview_inspectionId_clauseId_key" ON "ClauseReview"("inspectionId", "clauseId");
+
+-- AddForeignKey
+ALTER TABLE "ClauseReview" ADD CONSTRAINT "ClauseReview_inspectionId_fkey" FOREIGN KEY ("inspectionId") REFERENCES "SiteInspection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClauseReview" ADD CONSTRAINT "ClauseReview_clauseId_fkey" FOREIGN KEY ("clauseId") REFERENCES "BuildingCodeClause"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -205,6 +205,7 @@ model SiteInspection {
   
   // Relations
   checklistItems    ChecklistItem[]
+  clauseReviews     ClauseReview[]
   
   @@index([projectId])
   @@index([status])
@@ -301,6 +302,8 @@ model BuildingCodeClause {
   parent            BuildingCodeClause? @relation("ClauseHierarchy", fields: [parentId], references: [id])
   children          BuildingCodeClause[] @relation("ClauseHierarchy")
   
+  clauseReviews     ClauseReview[]
+  
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt
   
@@ -322,5 +325,40 @@ enum DurabilityPeriod {
   FIFTY_YEARS
   FIFTEEN_YEARS
   FIVE_YEARS
+  NA
+}
+
+// ============================================
+// Clause Review (for COA/CCC inspections)
+// ============================================
+
+model ClauseReview {
+  id              String              @id @default(uuid())
+  inspectionId    String
+  inspection      SiteInspection      @relation(fields: [inspectionId], references: [id], onDelete: Cascade)
+  
+  clauseId        String
+  clause          BuildingCodeClause  @relation(fields: [clauseId], references: [id])
+  
+  applicability   Applicability
+  naReason        String?
+  observations    String?
+  
+  photoIds        String[]            @default([])
+  docIds          String[]            @default([])
+  
+  docsRequired    String?
+  remedialWorks   String?
+  
+  sortOrder       Int                 @default(0)
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+  
+  @@unique([inspectionId, clauseId])
+  @@index([inspectionId])
+}
+
+enum Applicability {
+  APPLICABLE
   NA
 }

--- a/api/src/__tests__/clause-review.test.ts
+++ b/api/src/__tests__/clause-review.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ClauseReviewService,
+  ClauseReviewNotFoundError,
+} from '../services/clause-review.js';
+import type { IClauseReviewRepository, ClauseReviewWithClause } from '../repositories/interfaces/clause-review.js';
+
+// Mock repository
+const createMockRepository = (): IClauseReviewRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByInspectionId: vi.fn(),
+  findByInspectionAndClause: vi.fn(),
+  findAll: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  bulkCreate: vi.fn(),
+  initializeForInspection: vi.fn(),
+});
+
+const mockClauseReview: ClauseReviewWithClause = {
+  id: 'review-1',
+  inspectionId: 'insp-1',
+  clauseId: 'clause-1',
+  applicability: 'APPLICABLE',
+  naReason: null,
+  observations: 'Foundations look good',
+  photoIds: ['photo-1'],
+  docIds: [],
+  docsRequired: null,
+  remedialWorks: null,
+  sortOrder: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  clause: {
+    id: 'clause-1',
+    code: 'B1',
+    title: 'Structure',
+    category: 'B',
+    performanceText: 'Buildings shall withstand loads...',
+    durabilityPeriod: 'FIFTY_YEARS',
+    typicalEvidence: ['PS1', 'PS3'],
+  },
+};
+
+describe('ClauseReviewService', () => {
+  let repository: IClauseReviewRepository;
+  let service: ClauseReviewService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new ClauseReviewService(repository);
+  });
+
+  describe('create', () => {
+    it('should create a clause review', async () => {
+      vi.mocked(repository.create).mockResolvedValue(mockClauseReview);
+
+      const result = await service.create({
+        inspectionId: 'insp-1',
+        clauseId: 'clause-1',
+        applicability: 'APPLICABLE',
+      });
+
+      expect(repository.create).toHaveBeenCalled();
+      expect(result).toEqual(mockClauseReview);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return review by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockClauseReview);
+
+      const result = await service.findById('review-1');
+      expect(result).toEqual(mockClauseReview);
+    });
+
+    it('should throw ClauseReviewNotFoundError for non-existent review', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        ClauseReviewNotFoundError
+      );
+    });
+  });
+
+  describe('findByInspectionId', () => {
+    it('should return all reviews for inspection', async () => {
+      vi.mocked(repository.findByInspectionId).mockResolvedValue([mockClauseReview]);
+
+      const result = await service.findByInspectionId('insp-1');
+      expect(result).toEqual([mockClauseReview]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update clause review', async () => {
+      const updatedReview = { ...mockClauseReview, observations: 'Updated observations' };
+      vi.mocked(repository.findById).mockResolvedValue(mockClauseReview);
+      vi.mocked(repository.update).mockResolvedValue(updatedReview);
+
+      const result = await service.update('review-1', { observations: 'Updated observations' });
+      expect(result.observations).toBe('Updated observations');
+    });
+
+    it('should throw ClauseReviewNotFoundError for non-existent review', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { observations: 'Test' })
+      ).rejects.toThrow(ClauseReviewNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing review', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockClauseReview);
+      vi.mocked(repository.delete).mockResolvedValue();
+
+      await expect(service.delete('review-1')).resolves.toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith('review-1');
+    });
+
+    it('should throw ClauseReviewNotFoundError for non-existent review', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        ClauseReviewNotFoundError
+      );
+    });
+  });
+
+  describe('markAsNA', () => {
+    it('should mark review as N/A with reason', async () => {
+      const naReview = { ...mockClauseReview, applicability: 'NA' as const, naReason: 'Not in scope' };
+      vi.mocked(repository.findById).mockResolvedValue(mockClauseReview);
+      vi.mocked(repository.update).mockResolvedValue(naReview);
+
+      const result = await service.markAsNA('review-1', 'Not in scope');
+      expect(result.applicability).toBe('NA');
+      expect(result.naReason).toBe('Not in scope');
+    });
+  });
+
+  describe('markAsApplicable', () => {
+    it('should mark review as applicable', async () => {
+      const naReview = { ...mockClauseReview, applicability: 'NA' as const, naReason: 'Some reason' };
+      const applicableReview = { ...mockClauseReview, applicability: 'APPLICABLE' as const, naReason: null };
+      vi.mocked(repository.findById).mockResolvedValue(naReview);
+      vi.mocked(repository.update).mockResolvedValue(applicableReview);
+
+      const result = await service.markAsApplicable('review-1');
+      expect(result.applicability).toBe('APPLICABLE');
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should calculate summary correctly', async () => {
+      const reviews: ClauseReviewWithClause[] = [
+        { ...mockClauseReview, id: 'r1', applicability: 'APPLICABLE', observations: 'Obs', naReason: null, photoIds: [], remedialWorks: null },
+        { ...mockClauseReview, id: 'r2', applicability: 'APPLICABLE', observations: null, naReason: null, photoIds: [], remedialWorks: null },
+        { ...mockClauseReview, id: 'r3', applicability: 'NA', naReason: 'Not in scope', observations: null, photoIds: [], remedialWorks: null },
+        { ...mockClauseReview, id: 'r4', applicability: 'APPLICABLE', observations: 'Done', photoIds: ['p1'], remedialWorks: 'Fix needed', naReason: null },
+      ];
+      vi.mocked(repository.findByInspectionId).mockResolvedValue(reviews);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.total).toBe(4);
+      expect(summary.applicable).toBe(3);
+      expect(summary.na).toBe(1);
+      expect(summary.withObservations).toBe(2);
+      expect(summary.withPhotos).toBe(1);
+      expect(summary.needingRemedialWorks).toBe(1);
+    });
+
+    it('should group by category', async () => {
+      const reviewB = { ...mockClauseReview, id: 'r1', clause: { ...mockClauseReview.clause, category: 'B' } };
+      const reviewE = { ...mockClauseReview, id: 'r2', applicability: 'NA' as const, clause: { ...mockClauseReview.clause, category: 'E' } };
+      vi.mocked(repository.findByInspectionId).mockResolvedValue([reviewB, reviewE]);
+
+      const summary = await service.getSummary('insp-1');
+
+      expect(summary.byCategory['B']).toEqual({ applicable: 1, na: 0 });
+      expect(summary.byCategory['E']).toEqual({ applicable: 0, na: 1 });
+    });
+  });
+
+  describe('getGroupedByCategory', () => {
+    it('should group reviews by clause category', async () => {
+      const reviewB = { ...mockClauseReview, id: 'r1', clause: { ...mockClauseReview.clause, category: 'B' } };
+      const reviewE = { ...mockClauseReview, id: 'r2', clause: { ...mockClauseReview.clause, category: 'E' } };
+      vi.mocked(repository.findByInspectionId).mockResolvedValue([reviewB, reviewE]);
+
+      const grouped = await service.getGroupedByCategory('insp-1');
+
+      expect(grouped['B']).toHaveLength(1);
+      expect(grouped['E']).toHaveLength(1);
+    });
+  });
+
+  describe('initializeForInspection', () => {
+    it('should initialize clause reviews for inspection', async () => {
+      vi.mocked(repository.initializeForInspection).mockResolvedValue([mockClauseReview]);
+
+      const result = await service.initializeForInspection('insp-1', ['clause-1']);
+      expect(repository.initializeForInspection).toHaveBeenCalledWith('insp-1', ['clause-1']);
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -15,6 +15,7 @@ import { clientsRouter } from './routes/clients.js';
 import { siteInspectionsRouter } from './routes/site-inspections.js';
 import { checklistItemsRouter } from './routes/checklist-items.js';
 import { buildingCodeRouter } from './routes/building-code.js';
+import { clauseReviewsRouter } from './routes/clause-reviews.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -68,6 +69,7 @@ app.use('/api/clients', authMiddleware, clientsRouter);
 app.use('/api', authMiddleware, siteInspectionsRouter);
 app.use('/api', authMiddleware, checklistItemsRouter);
 app.use('/api/building-code', authMiddleware, buildingCodeRouter);
+app.use('/api', authMiddleware, clauseReviewsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/clause-review.ts
+++ b/api/src/repositories/interfaces/clause-review.ts
@@ -1,0 +1,54 @@
+import type { ClauseReview, Applicability } from '@prisma/client';
+
+export interface CreateClauseReviewInput {
+  inspectionId: string;
+  clauseId: string;
+  applicability: Applicability;
+  naReason?: string;
+  observations?: string;
+  photoIds?: string[];
+  docIds?: string[];
+  docsRequired?: string;
+  remedialWorks?: string;
+  sortOrder?: number;
+}
+
+export interface UpdateClauseReviewInput {
+  applicability?: Applicability;
+  naReason?: string;
+  observations?: string;
+  photoIds?: string[];
+  docIds?: string[];
+  docsRequired?: string;
+  remedialWorks?: string;
+  sortOrder?: number;
+}
+
+export interface ClauseReviewSearchParams {
+  inspectionId?: string;
+  applicability?: Applicability;
+}
+
+export interface ClauseReviewWithClause extends ClauseReview {
+  clause: {
+    id: string;
+    code: string;
+    title: string;
+    category: string;
+    performanceText: string;
+    durabilityPeriod: string | null;
+    typicalEvidence: string[];
+  };
+}
+
+export interface IClauseReviewRepository {
+  create(input: CreateClauseReviewInput): Promise<ClauseReviewWithClause>;
+  findById(id: string): Promise<ClauseReviewWithClause | null>;
+  findByInspectionId(inspectionId: string): Promise<ClauseReviewWithClause[]>;
+  findByInspectionAndClause(inspectionId: string, clauseId: string): Promise<ClauseReviewWithClause | null>;
+  findAll(params?: ClauseReviewSearchParams): Promise<ClauseReviewWithClause[]>;
+  update(id: string, input: UpdateClauseReviewInput): Promise<ClauseReviewWithClause>;
+  delete(id: string): Promise<void>;
+  bulkCreate(reviews: CreateClauseReviewInput[]): Promise<ClauseReviewWithClause[]>;
+  initializeForInspection(inspectionId: string, clauseIds: string[]): Promise<ClauseReviewWithClause[]>;
+}

--- a/api/src/repositories/prisma/clause-review.ts
+++ b/api/src/repositories/prisma/clause-review.ts
@@ -1,0 +1,117 @@
+import { PrismaClient } from '@prisma/client';
+import type {
+  IClauseReviewRepository,
+  CreateClauseReviewInput,
+  UpdateClauseReviewInput,
+  ClauseReviewSearchParams,
+  ClauseReviewWithClause,
+} from '../interfaces/clause-review.js';
+
+const clauseInclude = {
+  clause: {
+    select: {
+      id: true,
+      code: true,
+      title: true,
+      category: true,
+      performanceText: true,
+      durabilityPeriod: true,
+      typicalEvidence: true,
+    },
+  },
+};
+
+export class PrismaClauseReviewRepository implements IClauseReviewRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateClauseReviewInput): Promise<ClauseReviewWithClause> {
+    return this.prisma.clauseReview.create({
+      data: input,
+      include: clauseInclude,
+    }) as Promise<ClauseReviewWithClause>;
+  }
+
+  async findById(id: string): Promise<ClauseReviewWithClause | null> {
+    return this.prisma.clauseReview.findUnique({
+      where: { id },
+      include: clauseInclude,
+    }) as Promise<ClauseReviewWithClause | null>;
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<ClauseReviewWithClause[]> {
+    return this.prisma.clauseReview.findMany({
+      where: { inspectionId },
+      include: clauseInclude,
+      orderBy: [
+        { clause: { category: 'asc' } },
+        { sortOrder: 'asc' },
+      ],
+    }) as Promise<ClauseReviewWithClause[]>;
+  }
+
+  async findByInspectionAndClause(inspectionId: string, clauseId: string): Promise<ClauseReviewWithClause | null> {
+    return this.prisma.clauseReview.findUnique({
+      where: {
+        inspectionId_clauseId: { inspectionId, clauseId },
+      },
+      include: clauseInclude,
+    }) as Promise<ClauseReviewWithClause | null>;
+  }
+
+  async findAll(params?: ClauseReviewSearchParams): Promise<ClauseReviewWithClause[]> {
+    const where: Record<string, unknown> = {};
+
+    if (params?.inspectionId) {
+      where.inspectionId = params.inspectionId;
+    }
+    if (params?.applicability) {
+      where.applicability = params.applicability;
+    }
+
+    return this.prisma.clauseReview.findMany({
+      where,
+      include: clauseInclude,
+      orderBy: [
+        { clause: { category: 'asc' } },
+        { sortOrder: 'asc' },
+      ],
+    }) as Promise<ClauseReviewWithClause[]>;
+  }
+
+  async update(id: string, input: UpdateClauseReviewInput): Promise<ClauseReviewWithClause> {
+    return this.prisma.clauseReview.update({
+      where: { id },
+      data: input,
+      include: clauseInclude,
+    }) as Promise<ClauseReviewWithClause>;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.clauseReview.delete({
+      where: { id },
+    });
+  }
+
+  async bulkCreate(reviews: CreateClauseReviewInput[]): Promise<ClauseReviewWithClause[]> {
+    return this.prisma.$transaction(
+      reviews.map((review) =>
+        this.prisma.clauseReview.create({
+          data: review,
+          include: clauseInclude,
+        })
+      )
+    ) as Promise<ClauseReviewWithClause[]>;
+  }
+
+  async initializeForInspection(inspectionId: string, clauseIds: string[]): Promise<ClauseReviewWithClause[]> {
+    // Create clause reviews for all provided clauses with default applicability
+    const reviews = clauseIds.map((clauseId, index) => ({
+      inspectionId,
+      clauseId,
+      applicability: 'APPLICABLE' as const,
+      sortOrder: index,
+    }));
+
+    return this.bulkCreate(reviews);
+  }
+}

--- a/api/src/routes/clause-reviews.ts
+++ b/api/src/routes/clause-reviews.ts
@@ -1,0 +1,272 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaClauseReviewRepository } from '../repositories/prisma/clause-review.js';
+import { ClauseReviewService, ClauseReviewNotFoundError } from '../services/clause-review.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaClauseReviewRepository(prisma);
+const service = new ClauseReviewService(repository);
+
+export const clauseReviewsRouter = Router();
+
+// Enums
+const applicabilityValues = ['APPLICABLE', 'NA'] as const;
+
+// Validation schemas
+const CreateClauseReviewSchema = z.object({
+  clauseId: z.string().uuid('Invalid clause ID'),
+  applicability: z.enum(applicabilityValues),
+  naReason: z.string().optional(),
+  observations: z.string().optional(),
+  photoIds: z.array(z.string()).optional(),
+  docIds: z.array(z.string()).optional(),
+  docsRequired: z.string().optional(),
+  remedialWorks: z.string().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+const UpdateClauseReviewSchema = z.object({
+  applicability: z.enum(applicabilityValues).optional(),
+  naReason: z.string().optional(),
+  observations: z.string().optional(),
+  photoIds: z.array(z.string()).optional(),
+  docIds: z.array(z.string()).optional(),
+  docsRequired: z.string().optional(),
+  remedialWorks: z.string().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+const BulkCreateSchema = z.object({
+  reviews: z.array(CreateClauseReviewSchema),
+});
+
+const InitializeSchema = z.object({
+  clauseIds: z.array(z.string().uuid()),
+});
+
+// POST /api/site-inspections/:inspectionId/clause-reviews - Create review
+clauseReviewsRouter.post(
+  '/site-inspections/:inspectionId/clause-reviews',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = CreateClauseReviewSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const review = await service.create({
+        ...parsed.data,
+        inspectionId,
+      });
+      res.status(201).json(review);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/site-inspections/:inspectionId/clause-reviews/bulk - Bulk create
+clauseReviewsRouter.post(
+  '/site-inspections/:inspectionId/clause-reviews/bulk',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = BulkCreateSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const reviews = await service.bulkCreate(
+        parsed.data.reviews.map((review) => ({
+          ...review,
+          inspectionId,
+        }))
+      );
+      res.status(201).json(reviews);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/site-inspections/:inspectionId/clause-reviews/init - Initialize with all clauses
+clauseReviewsRouter.post(
+  '/site-inspections/:inspectionId/clause-reviews/init',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = InitializeSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const reviews = await service.initializeForInspection(inspectionId, parsed.data.clauseIds);
+      res.status(201).json(reviews);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/site-inspections/:inspectionId/clause-reviews - List reviews
+clauseReviewsRouter.get(
+  '/site-inspections/:inspectionId/clause-reviews',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const { applicability, grouped } = req.query;
+
+      if (grouped === 'true') {
+        const groupedReviews = await service.getGroupedByCategory(inspectionId);
+        res.json(groupedReviews);
+        return;
+      }
+
+      const reviews = await service.findAll({
+        inspectionId,
+        applicability: applicability as typeof applicabilityValues[number] | undefined,
+      });
+      res.json(reviews);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/site-inspections/:inspectionId/clause-review-summary - Get summary
+clauseReviewsRouter.get(
+  '/site-inspections/:inspectionId/clause-review-summary',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const summary = await service.getSummary(inspectionId);
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/clause-reviews/:id - Get review by ID
+clauseReviewsRouter.get(
+  '/clause-reviews/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const review = await service.findById(id);
+      res.json(review);
+    } catch (error) {
+      if (error instanceof ClauseReviewNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// PUT /api/clause-reviews/:id - Update review
+clauseReviewsRouter.put(
+  '/clause-reviews/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const parsed = UpdateClauseReviewSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const review = await service.update(id, parsed.data);
+      res.json(review);
+    } catch (error) {
+      if (error instanceof ClauseReviewNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// POST /api/clause-reviews/:id/mark-na - Mark as N/A with reason
+clauseReviewsRouter.post(
+  '/clause-reviews/:id/mark-na',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const { naReason } = req.body;
+
+      if (!naReason || typeof naReason !== 'string') {
+        res.status(400).json({ error: 'naReason is required' });
+        return;
+      }
+
+      const review = await service.markAsNA(id, naReason);
+      res.json(review);
+    } catch (error) {
+      if (error instanceof ClauseReviewNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// POST /api/clause-reviews/:id/mark-applicable - Mark as applicable
+clauseReviewsRouter.post(
+  '/clause-reviews/:id/mark-applicable',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const review = await service.markAsApplicable(id);
+      res.json(review);
+    } catch (error) {
+      if (error instanceof ClauseReviewNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/clause-reviews/:id - Delete review
+clauseReviewsRouter.delete(
+  '/clause-reviews/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      await service.delete(id);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof ClauseReviewNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -10,3 +10,4 @@ export * from './clients.js';
 export * from './site-inspections.js';
 export * from './checklist-items.js';
 export * from './building-code.js';
+export * from './clause-reviews.js';

--- a/api/src/services/clause-review.ts
+++ b/api/src/services/clause-review.ts
@@ -1,0 +1,176 @@
+// Applicability type is used implicitly via repository interface
+import type {
+  IClauseReviewRepository,
+  CreateClauseReviewInput,
+  UpdateClauseReviewInput,
+  ClauseReviewSearchParams,
+  ClauseReviewWithClause,
+} from '../repositories/interfaces/clause-review.js';
+
+export class ClauseReviewNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Clause review not found: ${id}`);
+    this.name = 'ClauseReviewNotFoundError';
+  }
+}
+
+export interface ClauseReviewSummary {
+  total: number;
+  applicable: number;
+  na: number;
+  withObservations: number;
+  withPhotos: number;
+  withDocs: number;
+  needingRemedialWorks: number;
+  byCategory: Record<string, { applicable: number; na: number }>;
+  completionPercentage: number;
+}
+
+export class ClauseReviewService {
+  constructor(private repository: IClauseReviewRepository) {}
+
+  async create(input: CreateClauseReviewInput): Promise<ClauseReviewWithClause> {
+    return this.repository.create(input);
+  }
+
+  async findAll(params?: ClauseReviewSearchParams): Promise<ClauseReviewWithClause[]> {
+    return this.repository.findAll(params);
+  }
+
+  async findById(id: string): Promise<ClauseReviewWithClause> {
+    const review = await this.repository.findById(id);
+    if (!review) {
+      throw new ClauseReviewNotFoundError(id);
+    }
+    return review;
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<ClauseReviewWithClause[]> {
+    return this.repository.findByInspectionId(inspectionId);
+  }
+
+  async findByInspectionAndClause(inspectionId: string, clauseId: string): Promise<ClauseReviewWithClause | null> {
+    return this.repository.findByInspectionAndClause(inspectionId, clauseId);
+  }
+
+  async update(id: string, input: UpdateClauseReviewInput): Promise<ClauseReviewWithClause> {
+    await this.findById(id);
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+
+  async bulkCreate(reviews: CreateClauseReviewInput[]): Promise<ClauseReviewWithClause[]> {
+    return this.repository.bulkCreate(reviews);
+  }
+
+  async initializeForInspection(inspectionId: string, clauseIds: string[]): Promise<ClauseReviewWithClause[]> {
+    return this.repository.initializeForInspection(inspectionId, clauseIds);
+  }
+
+  async markAsNA(id: string, naReason: string): Promise<ClauseReviewWithClause> {
+    return this.update(id, {
+      applicability: 'NA',
+      naReason,
+    });
+  }
+
+  async markAsApplicable(id: string): Promise<ClauseReviewWithClause> {
+    return this.update(id, {
+      applicability: 'APPLICABLE',
+      naReason: undefined,
+    });
+  }
+
+  async addObservation(id: string, observation: string): Promise<ClauseReviewWithClause> {
+    const review = await this.findById(id);
+    const currentObservations = review.observations || '';
+    const newObservations = currentObservations
+      ? `${currentObservations}\n\n${observation}`
+      : observation;
+    
+    return this.update(id, { observations: newObservations });
+  }
+
+  async getSummary(inspectionId: string): Promise<ClauseReviewSummary> {
+    const reviews = await this.findByInspectionId(inspectionId);
+
+    const summary: ClauseReviewSummary = {
+      total: reviews.length,
+      applicable: 0,
+      na: 0,
+      withObservations: 0,
+      withPhotos: 0,
+      withDocs: 0,
+      needingRemedialWorks: 0,
+      byCategory: {},
+      completionPercentage: 0,
+    };
+
+    let reviewedCount = 0;
+
+    for (const review of reviews) {
+      const category = review.clause.category;
+
+      // Initialize category if needed
+      if (!summary.byCategory[category]) {
+        summary.byCategory[category] = { applicable: 0, na: 0 };
+      }
+
+      // Count by applicability
+      if (review.applicability === 'APPLICABLE') {
+        summary.applicable++;
+        summary.byCategory[category].applicable++;
+      } else if (review.applicability === 'NA') {
+        summary.na++;
+        summary.byCategory[category].na++;
+      }
+
+      // Count other fields
+      if (review.observations && review.observations.trim() !== '') {
+        summary.withObservations++;
+      }
+      if (review.photoIds && review.photoIds.length > 0) {
+        summary.withPhotos++;
+      }
+      if (review.docIds && review.docIds.length > 0) {
+        summary.withDocs++;
+      }
+      if (review.remedialWorks && review.remedialWorks.trim() !== '') {
+        summary.needingRemedialWorks++;
+      }
+
+      // Count as reviewed if has applicability set and (NA with reason OR applicable with observations)
+      if (review.applicability === 'NA' && review.naReason) {
+        reviewedCount++;
+      } else if (review.applicability === 'APPLICABLE' && review.observations) {
+        reviewedCount++;
+      }
+    }
+
+    // Calculate completion percentage
+    summary.completionPercentage = reviews.length > 0
+      ? Math.round((reviewedCount / reviews.length) * 100)
+      : 0;
+
+    return summary;
+  }
+
+  async getGroupedByCategory(inspectionId: string): Promise<Record<string, ClauseReviewWithClause[]>> {
+    const reviews = await this.findByInspectionId(inspectionId);
+    
+    const grouped: Record<string, ClauseReviewWithClause[]> = {};
+    for (const review of reviews) {
+      const category = review.clause.category;
+      if (!grouped[category]) {
+        grouped[category] = [];
+      }
+      grouped[category].push(review);
+    }
+    
+    return grouped;
+  }
+}


### PR DESCRIPTION
## Summary
Implements ClauseReview entity for Building Code clause-by-clause inspections (COA, CCC Gap Analysis).

## Changes
- **Prisma Schema**: Added ClauseReview model with Applicability enum, linked to SiteInspection and BuildingCodeClause
- **Repository Layer**: Interface + Prisma implementation with init and bulk create
- **Service Layer**: Business logic with summary calculation, mark N/A helpers
- **Routes**: Full REST API for clause review management
- **Tests**: 14 unit tests for service layer

## API Endpoints

### Per-Inspection Operations
- `POST /api/site-inspections/:id/clause-reviews` - Create review
- `POST /api/site-inspections/:id/clause-reviews/bulk` - Bulk create
- `POST /api/site-inspections/:id/clause-reviews/init` - Initialize with clause IDs
- `GET /api/site-inspections/:id/clause-reviews` - List reviews (supports `?grouped=true`)
- `GET /api/site-inspections/:id/clause-review-summary` - Get summary

### Review Operations
- `GET /api/clause-reviews/:id` - Get review
- `PUT /api/clause-reviews/:id` - Update review
- `POST /api/clause-reviews/:id/mark-na` - Mark as N/A with reason
- `POST /api/clause-reviews/:id/mark-applicable` - Mark as applicable
- `DELETE /api/clause-reviews/:id` - Delete review

## Features
- Link to BuildingCodeClause for clause text auto-population
- Mark clauses as Applicable or N/A
- Record N/A reason (from templates)
- Record observations per clause
- Link photos and documents to clauses
- Track remedial works required
- Unique constraint (one review per inspection + clause)
- Summary with completion percentage

## Summary Response
```json
{
  "total": 20,
  "applicable": 15,
  "na": 5,
  "withObservations": 12,
  "withPhotos": 8,
  "withDocs": 3,
  "needingRemedialWorks": 2,
  "byCategory": { "B": { "applicable": 2, "na": 0 } },
  "completionPercentage": 75
}
```

## Acceptance Criteria
- [x] List all Building Code clauses for inspection
- [x] Mark clause as Applicable/N/A
- [x] Record N/A reason from templates
- [x] Record observations per clause
- [x] Link photos to clauses
- [x] Link documents to clauses
- [x] Track remedial works per clause
- [x] Auto-populate clause text from reference data

Closes #163

Ref: docs/design/004-inspection-checklist-system.md