### PR TITLE
fix(railway): increase healthcheck timeout to 120s

### DIFF
--- a/api/railway.toml
+++ b/api/railway.toml
@@ -8,6 +8,6 @@ builder = "nixpacks"
 # Run migrations and seed before starting the server
 startCommand = "npx prisma migrate deploy && npx prisma db seed && npm start"
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Problem
Container was crashing after migrations but before seed + server start completed.

```
00:05:41 No pending migrations to apply
00:05:42 Stopping Container ← crashed here
00:05:56 Starting Container ← restart
```

## Fix
Increase `healthcheckTimeout` from 30s to 120s to allow time for:
- Migrations (~5-10s)
- Seeding (~10-30s)
- Server startup (~5s)

## Changes
- `api/railway.toml`: healthcheckTimeout 30 → 120