### PR TITLE
[Sam] feat(web): implement document upload and management

### DIFF
--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -50,9 +50,12 @@ interface Project {
   documents?: Array<{
     id: string;
     appendixLetter: string | null;
+    filename: string;
     documentType: string;
     description: string;
     status: string;
+    linkedClauses: string[];
+    createdAt: string;
   }>;
   photos?: Array<{
     id: string;

--- a/web/components/confirm-dialog.tsx
+++ b/web/components/confirm-dialog.tsx
@@ -14,7 +14,7 @@ interface ConfirmDialogProps {
 }
 
 /**
- * Confirm Dialog Component — Issue #187
+ * Confirm Dialog Component — Issue #187, #188
  * 
  * Modal dialog for confirming destructive actions.
  */

--- a/web/components/document-list.tsx
+++ b/web/components/document-list.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { ConfirmDialog } from './confirm-dialog';
+
+export interface Document {
+  id: string;
+  appendixLetter: string | null;
+  filename: string;
+  documentType: string;
+  description: string;
+  status: string;
+  linkedClauses: string[];
+  createdAt: string;
+}
+
+interface DocumentListProps {
+  documents: Document[];
+  onUpdate: (docId: string, data: Partial<Document>) => Promise<void>;
+  onDelete: (docId: string) => Promise<void>;
+  isLoading?: boolean;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+const DOCUMENT_TYPES = [
+  { value: 'PS1', label: 'PS1 - Design Review' },
+  { value: 'PS2', label: 'PS2 - Design Certificate' },
+  { value: 'PS3', label: 'PS3 - Construction Review' },
+  { value: 'PS4', label: 'PS4 - Construction Certificate' },
+  { value: 'COC', label: 'Code Compliance Certificate' },
+  { value: 'ESC', label: 'Electrical Safety Certificate' },
+  { value: 'WARRANTY', label: 'Warranty Document' },
+  { value: 'INVOICE', label: 'Invoice' },
+  { value: 'DRAWING', label: 'Drawing/Plan' },
+  { value: 'REPORT', label: 'Report' },
+  { value: 'FLOOD_TEST', label: 'Flood Test Report' },
+  { value: 'PROPERTY_FILE', label: 'Property File Document' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+const STATUS_OPTIONS = [
+  { value: 'REQUIRED', label: 'Required', color: 'bg-yellow-100 text-yellow-800' },
+  { value: 'RECEIVED', label: 'Received', color: 'bg-green-100 text-green-800' },
+  { value: 'OUTSTANDING', label: 'Outstanding', color: 'bg-red-100 text-red-800' },
+  { value: 'NA', label: 'N/A', color: 'bg-gray-100 text-gray-800' },
+];
+
+/**
+ * Document List Component — Issue #188
+ * 
+ * List of documents with inline editing for description, type, and status.
+ */
+export function DocumentList({
+  documents,
+  onUpdate,
+  onDelete,
+  isLoading = false,
+}: DocumentListProps): React.ReactElement {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState<string>('');
+  const [deleteDoc, setDeleteDoc] = useState<Document | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleEdit = (doc: Document, field: string): void => {
+    setEditingId(doc.id);
+    setEditingField(field);
+    setEditValue(doc[field as keyof Document] as string);
+  };
+
+  const handleSave = useCallback(
+    async (docId: string, field: string, value: string): Promise<void> => {
+      setIsSaving(true);
+      try {
+        await onUpdate(docId, { [field]: value });
+      } finally {
+        setIsSaving(false);
+        setEditingId(null);
+        setEditingField(null);
+      }
+    },
+    [onUpdate]
+  );
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent,
+    docId: string,
+    field: string
+  ): void => {
+    if (e.key === 'Enter') {
+      handleSave(docId, field, editValue);
+    } else if (e.key === 'Escape') {
+      setEditingId(null);
+      setEditingField(null);
+    }
+  };
+
+  const handleDeleteConfirm = useCallback(async (): Promise<void> => {
+    if (!deleteDoc) return;
+    setIsSaving(true);
+    try {
+      await onDelete(deleteDoc.id);
+    } finally {
+      setIsSaving(false);
+      setDeleteDoc(null);
+    }
+  }, [deleteDoc, onDelete]);
+
+  const getStatusColor = (status: string): string => {
+    return STATUS_OPTIONS.find((s) => s.value === status)?.color || 'bg-gray-100 text-gray-800';
+  };
+
+  const getDocumentTypeLabel = (type: string): string => {
+    return DOCUMENT_TYPES.find((t) => t.value === type)?.label || type;
+  };
+
+  if (documents.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        <svg
+          className="w-10 h-10 mx-auto mb-3 text-gray-300"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        <p>No documents uploaded</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`overflow-x-auto ${
+          isLoading || isSaving ? 'opacity-50 pointer-events-none' : ''
+        }`}
+      >
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="py-2 pr-4">Appendix</th>
+              <th className="py-2 pr-4">Type</th>
+              <th className="py-2 pr-4">Description</th>
+              <th className="py-2 pr-4">Status</th>
+              <th className="py-2 w-10"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {documents.map((doc) => (
+              <tr key={doc.id} className="text-sm group">
+                {/* Appendix */}
+                <td className="py-2 pr-4 font-medium">
+                  {doc.appendixLetter || '—'}
+                </td>
+
+                {/* Type */}
+                <td className="py-2 pr-4">
+                  {editingId === doc.id && editingField === 'documentType' ? (
+                    <select
+                      value={editValue}
+                      onChange={(e) => {
+                        setEditValue(e.target.value);
+                        handleSave(doc.id, 'documentType', e.target.value);
+                      }}
+                      onBlur={() => {
+                        setEditingId(null);
+                        setEditingField(null);
+                      }}
+                      autoFocus
+                      className="text-sm border border-blue-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    >
+                      {DOCUMENT_TYPES.map((type) => (
+                        <option key={type.value} value={type.value}>
+                          {type.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(doc, 'documentType')}
+                      className="text-left hover:text-blue-600"
+                      title="Click to change type"
+                    >
+                      {getDocumentTypeLabel(doc.documentType)}
+                    </button>
+                  )}
+                </td>
+
+                {/* Description */}
+                <td className="py-2 pr-4 max-w-xs">
+                  {editingId === doc.id && editingField === 'description' ? (
+                    <input
+                      type="text"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={() => handleSave(doc.id, 'description', editValue)}
+                      onKeyDown={(e) => handleKeyDown(e, doc.id, 'description')}
+                      autoFocus
+                      className="w-full text-sm border border-blue-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(doc, 'description')}
+                      className="text-left truncate max-w-full hover:text-blue-600"
+                      title="Click to edit description"
+                    >
+                      {doc.description || <span className="text-gray-400 italic">Add description...</span>}
+                    </button>
+                  )}
+                </td>
+
+                {/* Status */}
+                <td className="py-2 pr-4">
+                  {editingId === doc.id && editingField === 'status' ? (
+                    <select
+                      value={editValue}
+                      onChange={(e) => {
+                        setEditValue(e.target.value);
+                        handleSave(doc.id, 'status', e.target.value);
+                      }}
+                      onBlur={() => {
+                        setEditingId(null);
+                        setEditingField(null);
+                      }}
+                      autoFocus
+                      className="text-sm border border-blue-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    >
+                      {STATUS_OPTIONS.map((status) => (
+                        <option key={status.value} value={status.value}>
+                          {status.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(doc, 'status')}
+                      className={`px-2 py-0.5 rounded-full text-xs font-medium ${getStatusColor(
+                        doc.status
+                      )}`}
+                      title="Click to change status"
+                    >
+                      {STATUS_OPTIONS.find((s) => s.value === doc.status)?.label || doc.status}
+                    </button>
+                  )}
+                </td>
+
+                {/* Actions */}
+                <td className="py-2">
+                  <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <a
+                      href={`${API_URL}/api/documents/${doc.id}/download`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="p-1 text-gray-500 hover:text-blue-600"
+                      title="Download"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => setDeleteDoc(doc)}
+                      className="p-1 text-gray-500 hover:text-red-600"
+                      title="Delete"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={!!deleteDoc}
+        title="Delete Document"
+        message={`Are you sure you want to delete "${deleteDoc?.description || deleteDoc?.filename}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteDoc(null)}
+      />
+    </>
+  );
+}

--- a/web/components/document-upload.tsx
+++ b/web/components/document-upload.tsx
@@ -44,15 +44,18 @@ export function DocumentUpload({
 
   const maxSizeBytes = maxSizeMB * 1024 * 1024;
 
-  const validateFile = (file: File): string | null => {
-    if (!acceptedTypes.includes(file.type)) {
-      return `Invalid file type: ${file.type}`;
-    }
-    if (file.size > maxSizeBytes) {
-      return `File too large: ${(file.size / 1024 / 1024).toFixed(1)}MB (max ${maxSizeMB}MB)`;
-    }
-    return null;
-  };
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      if (!acceptedTypes.includes(file.type)) {
+        return `Invalid file type: ${file.type}`;
+      }
+      if (file.size > maxSizeBytes) {
+        return `File too large: ${(file.size / 1024 / 1024).toFixed(1)}MB (max ${maxSizeMB}MB)`;
+      }
+      return null;
+    },
+    [acceptedTypes, maxSizeBytes, maxSizeMB]
+  );
 
   const uploadFile = useCallback(
     async (file: File): Promise<void> => {
@@ -133,7 +136,7 @@ export function DocumentUpload({
         );
       }
     },
-    [projectId, onUploadComplete, maxSizeBytes, acceptedTypes]
+    [projectId, onUploadComplete, validateFile]
   );
 
   const handleFiles = useCallback(

--- a/web/components/document-upload.tsx
+++ b/web/components/document-upload.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+
+interface UploadingFile {
+  id: string;
+  name: string;
+  progress: number;
+  error?: string;
+}
+
+interface DocumentUploadProps {
+  projectId: string;
+  onUploadComplete: () => void;
+  acceptedTypes?: string[];
+  maxSizeMB?: number;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+const DEFAULT_ACCEPTED_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+
+/**
+ * Document Upload Component — Issue #188
+ * 
+ * Drag & drop upload zone with progress indicators.
+ */
+export function DocumentUpload({
+  projectId,
+  onUploadComplete,
+  acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+  maxSizeMB = 25,
+}: DocumentUploadProps): React.ReactElement {
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const maxSizeBytes = maxSizeMB * 1024 * 1024;
+
+  const validateFile = (file: File): string | null => {
+    if (!acceptedTypes.includes(file.type)) {
+      return `Invalid file type: ${file.type}`;
+    }
+    if (file.size > maxSizeBytes) {
+      return `File too large: ${(file.size / 1024 / 1024).toFixed(1)}MB (max ${maxSizeMB}MB)`;
+    }
+    return null;
+  };
+
+  const uploadFile = useCallback(
+    async (file: File): Promise<void> => {
+      const uploadId = crypto.randomUUID();
+
+      // Validate file
+      const error = validateFile(file);
+      if (error) {
+        setUploadingFiles((prev) => [
+          ...prev,
+          { id: uploadId, name: file.name, progress: 0, error },
+        ]);
+        return;
+      }
+
+      // Add to uploading list
+      setUploadingFiles((prev) => [
+        ...prev,
+        { id: uploadId, name: file.name, progress: 0 },
+      ]);
+
+      try {
+        // Create form data
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('description', file.name);
+
+        // Upload with progress tracking via XMLHttpRequest
+        await new Promise<void>((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+
+          xhr.upload.addEventListener('progress', (e) => {
+            if (e.lengthComputable) {
+              const progress = Math.round((e.loaded / e.total) * 100);
+              setUploadingFiles((prev) =>
+                prev.map((f) =>
+                  f.id === uploadId ? { ...f, progress } : f
+                )
+              );
+            }
+          });
+
+          xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve();
+            } else {
+              reject(new Error(`Upload failed: ${xhr.status}`));
+            }
+          });
+
+          xhr.addEventListener('error', () => {
+            reject(new Error('Network error'));
+          });
+
+          xhr.open('POST', `${API_URL}/api/projects/${projectId}/documents`);
+          xhr.withCredentials = true;
+          xhr.send(formData);
+        });
+
+        // Success - remove from list after delay
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.id === uploadId ? { ...f, progress: 100 } : f
+          )
+        );
+
+        setTimeout(() => {
+          setUploadingFiles((prev) => prev.filter((f) => f.id !== uploadId));
+          onUploadComplete();
+        }, 1000);
+      } catch (err) {
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.id === uploadId
+              ? { ...f, error: err instanceof Error ? err.message : 'Upload failed' }
+              : f
+          )
+        );
+      }
+    },
+    [projectId, onUploadComplete, maxSizeBytes, acceptedTypes]
+  );
+
+  const handleFiles = useCallback(
+    (files: FileList | null): void => {
+      if (!files) return;
+      Array.from(files).forEach(uploadFile);
+    },
+    [uploadFile]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent): void => {
+      e.preventDefault();
+      setIsDragging(false);
+      handleFiles(e.dataTransfer.files);
+    },
+    [handleFiles]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent): void => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent): void => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleClick = (): void => {
+    fileInputRef.current?.click();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    handleFiles(e.target.files);
+    // Reset input so same file can be selected again
+    e.target.value = '';
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Drop zone */}
+      <div
+        onClick={handleClick}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+          isDragging
+            ? 'border-blue-500 bg-blue-50'
+            : 'border-gray-300 hover:border-gray-400'
+        }`}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={acceptedTypes.join(',')}
+          onChange={handleInputChange}
+          className="hidden"
+        />
+        <svg
+          className={`w-10 h-10 mx-auto mb-3 ${
+            isDragging ? 'text-blue-500' : 'text-gray-400'
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+          />
+        </svg>
+        <p className="text-sm text-gray-600">
+          <span className="font-medium text-blue-600">Click to upload</span> or
+          drag and drop
+        </p>
+        <p className="text-xs text-gray-500 mt-1">
+          PDF, Word, or images up to {maxSizeMB}MB
+        </p>
+      </div>
+
+      {/* Upload progress */}
+      {uploadingFiles.length > 0 && (
+        <div className="space-y-2">
+          {uploadingFiles.map((file) => (
+            <div
+              key={file.id}
+              className={`p-3 rounded-lg ${
+                file.error ? 'bg-red-50' : 'bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm font-medium text-gray-700 truncate">
+                  {file.name}
+                </span>
+                {file.error ? (
+                  <span className="text-xs text-red-600">{file.error}</span>
+                ) : (
+                  <span className="text-xs text-gray-500">{file.progress}%</span>
+                )}
+              </div>
+              {!file.error && (
+                <div className="w-full bg-gray-200 rounded-full h-1.5">
+                  <div
+                    className="bg-blue-600 h-1.5 rounded-full transition-all duration-300"
+                    style={{ width: `${file.progress}%` }}
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements document upload with drag & drop and inline management.

Closes #188

## Changes

### New Components
- `DocumentUpload` — drag & drop upload zone with progress indicators
- `DocumentList` — list with inline editing for type, description, status
- `ConfirmDialog` — reusable delete confirmation modal

### Features
- Drag & drop file upload
- Click to browse files
- Multi-file upload with progress indicators
- File type validation (PDF, Word, images)
- Max file size: 25MB
- Inline description editing (click to edit)
- Document type dropdown (PS1, PS2, PS3, PS4, CoC, etc.)
- Status selection (Required / Received / Outstanding / N/A)
- Delete with confirmation dialog
- Download link

## Acceptance Criteria
- [x] Drag & drop upload zone
- [x] Click to browse files
- [x] Multi-file upload support
- [x] Progress indicator during upload
- [x] Show uploaded documents in list
- [x] Edit document description inline
- [x] Set document type from dropdown (PS1, PS3, CoC, etc.)
- [x] Set document status (Required / Received / Outstanding)
- [x] Delete document with confirmation

## Not Implemented (future enhancement)
- [ ] Link documents to Building Code clauses (needs clause picker UI)

## Testing
- Lint ✅
- Typecheck ✅