### PR TITLE
[Alex] fix(api): remove unused imports and functions (#315)

### DIFF
--- a/api/src/routes/project-photos.ts
+++ b/api/src/routes/project-photos.ts
@@ -13,8 +13,6 @@ import {
   uploadPhotoWithThumbnail,
   getPresignedUrl,
   deletePhotoWithThumbnail,
-  generatePhotoKey,
-  generateThumbnailKey,
 } from '../services/r2-storage.js';
 
 const prisma = new PrismaClient();
@@ -77,17 +75,6 @@ async function generateThumbnailBuffer(buffer: Buffer): Promise<Buffer> {
     })
     .jpeg({ quality: 80 })
     .toBuffer();
-}
-
-// Generate thumbnail to file (for local storage)
-async function generateThumbnailToFile(buffer: Buffer, outputPath: string): Promise<void> {
-  await sharp(buffer)
-    .resize(THUMBNAIL_SIZE.width, THUMBNAIL_SIZE.height, {
-      fit: 'inside',
-      withoutEnlargement: true,
-    })
-    .jpeg({ quality: 80 })
-    .toFile(outputPath);
 }
 
 // Process image buffer (resize, convert to JPEG)

--- a/api/src/services/r2-storage.ts
+++ b/api/src/services/r2-storage.ts
@@ -56,7 +56,7 @@ export function generatePhotoKey(projectId: string, filename: string): string {
  * Generate a storage key for a thumbnail
  * Format: thumbnails/{projectId}/{uuid}.jpg
  */
-export function generateThumbnailKey(projectId: string, filename: string): string {
+export function generateThumbnailKey(projectId: string, _filename: string): string {
   const uuid = crypto.randomUUID();
   return `thumbnails/${projectId}/${uuid}.jpg`;
 }

--- a/api/src/services/site-measurement.ts
+++ b/api/src/services/site-measurement.ts
@@ -1,4 +1,4 @@
-import type { MeasurementType, MeasurementUnit, MeasurementResult } from '@prisma/client';
+import type { MeasurementType, MeasurementResult } from '@prisma/client';
 import type {
   ISiteMeasurementRepository,
   CreateSiteMeasurementInput,


### PR DESCRIPTION
Closes #315

## Summary
Remove unused imports and functions flagged by ESLint.

## Changes
- Remove unused imports from project-photos.ts (generatePhotoKey, generateThumbnailKey)
- Remove unused function generateThumbnailToFile
- Prefix unused parameter with underscore (_filename) in r2-storage.ts
- Remove unused MeasurementUnit import from site-measurement.ts

## Testing
- ✅ Lint now passes with 0 warnings
- ✅ All 211 tests pass
- ✅ TypeScript compiles