### PR TITLE
[Archer] fix(cd): prevent migration timeout with database wake step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,17 +49,30 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Wake database
+        run: |
+          echo "Waking database by hitting health endpoint..."
+          for i in 1 2 3 4 5; do
+            curl -sf "$API_URL/health" && break
+            echo "Attempt $i failed, waiting 5s..."
+            sleep 5
+          done
+          echo "Waiting 10s for database connections to stabilize..."
+          sleep 10
+        env:
+          API_URL: ${{ env.API_URL }}
+
       - name: Run database migrations
         run: |
           echo "Running Prisma migrations..."
-          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx prisma migrate deploy'"
+          flyctl ssh console --app ai-inspection-api-test --timeout 300 -C "sh -c 'cd /app && npx prisma migrate deploy'"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Seed database (test data)
         run: |
           echo "Seeding test database..."
-          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx tsx prisma/seed.ts'"
+          flyctl ssh console --app ai-inspection-api-test --timeout 300 -C "sh -c 'cd /app && npx tsx prisma/seed.ts'"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fixes CD pipeline migration timeout (P1017: Server has closed the connection).

## Root Cause

Fly.io's auto-suspend feature puts the database to sleep during inactivity. When migrations run via SSH, the database connection times out before fully waking.

## Changes

### Wake Database Step
Added a new step before migrations that:
- Hits the `/health` endpoint to wake the API (which connects to DB)
- Retries 5 times with 5s delay
- Waits 10s after success for connections to stabilize

### SSH Timeout
- Added `--timeout 300` (5 minutes) to both `flyctl ssh` commands
- Applies to both migrate and seed steps

## Testing

This fix can be tested by:
1. Merging to develop (will trigger CD)
2. Checking if migrations complete without P1017

---
Fixes #233