### PR TITLE
[Alex] fix(api): add NAReasonTemplate model for seed script

### DIFF
--- a/api/prisma/migrations/20260219050000_add_na_reason_template/migration.sql
+++ b/api/prisma/migrations/20260219050000_add_na_reason_template/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "NAReasonTemplate" (
+    "id" TEXT NOT NULL,
+    "template" TEXT NOT NULL,
+    "usage" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NAReasonTemplate_pkey" PRIMARY KEY ("id")
+);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -362,3 +362,16 @@ enum Applicability {
   APPLICABLE
   NA
 }
+
+// ============================================
+// N/A Reason Templates (reference data)
+// ============================================
+
+model NAReasonTemplate {
+  id          String   @id @default(uuid())
+  template    String
+  usage       String?
+  sortOrder   Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
Fixes seed script failure caused by missing NAReasonTemplate model.

## Problem
The seed script (prisma/seed.ts) referenced `prisma.nAReasonTemplate` but the model wasn't defined in the Prisma schema, causing the script to crash after seeding Building Code clauses.

## Changes
- Add `NAReasonTemplate` model to schema.prisma (reference data table)
- Add migration `20260219050000_add_na_reason_template`
- Regenerate Prisma client

## Testing
- All 128 API tests passing
- Seed script can now reference the NAReasonTemplate model

Closes #234