### PR TITLE
[Sam] feat(web): migrate inspection detail page to design system (#305)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3804,6 +3804,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -13938,6 +13961,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/web/app/inspections/[id]/page.tsx
+++ b/web/app/inspections/[id]/page.tsx
@@ -3,10 +3,36 @@
 import { useEffect, useState, use, useCallback } from 'react';
 import Link from 'next/link';
 import { api, InspectionDetail, Finding, ApiError } from '@/lib/api';
-import { StatusBadge, LoadingPage, ErrorPage, SectionList, FindingEditor } from '@/components';
+import { LoadingPage, ErrorPage, SectionList, FindingEditor } from '@/components';
+import { PageLayout, PageHeader, PageContent } from '@/components/page-layout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
 
 interface PageProps {
   params: Promise<{ id: string }>;
+}
+
+function getStatusBadgeVariant(status: string): "default" | "secondary" | "success" | "warning" | "destructive" {
+  switch (status.toLowerCase()) {
+    case 'completed':
+    case 'done':
+      return 'success';
+    case 'in_progress':
+    case 'active':
+      return 'warning';
+    case 'draft':
+      return 'secondary';
+    case 'cancelled':
+      return 'destructive';
+    default:
+      return 'default';
+  }
+}
+
+function formatStatus(status: string): string {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 export default function InspectionDetailPage({ params }: PageProps): React.ReactElement {
@@ -44,7 +70,6 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
     try {
       setGenerating(true);
       const result = await api.reports.generate(inspection.id);
-      // Open report in new tab
       window.open(result.url, '_blank');
     } catch (err) {
       if (err instanceof ApiError) {
@@ -64,7 +89,6 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
   const handleSaveFinding = (updatedFinding: Finding): void => {
     if (!inspection) return;
 
-    // Update the finding in the inspection state
     setInspection({
       ...inspection,
       findings: inspection.findings.map((f) =>
@@ -77,7 +101,6 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
   const handleDeleteFinding = (): void => {
     if (!inspection || !editingFinding) return;
 
-    // Remove the finding from the inspection state
     setInspection({
       ...inspection,
       findings: inspection.findings.filter((f) => f.id !== editingFinding.id),
@@ -102,120 +125,137 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
   const majorCount = inspection.findings.filter((f) => f.severity === 'MAJOR').length;
 
   return (
-    <div>
-      <div className="mb-8">
+    <PageLayout>
+      {/* Breadcrumb */}
+      <div className="mb-4">
         <Link
           href="/inspections"
-          className="text-sm text-blue-600 hover:text-blue-900 mb-2 inline-block"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           ← Back to Inspections
         </Link>
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">{inspection.address}</h1>
-            <p className="text-gray-600 mt-1">
-              Client: {inspection.clientName}
-              {inspection.inspectorName && ` • Inspector: ${inspection.inspectorName}`}
-            </p>
-          </div>
-          <StatusBadge status={inspection.status} />
-        </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Findings */}
-        <div className="lg:col-span-2">
-          <h2 className="text-lg font-medium text-gray-900 mb-4">Findings</h2>
-          <SectionList
-            findings={inspection.findings}
-            onEditFinding={handleEditFinding}
-          />
+      <PageHeader
+        title={inspection.address}
+        description={
+          <>
+            Client: {inspection.clientName}
+            {inspection.inspectorName && ` • Inspector: ${inspection.inspectorName}`}
+          </>
+        }
+        actions={
+          <Badge variant={getStatusBadgeVariant(inspection.status)}>
+            {formatStatus(inspection.status)}
+          </Badge>
+        }
+      />
+
+      <PageContent>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Findings - Main Content */}
+          <div className="lg:col-span-2 space-y-4">
+            <h2 className="text-lg font-medium text-foreground">Findings</h2>
+            <SectionList
+              findings={inspection.findings}
+              onEditFinding={handleEditFinding}
+            />
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-4">
+            {/* Actions Card */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Actions</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Button
+                  onClick={handleGenerateReport}
+                  disabled={generating || inspection.status !== 'COMPLETED'}
+                  className="w-full"
+                >
+                  {generating ? 'Generating...' : 'Generate Report'}
+                </Button>
+                {inspection.status !== 'COMPLETED' && (
+                  <p className="text-xs text-muted-foreground text-center">
+                    Complete the inspection to generate a report
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Summary Card */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Summary</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="space-y-3 text-sm">
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Total Findings</dt>
+                    <dd className="font-medium text-foreground">{findingsCount}</dd>
+                  </div>
+                  {urgentCount > 0 && (
+                    <div className="flex justify-between">
+                      <dt className="text-destructive">Urgent</dt>
+                      <dd className="font-medium text-destructive">{urgentCount}</dd>
+                    </div>
+                  )}
+                  {majorCount > 0 && (
+                    <div className="flex justify-between">
+                      <dt className="text-yellow-600">Major</dt>
+                      <dd className="font-medium text-yellow-600">{majorCount}</dd>
+                    </div>
+                  )}
+                  <Separator />
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Current Section</dt>
+                    <dd className="font-medium text-foreground capitalize">
+                      {inspection.currentSection.replace(/-/g, ' ')}
+                    </dd>
+                  </div>
+                </dl>
+              </CardContent>
+            </Card>
+
+            {/* Details Card */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Details</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="space-y-2 text-sm">
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Checklist</dt>
+                    <dd className="text-foreground">{inspection.checklistId}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Created</dt>
+                    <dd className="text-foreground">
+                      {new Date(inspection.createdAt).toLocaleDateString()}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Updated</dt>
+                    <dd className="text-foreground">
+                      {new Date(inspection.updatedAt).toLocaleDateString()}
+                    </dd>
+                  </div>
+                  {inspection.completedAt && (
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">Completed</dt>
+                      <dd className="text-foreground">
+                        {new Date(inspection.completedAt).toLocaleDateString()}
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </CardContent>
+            </Card>
+          </div>
         </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {/* Actions */}
-          <div className="bg-white shadow rounded-lg p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Actions</h3>
-            <div className="space-y-3">
-              <button
-                onClick={handleGenerateReport}
-                disabled={generating || inspection.status !== 'COMPLETED'}
-                className="w-full px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {generating ? 'Generating...' : 'Generate Report'}
-              </button>
-              {inspection.status !== 'COMPLETED' && (
-                <p className="text-xs text-gray-500 text-center">
-                  Complete the inspection to generate a report
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Summary */}
-          <div className="bg-white shadow rounded-lg p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Summary</h3>
-            <dl className="space-y-3 text-sm">
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Total Findings</dt>
-                <dd className="font-medium text-gray-900">{findingsCount}</dd>
-              </div>
-              {urgentCount > 0 && (
-                <div className="flex justify-between">
-                  <dt className="text-red-600">Urgent</dt>
-                  <dd className="font-medium text-red-600">{urgentCount}</dd>
-                </div>
-              )}
-              {majorCount > 0 && (
-                <div className="flex justify-between">
-                  <dt className="text-yellow-600">Major</dt>
-                  <dd className="font-medium text-yellow-600">{majorCount}</dd>
-                </div>
-              )}
-              <div className="pt-3 border-t border-gray-200">
-                <div className="flex justify-between">
-                  <dt className="text-gray-500">Current Section</dt>
-                  <dd className="font-medium text-gray-900 capitalize">
-                    {inspection.currentSection.replace(/-/g, ' ')}
-                  </dd>
-                </div>
-              </div>
-            </dl>
-          </div>
-
-          {/* Details */}
-          <div className="bg-white shadow rounded-lg p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Details</h3>
-            <dl className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Checklist</dt>
-                <dd className="text-gray-900">{inspection.checklistId}</dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Created</dt>
-                <dd className="text-gray-900">
-                  {new Date(inspection.createdAt).toLocaleDateString()}
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-500">Updated</dt>
-                <dd className="text-gray-900">
-                  {new Date(inspection.updatedAt).toLocaleDateString()}
-                </dd>
-              </div>
-              {inspection.completedAt && (
-                <div className="flex justify-between">
-                  <dt className="text-gray-500">Completed</dt>
-                  <dd className="text-gray-900">
-                    {new Date(inspection.completedAt).toLocaleDateString()}
-                  </dd>
-                </div>
-              )}
-            </dl>
-          </div>
-        </div>
-      </div>
+      </PageContent>
 
       {/* Finding Editor Modal */}
       {editingFinding && (
@@ -227,6 +267,6 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
           onCancel={() => setEditingFinding(null)}
         />
       )}
-    </div>
+    </PageLayout>
   );
 }

--- a/web/components/page-layout.tsx
+++ b/web/components/page-layout.tsx
@@ -17,7 +17,7 @@ export function PageLayout({ children, className }: PageLayoutProps): React.Reac
 
 interface PageHeaderProps {
   title: string;
-  description?: string;
+  description?: React.ReactNode;
   actions?: React.ReactNode;
   className?: string;
 }

--- a/web/components/ui/separator.tsx
+++ b/web/components/ui/separator.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
Migrates the inspection detail page to use the design system components.

## Changes
- Add Separator component from shadcn/ui
- Update PageHeader to accept ReactNode for description (allows inline elements)
- Use PageLayout with breadcrumb navigation
- Use Card components for sidebar sections (Actions, Summary, Details)
- Use Badge for status with semantic colors
- Use Button for Generate Report action
- Consistent typography with semantic colors (text-foreground, text-muted-foreground)

## Layout
```
← Back to Inspections (breadcrumb)

[Address]                    [Status Badge]
Client: X • Inspector: Y

┌─────────────────────┐  ┌─────────────────┐
│ Findings (main)     │  │ Actions Card    │
│ - Section List      │  ├─────────────────┤
│                     │  │ Summary Card    │
│                     │  ├─────────────────┤
│                     │  │ Details Card    │
└─────────────────────┘  └─────────────────┘
```

## Testing
- [x] Detail page loads correctly
- [x] Status badge shows correct variant
- [x] Cards display properly
- [x] Breadcrumb navigation works
- [x] Typecheck passes
- [x] Lint passes

Closes #305
Parent: #296
Stacked on: #322