### PR TITLE
[Alex] feat(api): add NAReasonTemplate API endpoints

### DIFF
--- a/api/src/__tests__/na-reason-template.test.ts
+++ b/api/src/__tests__/na-reason-template.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  NAReasonTemplateService,
+  NAReasonTemplateNotFoundError,
+} from '../services/na-reason-template.js';
+import type { INAReasonTemplateRepository } from '../repositories/interfaces/na-reason-template.js';
+import type { NAReasonTemplate } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): INAReasonTemplateRepository => ({
+  findAll: vi.fn(),
+  findById: vi.fn(),
+});
+
+const mockTemplate: NAReasonTemplate = {
+  id: 'template-1',
+  template: 'The CoA works do not affect {element}. As such, this Clause is not applicable.',
+  usage: 'General - when works don\'t impact a specific building element',
+  sortOrder: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('NAReasonTemplateService', () => {
+  let repository: INAReasonTemplateRepository;
+  let service: NAReasonTemplateService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    service = new NAReasonTemplateService(repository);
+  });
+
+  describe('findAll', () => {
+    it('should return all templates', async () => {
+      const templates = [
+        mockTemplate,
+        { ...mockTemplate, id: 'template-2', template: 'This Clause does not apply to {space_type}.', sortOrder: 2 },
+      ];
+      vi.mocked(repository.findAll).mockResolvedValue(templates);
+
+      const result = await service.findAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].template).toContain('CoA works');
+    });
+
+    it('should return empty array when no templates', async () => {
+      vi.mocked(repository.findAll).mockResolvedValue([]);
+
+      const result = await service.findAll();
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return template by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockTemplate);
+
+      const result = await service.findById('template-1');
+
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('should throw NAReasonTemplateNotFoundError for non-existent template', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        NAReasonTemplateNotFoundError
+      );
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -17,6 +17,7 @@ import { checklistItemsRouter } from './routes/checklist-items.js';
 import { buildingCodeRouter } from './routes/building-code.js';
 import { clauseReviewsRouter } from './routes/clause-reviews.js';
 import { documentsRouter } from './routes/documents.js';
+import { naReasonTemplatesRouter } from './routes/na-reason-templates.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -72,6 +73,7 @@ app.use('/api', authMiddleware, checklistItemsRouter);
 app.use('/api/building-code', authMiddleware, buildingCodeRouter);
 app.use('/api', authMiddleware, clauseReviewsRouter);
 app.use('/api', authMiddleware, documentsRouter);
+app.use('/api/na-reason-templates', authMiddleware, naReasonTemplatesRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/na-reason-template.ts
+++ b/api/src/repositories/interfaces/na-reason-template.ts
@@ -1,0 +1,6 @@
+import type { NAReasonTemplate } from '@prisma/client';
+
+export interface INAReasonTemplateRepository {
+  findAll(): Promise<NAReasonTemplate[]>;
+  findById(id: string): Promise<NAReasonTemplate | null>;
+}

--- a/api/src/repositories/prisma/na-reason-template.ts
+++ b/api/src/repositories/prisma/na-reason-template.ts
@@ -1,0 +1,18 @@
+import { PrismaClient, type NAReasonTemplate } from '@prisma/client';
+import type { INAReasonTemplateRepository } from '../interfaces/na-reason-template.js';
+
+export class PrismaNAReasonTemplateRepository implements INAReasonTemplateRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async findAll(): Promise<NAReasonTemplate[]> {
+    return this.prisma.nAReasonTemplate.findMany({
+      orderBy: { sortOrder: 'asc' },
+    });
+  }
+
+  async findById(id: string): Promise<NAReasonTemplate | null> {
+    return this.prisma.nAReasonTemplate.findUnique({
+      where: { id },
+    });
+  }
+}

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -12,3 +12,4 @@ export * from './checklist-items.js';
 export * from './building-code.js';
 export * from './clause-reviews.js';
 export * from './documents.js';
+export * from './na-reason-templates.js';

--- a/api/src/routes/na-reason-templates.ts
+++ b/api/src/routes/na-reason-templates.ts
@@ -1,0 +1,35 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { PrismaNAReasonTemplateRepository } from '../repositories/prisma/na-reason-template.js';
+import { NAReasonTemplateService, NAReasonTemplateNotFoundError } from '../services/na-reason-template.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaNAReasonTemplateRepository(prisma);
+const service = new NAReasonTemplateService(repository);
+
+export const naReasonTemplatesRouter: Router = Router();
+
+// GET /api/na-reason-templates - List all templates
+naReasonTemplatesRouter.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const templates = await service.findAll();
+    res.json(templates);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/na-reason-templates/:id - Get template by ID
+naReasonTemplatesRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const template = await service.findById(id);
+    res.json(template);
+  } catch (error) {
+    if (error instanceof NAReasonTemplateNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/services/na-reason-template.ts
+++ b/api/src/services/na-reason-template.ts
@@ -1,0 +1,25 @@
+import type { NAReasonTemplate } from '@prisma/client';
+import type { INAReasonTemplateRepository } from '../repositories/interfaces/na-reason-template.js';
+
+export class NAReasonTemplateNotFoundError extends Error {
+  constructor(id: string) {
+    super(`N/A reason template not found: ${id}`);
+    this.name = 'NAReasonTemplateNotFoundError';
+  }
+}
+
+export class NAReasonTemplateService {
+  constructor(private repository: INAReasonTemplateRepository) {}
+
+  async findAll(): Promise<NAReasonTemplate[]> {
+    return this.repository.findAll();
+  }
+
+  async findById(id: string): Promise<NAReasonTemplate> {
+    const template = await this.repository.findById(id);
+    if (!template) {
+      throw new NAReasonTemplateNotFoundError(id);
+    }
+    return template;
+  }
+}


### PR DESCRIPTION
## Summary
Adds API endpoints to retrieve N/A reason templates for clause reviews.

## Changes
- Repository interface and Prisma implementation
- Service layer with error handling  
- API routes for list and get by ID
- 4 unit tests

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | /api/na-reason-templates | List all templates |
| GET | /api/na-reason-templates/:id | Get template by ID |

## Testing
- 155 API tests passing (4 new for NAReasonTemplate)

Closes #170