### PR TITLE
chore: add auto-rebase workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,18 @@
+name: Auto Rebase
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  rebase-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rebase open PRs
+        uses: peter-evans/rebase@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: develop
+          exclude-drafts: true
+          exclude-labels: no-auto-rebase


### PR DESCRIPTION
## Summary
Automatically rebases open PRs when develop is updated.

## How it works
- Triggers on every push to develop
- Rebases all open PRs targeting develop
- Excludes draft PRs
- Add `no-auto-rebase` label to skip specific PRs

## Benefits
- No more manual rebasing after merges
- Keeps PRs up-to-date automatically
- Catches conflicts earlier