### PR TITLE
[Sam] chore(web): add monorepo install command to vercel.json

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "cd .. && npm install",
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "framework": "nextjs",


### PR DESCRIPTION
## Summary
Adds `installCommand` to `web/vercel.json` for proper npm workspaces monorepo support.

## Changes
- Added `installCommand: "cd .. && npm install"` to install from root directory
- This resolves workspace dependencies (e.g., `@ai-inspection/shared`) when Vercel deploys from `web/`

## Context
Suggested by Archer for proper monorepo settings.

---
👩‍💻 **Sam**