### PR TITLE
[Alex] feat(server): update MCP tools for new inspection checklist system

### DIFF
--- a/server/src/tools/finding.ts
+++ b/server/src/tools/finding.ts
@@ -6,7 +6,14 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { inspectionApi, findingsApi, photosApi } from "../api/client.js";
+import { 
+  inspectionApi, 
+  findingsApi, 
+  photosApi,
+  siteInspectionApi,
+  checklistItemApi,
+  clauseReviewApi,
+} from "../api/client.js";
 import { commentLibrary } from "../services/comments.js";
 
 // ============================================================================
@@ -134,6 +141,162 @@ export function registerFindingTools(server: McpServer): void {
             text: JSON.stringify(response, null, 2),
           }],
         };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to add finding",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // site_inspection_add_finding - Add finding to site inspection
+  // -------------------------------------------------------------------------
+  server.tool(
+    "site_inspection_add_finding",
+    "Record a finding for a site inspection - creates ChecklistItem (Simple mode) or ClauseReview observation (Clause Review mode)",
+    {
+      inspection_id: z.string().describe("ID of the site inspection"),
+      // For Simple mode
+      category: z.enum(['EXTERIOR', 'INTERIOR', 'DECKS', 'SERVICES', 'SITE']).optional()
+        .describe("Category for Simple mode checklist item"),
+      item: z.string().optional().describe("Checklist item name (Simple mode)"),
+      decision: z.enum(['PASS', 'FAIL', 'NA']).optional().describe("Decision for Simple mode"),
+      // For Clause Review mode
+      clause_id: z.string().optional().describe("Building code clause ID (Clause Review mode)"),
+      applicability: z.enum(['APPLICABLE', 'NA']).optional().describe("Clause applicability (Clause Review mode)"),
+      na_reason: z.string().optional().describe("Reason for N/A (Clause Review mode)"),
+      // Common
+      notes: z.string().optional().describe("Notes or observations"),
+      photo_ids: z.array(z.string()).optional().describe("Photo IDs to attach"),
+    },
+    async ({ inspection_id, category, item, decision, clause_id, applicability, notes, na_reason, photo_ids }) => {
+      try {
+        // Get inspection to determine type
+        const inspResult = await siteInspectionApi.get(inspection_id);
+        if (!inspResult.ok || !inspResult.data) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Inspection not found",
+                inspection_id,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        const inspection = inspResult.data;
+
+        if (inspection.type === 'SIMPLE') {
+          // Simple mode - create ChecklistItem
+          if (!category || !item || !decision) {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "Simple mode requires category, item, and decision",
+                  inspection_type: "SIMPLE",
+                }, null, 2),
+              }],
+              isError: true,
+            };
+          }
+
+          const result = await checklistItemApi.create(inspection_id, {
+            category,
+            item,
+            decision,
+            notes,
+            photoIds: photo_ids,
+          });
+
+          if (!result.ok || !result.data) {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "Failed to create checklist item",
+                  details: result.error,
+                }, null, 2),
+              }],
+              isError: true,
+            };
+          }
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                item_id: result.data.id,
+                category: result.data.category,
+                item: result.data.item,
+                decision: result.data.decision,
+                notes: result.data.notes,
+                photos_attached: result.data.photoIds?.length || 0,
+                message: `Checklist item recorded: ${item} - ${decision}`,
+              }, null, 2),
+            }],
+          };
+        } else {
+          // Clause Review mode - create or update ClauseReview
+          if (!clause_id) {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "Clause Review mode requires clause_id",
+                  inspection_type: "CLAUSE_REVIEW",
+                }, null, 2),
+              }],
+              isError: true,
+            };
+          }
+
+          const result = await clauseReviewApi.create(inspection_id, {
+            clauseId: clause_id,
+            applicability: applicability || 'APPLICABLE',
+            naReason: na_reason,
+            observations: notes,
+            photoIds: photo_ids,
+          });
+
+          if (!result.ok || !result.data) {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "Failed to create clause review",
+                  details: result.error,
+                }, null, 2),
+              }],
+              isError: true,
+            };
+          }
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                review_id: result.data.id,
+                clause_code: result.data.clause.code,
+                clause_title: result.data.clause.title,
+                applicability: result.data.applicability,
+                observations: result.data.observations,
+                photos_attached: result.data.photoIds?.length || 0,
+                message: `Clause ${result.data.clause.code} reviewed: ${result.data.applicability}`,
+              }, null, 2),
+            }],
+          };
+        }
       } catch (error) {
         return {
           content: [{

--- a/server/src/tools/finding.ts
+++ b/server/src/tools/finding.ts
@@ -28,7 +28,7 @@ export function registerFindingTools(server: McpServer): void {
     "inspection_add_finding",
     "Record a finding or issue during the inspection with optional photos",
     {
-      inspection_id: z.string().describe("ID of the active inspection"),
+      inspection_id: z.string().uuid().describe("ID of the active inspection"),
       section: z.string().optional().describe("Section ID (defaults to current section)"),
       text: z.string().describe("Inspector's note or description of the finding"),
       photos: z.array(z.object({
@@ -163,19 +163,19 @@ export function registerFindingTools(server: McpServer): void {
     "site_inspection_add_finding",
     "Record a finding for a site inspection - creates ChecklistItem (Simple mode) or ClauseReview observation (Clause Review mode)",
     {
-      inspection_id: z.string().describe("ID of the site inspection"),
+      inspection_id: z.string().uuid().describe("ID of the site inspection"),
       // For Simple mode
       category: z.enum(['EXTERIOR', 'INTERIOR', 'DECKS', 'SERVICES', 'SITE']).optional()
         .describe("Category for Simple mode checklist item"),
       item: z.string().optional().describe("Checklist item name (Simple mode)"),
       decision: z.enum(['PASS', 'FAIL', 'NA']).optional().describe("Decision for Simple mode"),
       // For Clause Review mode
-      clause_id: z.string().optional().describe("Building code clause ID (Clause Review mode)"),
+      clause_id: z.string().uuid().optional().describe("Building code clause ID (Clause Review mode)"),
       applicability: z.enum(['APPLICABLE', 'NA']).optional().describe("Clause applicability (Clause Review mode)"),
       na_reason: z.string().optional().describe("Reason for N/A (Clause Review mode)"),
       // Common
       notes: z.string().optional().describe("Notes or observations"),
-      photo_ids: z.array(z.string()).optional().describe("Photo IDs to attach"),
+      photo_ids: z.array(z.string().uuid()).optional().describe("Photo IDs to attach"),
     },
     async ({ inspection_id, category, item, decision, clause_id, applicability, notes, na_reason, photo_ids }) => {
       try {

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -25,7 +25,7 @@ export function registerTools(server: McpServer): void {
     "inspection_navigate",
     "Navigate to a different section of the inspection checklist",
     {
-      inspection_id: z.string().describe("ID of the active inspection"),
+      inspection_id: z.string().uuid().describe("ID of the active inspection"),
       section: z.string().describe("Section ID to navigate to"),
     },
     async ({ inspection_id, section }) => {
@@ -83,7 +83,7 @@ export function registerTools(server: McpServer): void {
     "inspection_suggest_next",
     "Get guidance for what to do next based on current state",
     {
-      inspection_id: z.string().describe("ID of the active inspection"),
+      inspection_id: z.string().uuid().describe("ID of the active inspection"),
     },
     async ({ inspection_id }) => {
       try {

--- a/server/src/tools/inspection.ts
+++ b/server/src/tools/inspection.ts
@@ -143,7 +143,7 @@ export function registerInspectionTools(server: McpServer): void {
     "inspection_status",
     "Get the current inspection state and progress",
     {
-      inspection_id: z.string().describe("ID of the inspection to check"),
+      inspection_id: z.string().uuid().describe("ID of the inspection to check"),
     },
     async ({ inspection_id }) => {
       try {
@@ -219,7 +219,7 @@ export function registerInspectionTools(server: McpServer): void {
     "site_inspection_start",
     "Start a new site inspection with Simple (Pass/Fail) or Clause Review (COA/CCC) mode",
     {
-      project_id: z.string().describe("ID of the project to attach inspection to"),
+      project_id: z.string().uuid().describe("ID of the project to attach inspection to"),
       type: z.enum(['SIMPLE', 'CLAUSE_REVIEW']).describe("Inspection type: SIMPLE for Pass/Fail, CLAUSE_REVIEW for COA/CCC"),
       stage: z.string().describe("Inspection stage (e.g., INS_05, COA, CCC_GA)"),
       inspector_name: z.string().describe("Name of the inspector"),
@@ -320,7 +320,7 @@ export function registerInspectionTools(server: McpServer): void {
     "site_inspection_status",
     "Get status and progress for a site inspection",
     {
-      inspection_id: z.string().describe("ID of the site inspection"),
+      inspection_id: z.string().uuid().describe("ID of the site inspection"),
     },
     async ({ inspection_id }) => {
       try {

--- a/server/src/tools/inspection.ts
+++ b/server/src/tools/inspection.ts
@@ -2,11 +2,19 @@
  * Inspection Tools
  * 
  * MCP tools for starting and managing inspections via API.
+ * Supports both Simple (Pass/Fail) and Clause Review (COA/CCC) modes.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { inspectionApi, navigationApi } from "../api/client.js";
+import { 
+  inspectionApi, 
+  navigationApi,
+  siteInspectionApi,
+  checklistItemApi,
+  clauseReviewApi,
+  buildingCodeApi,
+} from "../api/client.js";
 import { checklistService } from "../services/checklist.js";
 
 // ============================================================================
@@ -181,6 +189,182 @@ export function registerInspectionTools(server: McpServer): void {
           progress: status.progress,
           total_findings: status.totalFindings,
           can_complete: status.canComplete,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to get inspection status",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // site_inspection_start - Start new inspection with type selection
+  // -------------------------------------------------------------------------
+  server.tool(
+    "site_inspection_start",
+    "Start a new site inspection with Simple (Pass/Fail) or Clause Review (COA/CCC) mode",
+    {
+      project_id: z.string().describe("ID of the project to attach inspection to"),
+      type: z.enum(['SIMPLE', 'CLAUSE_REVIEW']).describe("Inspection type: SIMPLE for Pass/Fail, CLAUSE_REVIEW for COA/CCC"),
+      stage: z.string().describe("Inspection stage (e.g., INS_05, COA, CCC_GA)"),
+      inspector_name: z.string().describe("Name of the inspector"),
+      weather: z.string().optional().describe("Weather conditions"),
+    },
+    async ({ project_id, type, stage, inspector_name, weather }) => {
+      try {
+        // Create site inspection via API
+        const result = await siteInspectionApi.create(project_id, {
+          type,
+          stage,
+          date: new Date().toISOString(),
+          inspectorName: inspector_name,
+          weather,
+        });
+
+        if (!result.ok || !result.data) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Failed to create site inspection",
+                details: result.error,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        const inspection = result.data;
+
+        // Get first section/clause based on type
+        let firstSection;
+        if (type === 'SIMPLE') {
+          firstSection = {
+            type: 'category',
+            id: 'EXTERIOR',
+            name: 'Exterior',
+            prompt: 'Check exterior elements: roof, cladding, flashings, windows.',
+            items: ['Roof cladding / flashings', 'Wall cladding', 'Window flashings', 'Window glazing'],
+          };
+        } else {
+          // Get first building code clause
+          const clausesResult = await buildingCodeApi.listClauses('B');
+          const firstClause = clausesResult.data?.[0];
+          firstSection = firstClause ? {
+            type: 'clause',
+            id: firstClause.id,
+            code: firstClause.code,
+            name: firstClause.title,
+            prompt: `Check: ${firstClause.performanceText}`,
+            typical_evidence: firstClause.typicalEvidence,
+          } : {
+            type: 'clause',
+            id: 'B1',
+            name: 'Structure',
+            prompt: 'Check structural elements and foundations.',
+          };
+        }
+
+        const response = {
+          inspection_id: inspection.id,
+          project_id: inspection.projectId,
+          type: inspection.type,
+          stage: inspection.stage,
+          status: 'started',
+          address: inspection.project?.property?.streetAddress,
+          client_name: inspection.project?.client?.name,
+          first_section: firstSection,
+          message: `${type === 'SIMPLE' ? 'Simple checklist' : 'Clause review'} inspection started. Ready to begin with ${firstSection.name}.`,
+        };
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              error: "Failed to start site inspection",
+              details: error instanceof Error ? error.message : String(error),
+            }, null, 2),
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // site_inspection_status - Get status for new inspection system
+  // -------------------------------------------------------------------------
+  server.tool(
+    "site_inspection_status",
+    "Get status and progress for a site inspection",
+    {
+      inspection_id: z.string().describe("ID of the site inspection"),
+    },
+    async ({ inspection_id }) => {
+      try {
+        // Get inspection
+        const inspResult = await siteInspectionApi.get(inspection_id);
+        if (!inspResult.ok || !inspResult.data) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Failed to get inspection",
+                details: inspResult.error,
+              }, null, 2),
+            }],
+            isError: true,
+          };
+        }
+
+        const inspection = inspResult.data;
+
+        // Get summary based on type
+        let summary;
+        if (inspection.type === 'SIMPLE') {
+          const summaryResult = await checklistItemApi.getSummary(inspection_id);
+          summary = summaryResult.data;
+        } else {
+          const summaryResult = await clauseReviewApi.getSummary(inspection_id);
+          summary = summaryResult.data;
+        }
+
+        const response = {
+          inspection_id: inspection.id,
+          project_id: inspection.projectId,
+          type: inspection.type,
+          stage: inspection.stage,
+          status: inspection.status,
+          address: inspection.project?.property?.streetAddress,
+          client_name: inspection.project?.client?.name,
+          current_section: inspection.currentSection,
+          current_clause_id: inspection.currentClauseId,
+          summary,
+          can_complete: inspection.type === 'SIMPLE' 
+            ? (summary as { overallResult?: string })?.overallResult !== 'INCOMPLETE'
+            : ((summary as { completionPercentage?: number })?.completionPercentage ?? 0) >= 80,
         };
 
         return {

--- a/server/src/tools/report.ts
+++ b/server/src/tools/report.ts
@@ -20,7 +20,7 @@ export function registerReportTools(server: McpServer): void {
     "inspection_complete",
     "Finish the inspection and generate the PDF report",
     {
-      inspection_id: z.string().describe("ID of the inspection to complete"),
+      inspection_id: z.string().uuid().describe("ID of the inspection to complete"),
       summary_notes: z.string().optional().describe("Overall summary or additional notes"),
       weather: z.string().optional().describe("Weather conditions at time of inspection"),
     },
@@ -154,7 +154,7 @@ export function registerReportTools(server: McpServer): void {
     "inspection_get_report",
     "Retrieve a generated inspection report",
     {
-      inspection_id: z.string().describe("ID of the inspection"),
+      inspection_id: z.string().uuid().describe("ID of the inspection"),
       format: z.enum(["pdf", "markdown"]).optional().describe("Report format (default: pdf)"),
     },
     async ({ inspection_id, format = "pdf" }) => {


### PR DESCRIPTION
## Summary
Updates MCP tools to support the new inspection checklist system with Simple (Pass/Fail) and Clause Review (COA/CCC) modes.

## Changes
- **API Client**: Added methods for SiteInspection, ChecklistItem, ClauseReview, BuildingCode
- **New Tools**: Added 3 new MCP tools for the new inspection system
- **Backward Compatible**: Existing `inspection_*` tools still work for legacy system

## New MCP Tools

### site_inspection_start
Start a new site inspection with type selection.

```typescript
{
  project_id: string,       // Project to attach inspection to
  type: 'SIMPLE' | 'CLAUSE_REVIEW',
  stage: string,            // INS_05, COA, CCC_GA, etc.
  inspector_name: string,
  weather?: string
}
```

### site_inspection_status
Get progress and summary for a site inspection.

```typescript
{
  inspection_id: string
}
// Returns mode-specific summary (checklist or clause review)
```

### site_inspection_add_finding
Record a finding - creates ChecklistItem (Simple) or ClauseReview (Clause Review).

**Simple Mode:**
```typescript
{
  inspection_id: string,
  category: 'EXTERIOR' | 'INTERIOR' | 'DECKS' | 'SERVICES' | 'SITE',
  item: string,
  decision: 'PASS' | 'FAIL' | 'NA',
  notes?: string,
  photo_ids?: string[]
}
```

**Clause Review Mode:**
```typescript
{
  inspection_id: string,
  clause_id: string,
  applicability: 'APPLICABLE' | 'NA',
  na_reason?: string,
  notes?: string,
  photo_ids?: string[]
}
```

## Example WhatsApp Flow

**Simple Mode:**
```
Inspector: "Start pre-line inspection for project ABC"
OpenClaw: [calls site_inspection_start with type=SIMPLE]
         "Simple checklist started. Beginning with Exterior."

Inspector: "Roof pass, cladding pass, window flashings fail - missing head flashing"
OpenClaw: [calls site_inspection_add_finding for each item]
         "Recorded: Roof ✓, Cladding ✓, Window flashings ✗"

Inspector: "Status"
OpenClaw: [calls site_inspection_status]
         "3/15 items checked. 2 pass, 1 fail."
```

**Clause Review Mode:**
```
Inspector: "Start COA inspection for project XYZ"
OpenClaw: [calls site_inspection_start with type=CLAUSE_REVIEW]
         "Clause review started. First clause: B1 Structure."

Inspector: "B1 applicable - foundations look good, no cracking"
OpenClaw: [calls site_inspection_add_finding with clause_id and observations]
         "B1 Structure marked APPLICABLE with observations."

Inspector: "B2 N/A - building predates durability requirements"
OpenClaw: [calls site_inspection_add_finding with applicability=NA]
         "B2 Durability marked N/A."
```

## Acceptance Criteria
- [x] Start inspection with type selection
- [x] Add findings mapped to correct entity
- [x] Navigate based on inspection type (via status)
- [x] Show progress summary

Closes #165

Ref: docs/design/004-inspection-checklist-system.md