### PR TITLE
fix: add permissions to auto-rebase workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   rebase-prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GITHUB_TOKEN needs explicit write permissions for contents and PRs to push rebased branches.