### PR TITLE
fix: add Prisma schema validation to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,6 +8,11 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 echo "📦 Checking api..."
 cd "$REPO_ROOT/api" && npm run typecheck && npm run lint || exit 1
 
+# Validate Prisma schema (use dummy URL for syntax check only)
+echo "🔍 Validating Prisma schema..."
+cd "$REPO_ROOT/api"
+DATABASE_URL="postgresql://localhost/dummy" npx prisma validate || exit 1
+
 # Check web
 echo "📦 Checking web..."
 cd "$REPO_ROOT/web" && npm run typecheck && npm run lint || exit 1


### PR DESCRIPTION
## Summary
Adds Prisma schema validation to pre-push hook to catch syntax errors before CI.

## Changes
- Validates `schema.prisma` syntax on every push
- Uses dummy DATABASE_URL (just checks syntax, no DB connection)

## Note
Full drift check (migration ↔ schema mismatch) requires a shadow database.
That's better suited for CI than local hooks.

## Testing
- [x] Pre-push runs `prisma validate`
- [x] Invalid schema blocks push