### PR TITLE
[Archer] fix(api): increase Fly.io RAM to 512MB for stable migrations

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -24,6 +24,6 @@ primary_region = "syd"
     soft_limit = 20
 
 [[vm]]
-  memory = "256mb"
+  memory = "512mb"
   cpu_kind = "shared"
   cpus = 1


### PR DESCRIPTION
## Summary

Increase Fly.io machine memory to prevent SSH session disconnections during migrations.

## Problem

CD migrations failing with:
```
Error: ssh shell: session forcibly closed; the remote process may still be running
```

The 256MB machine is likely running out of memory during Prisma migrations, causing the SSH session to be forcibly terminated.

## Fix

Scale to 512MB RAM (~$5/mo increase).

## Related

- Per platform decision #254 (stay on Fly.io, scale RAM)
- Follows flyctl v1.5 fix (#268) which resolved the nil pointer crash

---
Fixes #233