### PR TITLE
fix: pre-commit/pre-push hooks check all workspaces

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,31 @@
 #!/bin/sh
 
-# Run typecheck and lint on server workspace (MCP server)
-cd server
+echo "🔍 Running pre-commit checks..."
 
-echo "🔍 Running typecheck..."
-npm run typecheck || exit 1
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-echo "🧹 Running lint..."
-npm run lint || exit 1
+# Check api workspace
+if git diff --cached --name-only | grep -q "^api/"; then
+  echo "📦 Checking api..."
+  cd "$REPO_ROOT/api"
+  npm run typecheck || exit 1
+  npm run lint || exit 1
+fi
+
+# Check web workspace
+if git diff --cached --name-only | grep -q "^web/"; then
+  echo "📦 Checking web..."
+  cd "$REPO_ROOT/web"
+  npm run typecheck || exit 1
+  npm run lint || exit 1
+fi
+
+# Check server workspace (MCP server)
+if git diff --cached --name-only | grep -q "^server/"; then
+  echo "📦 Checking server..."
+  cd "$REPO_ROOT/server"
+  npm run typecheck || exit 1
+  npm run lint || exit 1
+fi
 
 echo "✅ Pre-commit checks passed!"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+echo "🚀 Running pre-push checks (full lint + typecheck)..."
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Check api
+echo "📦 Checking api..."
+cd "$REPO_ROOT/api" && npm run typecheck && npm run lint || exit 1
+
+# Check web
+echo "📦 Checking web..."
+cd "$REPO_ROOT/web" && npm run typecheck && npm run lint || exit 1
+
+# Check server
+echo "📦 Checking server..."
+cd "$REPO_ROOT/server" && npm run typecheck && npm run lint || exit 1
+
+echo "✅ Pre-push checks passed!"

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
+    "postinstall": "prisma generate",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary
Fixes #237 - Prevents lint/type errors from being pushed to CI.

## Changes
- **Pre-commit**: Checks only changed workspaces (api/web/server) - fast
- **Pre-push**: Runs full lint+typecheck on all workspaces - thorough
- **api/package.json**: Adds `postinstall` script to run `prisma generate` automatically

## Root Cause
Disk was full (118MB free) causing `npm install` to fail silently. Fixed by clearing caches (now 14GB free).

## Testing
- [x] Pre-commit triggers on api changes
- [x] Pre-push checks all 3 workspaces
- [x] All typechecks pass locally