### PR TITLE
fix(cd): shell syntax error in DB connectivity check

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,7 @@ jobs:
           # Run a simple prisma query to ensure DB is awake and responsive
           for i in 1 2 3; do
             echo "Attempt $i: Testing database connection..."
-            if timeout 60 flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && npx prisma db execute --stdin <<< \"SELECT 1;\"'" 2>&1; then
+            if timeout 60 flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && echo \"SELECT 1;\" | npx prisma db execute --stdin'" 2>&1; then
               echo "Database connection verified!"
               break
             fi


### PR DESCRIPTION
## Bug

The `<<<` heredoc syntax doesn't work in `sh` (Alpine uses `sh`, not `bash`).

**Error from logs:**
```
sh: syntax error: unexpected redirection
Error: ssh shell: Process exited with status 2
```

## Fix

Changed from:
```sh
npx prisma db execute --stdin <<< "SELECT 1;"
```

To POSIX-compatible:
```sh
echo "SELECT 1;" | npx prisma db execute --stdin
```

---

Fixes #233