### PR TITLE
[Alex] fix(api): add railway.toml to run seed on deploy (#293)

### DIFF
--- a/api/railway.toml
+++ b/api/railway.toml
@@ -1,0 +1,13 @@
+# Railway configuration for API service
+# See: https://docs.railway.app/reference/config-as-code
+
+[build]
+builder = "nixpacks"
+
+[deploy]
+# Run migrations and seed before starting the server
+startCommand = "npx prisma migrate deploy && npx prisma db seed && npm start"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
Closes #293

## Problem
Railway deployment doesn't run the seed script, causing E2E tests to fail because the test user doesn't exist.

## Solution
Added `api/railway.toml` with deploy configuration:

```toml
[deploy]
startCommand = "npx prisma migrate deploy && npx prisma db seed && npm start"
healthcheckPath = "/health"
```

## Changes
- Deploy runs: migrate → seed → start
- Adds health check configuration
- Adds restart policy (on_failure, max 3 retries)

## Expected Result
- Test user `test@example.com` will be created on deploy
- E2E auth.setup.ts will pass
- CD pipeline will succeed