### PR TITLE
[Sam] feat(web): add version info and UI display

### DIFF
--- a/web/app/api/version/route.ts
+++ b/web/app/api/version/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export function GET(): NextResponse {
+  return NextResponse.json({
+    sha: process.env.NEXT_PUBLIC_GIT_SHA,
+    shortSha: process.env.NEXT_PUBLIC_GIT_SHA?.slice(0, 7),
+    branch: process.env.NEXT_PUBLIC_GIT_BRANCH,
+    buildTime: process.env.NEXT_PUBLIC_BUILD_TIME,
+  });
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth";
 import { AppHeader } from "@/components/app-header";
+import { VersionBadge } from "@/components/version-badge";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,13 +28,20 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50 min-h-screen`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
       >
         <AuthProvider>
-          <AppHeader />
-          <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-            {children}
-          </main>
+          <div className="flex min-h-screen flex-col">
+            <AppHeader />
+            <main className="mx-auto max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+              {children}
+            </main>
+            <footer className="border-t border-gray-200 bg-white py-4">
+              <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-right">
+                <VersionBadge />
+              </div>
+            </footer>
+          </div>
         </AuthProvider>
       </body>
     </html>

--- a/web/components/version-badge.tsx
+++ b/web/components/version-badge.tsx
@@ -1,0 +1,10 @@
+export function VersionBadge(): React.ReactElement {
+  const sha = process.env.NEXT_PUBLIC_GIT_SHA?.slice(0, 7) || 'local';
+  const branch = process.env.NEXT_PUBLIC_GIT_BRANCH || 'local';
+  
+  return (
+    <span className="text-xs text-gray-400" title={`Branch: ${branch}`}>
+      v: {sha}
+    </span>
+  );
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_GIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA || 'local',
+    NEXT_PUBLIC_GIT_BRANCH: process.env.VERCEL_GIT_COMMIT_REF || 'local',
+    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Exposes git SHA in the web app and displays it in the UI footer for easy debugging.

## Changes
- **next.config.ts**: Inject `NEXT_PUBLIC_GIT_SHA`, `NEXT_PUBLIC_GIT_BRANCH`, and `NEXT_PUBLIC_BUILD_TIME` at build time (uses Vercel env vars when deployed)
- **app/api/version/route.ts**: API endpoint returning version info as JSON
- **components/version-badge.tsx**: Simple component displaying short SHA with branch tooltip
- **app/layout.tsx**: Added footer with VersionBadge

## Testing
- Locally shows "v: local"
- On Vercel, will show first 7 chars of commit SHA
- `/api/version` returns full version info object

Closes #285

---
👩‍💻 **Sam**