### PR TITLE
[Archer] fix(cd): pin flyctl-actions to v1.5 for stability

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only


### PR DESCRIPTION
## Summary

**P1 Hotfix** — Addresses flyctl SSH crashes blocking CD pipeline.

## Problem

CD failing with flyctl runtime error:
```
runtime error: invalid memory address or nil pointer dereference
github.com/superfly/flyctl/internal/command/ssh.selectContainer
```

## Root Cause

Using `superfly/flyctl-actions/setup-flyctl@master` pulls bleeding-edge flyctl which has SSH bugs.

## Fix

Pin to stable release `@1.5` instead of `@master`.

## Testing

This will be tested automatically when merged — CD will run with the pinned version.

---
Fixes #233