### PR TITLE
[Sam] fix(web): widen login/register form cards

### DIFF
--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -39,7 +39,7 @@ export default function LoginPage(): React.ReactElement {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="max-w-md w-full">
+      <div className="max-w-lg w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-900">AI Inspection</h1>
           <p className="mt-2 text-gray-600">Sign in to your account</p>

--- a/web/app/register/page.tsx
+++ b/web/app/register/page.tsx
@@ -85,7 +85,7 @@ export default function RegisterPage(): React.ReactElement {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="max-w-md w-full">
+      <div className="max-w-lg w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-900">AI Inspection</h1>
           <p className="mt-2 text-gray-600">Create your account</p>


### PR DESCRIPTION
## Summary
Login and register forms looked too narrow on wide screens.

## Changes
- Changed `max-w-md` (448px) → `max-w-lg` (512px) on both pages

---
👩‍💻 **Sam**