### PR TITLE
[Alex] feat(api): add SiteMeasurement entity (#164)

### DIFF
--- a/api/prisma/migrations/20260219080000_add_site_measurement/migration.sql
+++ b/api/prisma/migrations/20260219080000_add_site_measurement/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "MeasurementType" AS ENUM ('MOISTURE_CONTENT', 'SLOPE_FALL', 'DIMENSION', 'CLEARANCE', 'TEMPERATURE', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "MeasurementUnit" AS ENUM ('PERCENT', 'MM_PER_M', 'MM', 'CM', 'M', 'CELSIUS');
+
+-- CreateEnum
+CREATE TYPE "MeasurementResult" AS ENUM ('PENDING', 'PASS', 'FAIL');
+
+-- CreateTable
+CREATE TABLE "SiteMeasurement" (
+    "id" TEXT NOT NULL,
+    "inspectionId" TEXT NOT NULL,
+    "type" "MeasurementType" NOT NULL,
+    "location" TEXT NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+    "unit" "MeasurementUnit" NOT NULL,
+    "result" "MeasurementResult" NOT NULL DEFAULT 'PENDING',
+    "linkedClauseId" TEXT,
+    "notes" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SiteMeasurement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SiteMeasurement_inspectionId_idx" ON "SiteMeasurement"("inspectionId");
+
+-- CreateIndex
+CREATE INDEX "SiteMeasurement_type_idx" ON "SiteMeasurement"("type");
+
+-- AddForeignKey
+ALTER TABLE "SiteMeasurement" ADD CONSTRAINT "SiteMeasurement_inspectionId_fkey" FOREIGN KEY ("inspectionId") REFERENCES "SiteInspection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SiteMeasurement" ADD CONSTRAINT "SiteMeasurement_linkedClauseId_fkey" FOREIGN KEY ("linkedClauseId") REFERENCES "BuildingCodeClause"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -209,9 +209,59 @@ model SiteInspection {
   // Relations
   checklistItems    ChecklistItem[]
   clauseReviews     ClauseReview[]
+  measurements      SiteMeasurement[]
   
   @@index([projectId])
   @@index([status])
+}
+
+// Site measurement records
+model SiteMeasurement {
+  id              String              @id @default(uuid())
+  inspectionId    String
+  inspection      SiteInspection      @relation(fields: [inspectionId], references: [id], onDelete: Cascade)
+  
+  type            MeasurementType
+  location        String
+  value           Float
+  unit            MeasurementUnit
+  result          MeasurementResult   @default(PENDING)
+  
+  linkedClauseId  String?
+  linkedClause    BuildingCodeClause? @relation(fields: [linkedClauseId], references: [id])
+  
+  notes           String?
+  
+  sortOrder       Int                 @default(0)
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+  
+  @@index([inspectionId])
+  @@index([type])
+}
+
+enum MeasurementType {
+  MOISTURE_CONTENT
+  SLOPE_FALL
+  DIMENSION
+  CLEARANCE
+  TEMPERATURE
+  OTHER
+}
+
+enum MeasurementUnit {
+  PERCENT         // %
+  MM_PER_M        // mm/m (slope)
+  MM              // mm
+  CM              // cm
+  M               // m
+  CELSIUS         // °C
+}
+
+enum MeasurementResult {
+  PENDING
+  PASS
+  FAIL
 }
 
 model ChecklistItem {
@@ -306,6 +356,7 @@ model BuildingCodeClause {
   children          BuildingCodeClause[] @relation("ClauseHierarchy")
   
   clauseReviews     ClauseReview[]
+  measurements      SiteMeasurement[]
   
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt

--- a/api/src/__tests__/site-measurement.test.ts
+++ b/api/src/__tests__/site-measurement.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SiteMeasurementService, SiteMeasurementNotFoundError } from '../services/site-measurement.js';
+import type { ISiteMeasurementRepository, SiteMeasurementWithClause } from '../repositories/interfaces/site-measurement.js';
+
+// Mock repository
+function createMockRepository(): ISiteMeasurementRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByInspectionId: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+// Sample measurement for tests
+const sampleMeasurement: SiteMeasurementWithClause = {
+  id: 'measurement-123',
+  inspectionId: 'inspection-456',
+  type: 'MOISTURE_CONTENT',
+  location: 'Bathroom floor near shower',
+  value: 15.5,
+  unit: 'PERCENT',
+  result: 'PASS',
+  linkedClauseId: null,
+  linkedClause: null,
+  notes: 'Reading taken at base of shower',
+  sortOrder: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('SiteMeasurementService', () => {
+  let service: SiteMeasurementService;
+  let mockRepo: ISiteMeasurementRepository;
+
+  beforeEach(() => {
+    mockRepo = createMockRepository();
+    service = new SiteMeasurementService(mockRepo);
+  });
+
+  describe('create', () => {
+    it('should create measurement and auto-evaluate PASS for moisture < 18%', async () => {
+      const created = { ...sampleMeasurement, result: 'PENDING' as const };
+      const evaluated = { ...sampleMeasurement, result: 'PASS' as const };
+      
+      vi.mocked(mockRepo.create).mockResolvedValue(created);
+      vi.mocked(mockRepo.update).mockResolvedValue(evaluated);
+
+      const result = await service.create({
+        inspectionId: 'inspection-456',
+        type: 'MOISTURE_CONTENT',
+        location: 'Bathroom floor',
+        value: 15.5,
+        unit: 'PERCENT',
+      });
+
+      expect(result.result).toBe('PASS');
+      expect(mockRepo.update).toHaveBeenCalledWith('measurement-123', { result: 'PASS' });
+    });
+
+    it('should create measurement and auto-evaluate FAIL for moisture > 18%', async () => {
+      const created = { ...sampleMeasurement, value: 22, result: 'PENDING' as const };
+      const evaluated = { ...sampleMeasurement, value: 22, result: 'FAIL' as const };
+      
+      vi.mocked(mockRepo.create).mockResolvedValue(created);
+      vi.mocked(mockRepo.update).mockResolvedValue(evaluated);
+
+      const result = await service.create({
+        inspectionId: 'inspection-456',
+        type: 'MOISTURE_CONTENT',
+        location: 'Bathroom floor',
+        value: 22,
+        unit: 'PERCENT',
+      });
+
+      expect(result.result).toBe('FAIL');
+    });
+
+    it('should create measurement with PENDING for types without auto-eval', async () => {
+      const created = { ...sampleMeasurement, type: 'DIMENSION' as const, result: 'PENDING' as const };
+      
+      vi.mocked(mockRepo.create).mockResolvedValue(created);
+
+      const result = await service.create({
+        inspectionId: 'inspection-456',
+        type: 'DIMENSION',
+        location: 'Window width',
+        value: 1200,
+        unit: 'MM',
+      });
+
+      expect(result.result).toBe('PENDING');
+      expect(mockRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findById', () => {
+    it('should return measurement by id', async () => {
+      vi.mocked(mockRepo.findById).mockResolvedValue(sampleMeasurement);
+
+      const result = await service.findById('measurement-123');
+
+      expect(result).toEqual(sampleMeasurement);
+    });
+
+    it('should throw SiteMeasurementNotFoundError for non-existent id', async () => {
+      vi.mocked(mockRepo.findById).mockResolvedValue(null);
+
+      await expect(service.findById('nonexistent'))
+        .rejects.toThrow(SiteMeasurementNotFoundError);
+    });
+  });
+
+  describe('findByInspectionId', () => {
+    it('should return all measurements for inspection', async () => {
+      const measurements = [
+        sampleMeasurement,
+        { ...sampleMeasurement, id: 'measurement-456', type: 'SLOPE_FALL' as const },
+      ];
+      vi.mocked(mockRepo.findByInspectionId).mockResolvedValue(measurements);
+
+      const result = await service.findByInspectionId('inspection-456');
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('update', () => {
+    it('should re-evaluate when value changes', async () => {
+      const updated = { ...sampleMeasurement, value: 25, result: 'FAIL' as const };
+      vi.mocked(mockRepo.findById).mockResolvedValue(sampleMeasurement);
+      vi.mocked(mockRepo.update).mockResolvedValue(updated);
+
+      const result = await service.update('measurement-123', { value: 25 });
+
+      expect(result.result).toBe('FAIL');
+    });
+
+    it('should throw SiteMeasurementNotFoundError for non-existent id', async () => {
+      vi.mocked(mockRepo.findById).mockResolvedValue(null);
+
+      await expect(service.update('nonexistent', { value: 20 }))
+        .rejects.toThrow(SiteMeasurementNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing measurement', async () => {
+      vi.mocked(mockRepo.findById).mockResolvedValue(sampleMeasurement);
+      vi.mocked(mockRepo.delete).mockResolvedValue(undefined);
+
+      await service.delete('measurement-123');
+
+      expect(mockRepo.delete).toHaveBeenCalledWith('measurement-123');
+    });
+
+    it('should throw SiteMeasurementNotFoundError for non-existent id', async () => {
+      vi.mocked(mockRepo.findById).mockResolvedValue(null);
+
+      await expect(service.delete('nonexistent'))
+        .rejects.toThrow(SiteMeasurementNotFoundError);
+    });
+  });
+
+  describe('getAcceptableRange', () => {
+    it('should return range for MOISTURE_CONTENT', () => {
+      const range = service.getAcceptableRange('MOISTURE_CONTENT');
+
+      expect(range).toEqual({ max: 18, description: '< 18' });
+    });
+
+    it('should return range for SLOPE_FALL', () => {
+      const range = service.getAcceptableRange('SLOPE_FALL');
+
+      expect(range).toEqual({ min: 10, description: '≥ 10' });
+    });
+
+    it('should return null for types without ranges', () => {
+      const range = service.getAcceptableRange('DIMENSION');
+
+      expect(range).toBeNull();
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -20,6 +20,7 @@ import { documentsRouter } from './routes/documents.js';
 import { naReasonTemplatesRouter } from './routes/na-reason-templates.js';
 import { projectPhotosRouter } from './routes/project-photos.js';
 import { buildingHistoryRouter } from './routes/building-history.js';
+import { siteMeasurementsRouter } from './routes/site-measurements.js';
 import { authMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -78,6 +79,7 @@ app.use('/api', authMiddleware, documentsRouter);
 app.use('/api/na-reason-templates', authMiddleware, naReasonTemplatesRouter);
 app.use('/api', authMiddleware, projectPhotosRouter);
 app.use('/api', authMiddleware, buildingHistoryRouter);
+app.use('/api', authMiddleware, siteMeasurementsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/site-measurement.ts
+++ b/api/src/repositories/interfaces/site-measurement.ts
@@ -1,0 +1,38 @@
+import type { SiteMeasurement, MeasurementType, MeasurementUnit, MeasurementResult } from '@prisma/client';
+
+export interface CreateSiteMeasurementInput {
+  inspectionId: string;
+  type: MeasurementType;
+  location: string;
+  value: number;
+  unit: MeasurementUnit;
+  linkedClauseId?: string;
+  notes?: string;
+}
+
+export interface UpdateSiteMeasurementInput {
+  type?: MeasurementType;
+  location?: string;
+  value?: number;
+  unit?: MeasurementUnit;
+  result?: MeasurementResult;
+  linkedClauseId?: string | null;
+  notes?: string;
+  sortOrder?: number;
+}
+
+export interface SiteMeasurementWithClause extends SiteMeasurement {
+  linkedClause?: {
+    id: string;
+    code: string;
+    title: string;
+  } | null;
+}
+
+export interface ISiteMeasurementRepository {
+  create(input: CreateSiteMeasurementInput): Promise<SiteMeasurementWithClause>;
+  findById(id: string): Promise<SiteMeasurementWithClause | null>;
+  findByInspectionId(inspectionId: string): Promise<SiteMeasurementWithClause[]>;
+  update(id: string, input: UpdateSiteMeasurementInput): Promise<SiteMeasurementWithClause>;
+  delete(id: string): Promise<void>;
+}

--- a/api/src/repositories/prisma/site-measurement.ts
+++ b/api/src/repositories/prisma/site-measurement.ts
@@ -1,0 +1,74 @@
+import type { PrismaClient } from '@prisma/client';
+import type {
+  ISiteMeasurementRepository,
+  CreateSiteMeasurementInput,
+  UpdateSiteMeasurementInput,
+  SiteMeasurementWithClause,
+} from '../interfaces/site-measurement.js';
+
+const clauseInclude = {
+  linkedClause: {
+    select: {
+      id: true,
+      code: true,
+      title: true,
+    },
+  },
+};
+
+export class PrismaSiteMeasurementRepository implements ISiteMeasurementRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateSiteMeasurementInput): Promise<SiteMeasurementWithClause> {
+    return this.prisma.siteMeasurement.create({
+      data: {
+        inspectionId: input.inspectionId,
+        type: input.type,
+        location: input.location,
+        value: input.value,
+        unit: input.unit,
+        linkedClauseId: input.linkedClauseId,
+        notes: input.notes,
+      },
+      include: clauseInclude,
+    });
+  }
+
+  async findById(id: string): Promise<SiteMeasurementWithClause | null> {
+    return this.prisma.siteMeasurement.findUnique({
+      where: { id },
+      include: clauseInclude,
+    });
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<SiteMeasurementWithClause[]> {
+    return this.prisma.siteMeasurement.findMany({
+      where: { inspectionId },
+      include: clauseInclude,
+      orderBy: { sortOrder: 'asc' },
+    });
+  }
+
+  async update(id: string, input: UpdateSiteMeasurementInput): Promise<SiteMeasurementWithClause> {
+    return this.prisma.siteMeasurement.update({
+      where: { id },
+      data: {
+        type: input.type,
+        location: input.location,
+        value: input.value,
+        unit: input.unit,
+        result: input.result,
+        linkedClauseId: input.linkedClauseId,
+        notes: input.notes,
+        sortOrder: input.sortOrder,
+      },
+      include: clauseInclude,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.siteMeasurement.delete({
+      where: { id },
+    });
+  }
+}

--- a/api/src/routes/site-measurements.ts
+++ b/api/src/routes/site-measurements.ts
@@ -1,0 +1,169 @@
+import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaSiteMeasurementRepository } from '../repositories/prisma/site-measurement.js';
+import { SiteMeasurementService, SiteMeasurementNotFoundError } from '../services/site-measurement.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaSiteMeasurementRepository(prisma);
+const service = new SiteMeasurementService(repository);
+
+export const siteMeasurementsRouter: RouterType = Router();
+
+// Enums for validation
+const MeasurementTypeEnum = z.enum([
+  'MOISTURE_CONTENT', 'SLOPE_FALL', 'DIMENSION', 'CLEARANCE', 'TEMPERATURE', 'OTHER'
+]);
+const MeasurementUnitEnum = z.enum([
+  'PERCENT', 'MM_PER_M', 'MM', 'CM', 'M', 'CELSIUS'
+]);
+const MeasurementResultEnum = z.enum(['PENDING', 'PASS', 'FAIL']);
+
+// Validation schemas
+const CreateMeasurementSchema = z.object({
+  type: MeasurementTypeEnum,
+  location: z.string().min(1),
+  value: z.number(),
+  unit: MeasurementUnitEnum,
+  linkedClauseId: z.string().uuid().optional(),
+  notes: z.string().optional(),
+});
+
+const UpdateMeasurementSchema = z.object({
+  type: MeasurementTypeEnum.optional(),
+  location: z.string().min(1).optional(),
+  value: z.number().optional(),
+  unit: MeasurementUnitEnum.optional(),
+  result: MeasurementResultEnum.optional(),
+  linkedClauseId: z.string().uuid().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  sortOrder: z.number().int().optional(),
+});
+
+// POST /api/site-inspections/:inspectionId/measurements - Create measurement
+siteMeasurementsRouter.post(
+  '/site-inspections/:inspectionId/measurements',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const parsed = CreateMeasurementSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const measurement = await service.create({
+        inspectionId,
+        ...parsed.data,
+      });
+
+      res.status(201).json(measurement);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/site-inspections/:inspectionId/measurements - List measurements
+siteMeasurementsRouter.get(
+  '/site-inspections/:inspectionId/measurements',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const inspectionId = req.params.inspectionId as string;
+      const measurements = await service.findByInspectionId(inspectionId);
+      res.json(measurements);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/measurements/:id - Get single measurement
+siteMeasurementsRouter.get(
+  '/measurements/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const measurement = await service.findById(id);
+      res.json(measurement);
+    } catch (error) {
+      if (error instanceof SiteMeasurementNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// PUT /api/measurements/:id - Update measurement
+siteMeasurementsRouter.put(
+  '/measurements/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const parsed = UpdateMeasurementSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const updateData = {
+        ...parsed.data,
+        linkedClauseId: parsed.data.linkedClauseId === null ? undefined : parsed.data.linkedClauseId,
+        notes: parsed.data.notes === null ? undefined : parsed.data.notes,
+      };
+
+      const measurement = await service.update(id, updateData);
+      res.json(measurement);
+    } catch (error) {
+      if (error instanceof SiteMeasurementNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/measurements/:id - Delete measurement
+siteMeasurementsRouter.delete(
+  '/measurements/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      await service.delete(id);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof SiteMeasurementNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/measurements/acceptable-ranges - Get acceptable ranges for all types
+siteMeasurementsRouter.get(
+  '/measurements/acceptable-ranges',
+  (_req: Request, res: Response) => {
+    const ranges = {
+      MOISTURE_CONTENT: { max: 18, unit: 'PERCENT', description: '< 18%' },
+      SLOPE_FALL: { min: 10, unit: 'MM_PER_M', description: '≥ 1:100 (10mm/m)' },
+      DIMENSION: null,
+      CLEARANCE: null,
+      TEMPERATURE: null,
+      OTHER: null,
+    };
+    res.json(ranges);
+  }
+);

--- a/api/src/services/site-measurement.ts
+++ b/api/src/services/site-measurement.ts
@@ -1,0 +1,106 @@
+import type { MeasurementType, MeasurementUnit, MeasurementResult } from '@prisma/client';
+import type {
+  ISiteMeasurementRepository,
+  CreateSiteMeasurementInput,
+  UpdateSiteMeasurementInput,
+  SiteMeasurementWithClause,
+} from '../repositories/interfaces/site-measurement.js';
+
+export class SiteMeasurementNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Site measurement not found: ${id}`);
+    this.name = 'SiteMeasurementNotFoundError';
+  }
+}
+
+// Acceptable ranges for auto-evaluation
+const ACCEPTABLE_RANGES: Partial<Record<MeasurementType, { max?: number; min?: number }>> = {
+  MOISTURE_CONTENT: { max: 18 },      // < 18% is acceptable
+  SLOPE_FALL: { min: 10 },            // ≥ 1:100 (10mm/m) is acceptable
+};
+
+export class SiteMeasurementService {
+  constructor(private repository: ISiteMeasurementRepository) {}
+
+  async create(input: CreateSiteMeasurementInput): Promise<SiteMeasurementWithClause> {
+    const measurement = await this.repository.create(input);
+    
+    // Auto-evaluate if we have acceptable ranges
+    const result = this.evaluate(input.type, input.value);
+    if (result !== 'PENDING') {
+      return this.repository.update(measurement.id, { result });
+    }
+    
+    return measurement;
+  }
+
+  async findById(id: string): Promise<SiteMeasurementWithClause> {
+    const measurement = await this.repository.findById(id);
+    if (!measurement) {
+      throw new SiteMeasurementNotFoundError(id);
+    }
+    return measurement;
+  }
+
+  async findByInspectionId(inspectionId: string): Promise<SiteMeasurementWithClause[]> {
+    return this.repository.findByInspectionId(inspectionId);
+  }
+
+  async update(id: string, input: UpdateSiteMeasurementInput): Promise<SiteMeasurementWithClause> {
+    const existing = await this.findById(id);
+    
+    // Re-evaluate if value or type changed
+    if (input.value !== undefined || input.type !== undefined) {
+      const type = input.type || existing.type;
+      const value = input.value !== undefined ? input.value : existing.value;
+      const result = this.evaluate(type, value);
+      if (result !== 'PENDING') {
+        input.result = result;
+      }
+    }
+    
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+
+  /**
+   * Evaluate measurement against acceptable ranges
+   */
+  private evaluate(type: MeasurementType, value: number): MeasurementResult {
+    const range = ACCEPTABLE_RANGES[type];
+    if (!range) {
+      return 'PENDING'; // No auto-evaluation for this type
+    }
+
+    if (range.max !== undefined && value > range.max) {
+      return 'FAIL';
+    }
+    if (range.min !== undefined && value < range.min) {
+      return 'FAIL';
+    }
+    
+    return 'PASS';
+  }
+
+  /**
+   * Get acceptable range info for a measurement type
+   */
+  getAcceptableRange(type: MeasurementType): { max?: number; min?: number; description: string } | null {
+    const range = ACCEPTABLE_RANGES[type];
+    if (!range) return null;
+
+    let description = '';
+    if (range.max !== undefined) {
+      description = `< ${range.max}`;
+    }
+    if (range.min !== undefined) {
+      description = `≥ ${range.min}`;
+    }
+
+    return { ...range, description };
+  }
+}


### PR DESCRIPTION
Closes #164

## Summary
Implement structured site measurements with auto-evaluation.

## Changes
- Added SiteMeasurement entity with:
  - Types: MOISTURE_CONTENT, SLOPE_FALL, DIMENSION, CLEARANCE, TEMPERATURE, OTHER
  - Units: PERCENT, MM_PER_M, MM, CM, M, CELSIUS
  - Auto-evaluation for moisture (< 18% = PASS) and slope (≥ 10mm/m = PASS)
  - Link to BuildingCodeClause

- API endpoints:
  - POST /api/site-inspections/:id/measurements
  - GET /api/site-inspections/:id/measurements
  - GET /api/measurements/:id
  - PUT /api/measurements/:id
  - DELETE /api/measurements/:id
  - GET /api/measurements/acceptable-ranges

## Testing
- ✅ 13 new tests (164 total)
- ✅ TypeScript compiles
- ✅ Lint passes