### PR TITLE
[Archer] fix(api): ensure Prisma client regenerates on schema changes

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,11 +7,8 @@ WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 
-# Install dependencies
+# Install dependencies (postinstall runs prisma generate)
 RUN npm install
-
-# Generate Prisma client
-RUN npx prisma generate
 
 # Copy source
 COPY . .

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
+    "postinstall": "prisma generate",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary

Fixes Docker build cache issue where Prisma client wasn't regenerated after schema changes (adding NAReasonTemplate model).

## Changes

- Add `postinstall` script to `api/package.json` that runs `prisma generate`
- Simplify `api/Dockerfile` by removing explicit prisma generate (now handled by postinstall)

## Root Cause

Docker BuildKit cached the `RUN npx prisma generate` layer from a build before the NAReasonTemplate model was added. When the seed script ran, `prisma.nAReasonTemplate` was undefined.

## Fix

By adding `prisma generate` to postinstall, it runs automatically whenever `npm install` runs. When Docker re-runs npm install (due to package.json/lock changes), the Prisma client is regenerated.

---
Fixes #234
Related: #171, #163