### PR TITLE
[Archer] fix(cd): remove broken db connectivity check

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,22 +62,6 @@ jobs:
         env:
           API_URL: ${{ env.API_URL }}
 
-      - name: Verify database connectivity
-        run: |
-          echo "Verifying database connectivity before migrations..."
-          # Run a simple prisma query to ensure DB is awake and responsive
-          for i in 1 2 3; do
-            echo "Attempt $i: Testing database connection..."
-            if timeout 60 flyctl ssh console --app ai-inspection-api-test -C "sh -c 'cd /app && echo \"SELECT 1;\" | npx prisma db execute --stdin'" 2>&1; then
-              echo "Database connection verified!"
-              break
-            fi
-            echo "Connection test failed, waiting 10s..."
-            sleep 10
-          done
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
       - name: Run database migrations
         run: |
           echo "Running Prisma migrations..."


### PR DESCRIPTION
## Summary
Removes the "Verify database connectivity" step from CD workflow.

**Problem:** SSH shell doesn't inherit app env vars, so `DATABASE_URL` isn't available for prisma command.

**Why safe to remove:**
- API already verifies DB connection on startup (shows "Database connected" ✅)
- Migrations step has its own retry logic
- Wake database step ensures DB is responsive

Closes #233