### PR TITLE
[Alex] feat(api): add version info to /health endpoint (#284)

### DIFF
--- a/api/src/__tests__/health.test.ts
+++ b/api/src/__tests__/health.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { version } from '../config/version.js';
+
+describe('Health Endpoint', () => {
+  describe('Version info', () => {
+    it('should have required version fields', () => {
+      expect(version).toHaveProperty('sha');
+      expect(version).toHaveProperty('shortSha');
+      expect(version).toHaveProperty('branch');
+      expect(version).toHaveProperty('buildTime');
+    });
+
+    it('should have shortSha as 7 characters or "unknown"', () => {
+      if (version.sha === 'unknown') {
+        expect(version.shortSha).toBe('unknown');
+      } else {
+        expect(version.shortSha).toHaveLength(7);
+      }
+    });
+
+    it('should have valid buildTime format', () => {
+      // Should be ISO 8601 format
+      expect(() => new Date(version.buildTime)).not.toThrow();
+      expect(new Date(version.buildTime).toISOString()).toBeTruthy();
+    });
+
+    it('should default to unknown for missing env vars', () => {
+      // In test environment, env vars are typically not set
+      expect(['unknown', version.sha]).toContain(version.sha);
+      expect(['unknown', version.branch]).toContain(version.branch);
+    });
+  });
+});

--- a/api/src/config/version.ts
+++ b/api/src/config/version.ts
@@ -1,0 +1,15 @@
+/**
+ * Version information for health endpoint
+ * 
+ * Railway auto-injects RAILWAY_GIT_COMMIT_SHA and RAILWAY_GIT_BRANCH
+ * For local dev, falls back to 'unknown'
+ */
+
+const sha = process.env.GIT_SHA || process.env.RAILWAY_GIT_COMMIT_SHA || 'unknown';
+
+export const version = {
+  sha,
+  shortSha: sha.slice(0, 7),
+  branch: process.env.GIT_BRANCH || process.env.RAILWAY_GIT_BRANCH || 'unknown',
+  buildTime: process.env.BUILD_TIME || new Date().toISOString(),
+};

--- a/api/src/routes/health.ts
+++ b/api/src/routes/health.ts
@@ -1,7 +1,8 @@
 import { Router, type Router as RouterType } from 'express';
+import { version } from '../config/version.js';
 
 export const healthRouter: RouterType = Router();
 
 healthRouter.get('/', (_req, res) => {
-  res.json({ status: 'ok' });
+  res.json({ status: 'ok', version });
 });


### PR DESCRIPTION
Closes #284

## Summary
Add git SHA and build time to the /health endpoint response.

## Changes
- Added `src/config/version.ts`:
  - `sha` — full git commit SHA
  - `shortSha` — first 7 characters
  - `branch` — git branch name
  - `buildTime` — ISO 8601 timestamp

- Updated `/health` endpoint response:
```json
{
  "status": "ok",
  "version": {
    "sha": "abc1234def5678",
    "shortSha": "abc1234",
    "branch": "develop",
    "buildTime": "2026-02-20T15:00:00Z"
  }
}
```

## Environment Variables
- Uses `RAILWAY_GIT_COMMIT_SHA` and `RAILWAY_GIT_BRANCH` (auto-injected by Railway)
- Falls back to `GIT_SHA` / `GIT_BRANCH` / `BUILD_TIME` if set manually
- Defaults to 'unknown' for local dev

## Testing
- ✅ 4 new tests (211 total)
- ✅ TypeScript compiles
- ✅ Lint passes