### PR TITLE
[Archer] fix(cd): remove invalid --timeout flag from flyctl ssh

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,14 +65,14 @@ jobs:
       - name: Run database migrations
         run: |
           echo "Running Prisma migrations..."
-          flyctl ssh console --app ai-inspection-api-test --timeout 300 -C "sh -c 'cd /app && npx prisma migrate deploy'"
+          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx prisma migrate deploy'"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Seed database (test data)
         run: |
           echo "Seeding test database..."
-          flyctl ssh console --app ai-inspection-api-test --timeout 300 -C "sh -c 'cd /app && npx tsx prisma/seed.ts'"
+          flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx tsx prisma/seed.ts'"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Summary

**P1 Hotfix** — Removes invalid `--timeout` flag that was breaking CD pipeline.

## Problem

PR #241 added `--timeout 300` to `flyctl ssh console` commands, but this flag isn't supported by flyctl, causing CD to fail with:
```
Error: unknown flag: --timeout
```

## Fix

Remove the invalid `--timeout 300` flags from migration and seed commands.

The "Wake database" step (also from #241) still ensures the database is ready before migrations run, so timeout protection isn't lost entirely.

## Note

PR #243 adds retry logic which will provide additional resilience once merged.

---
Fixes #246