### PR TITLE
fix(railway): use Dockerfile instead of Nixpacks

### DIFF
--- a/api/railway.toml
+++ b/api/railway.toml
@@ -2,7 +2,8 @@
 # See: https://docs.railway.app/reference/config-as-code
 
 [build]
-builder = "nixpacks"
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
 
 [deploy]
 # Run migrations and seed before starting the server


### PR DESCRIPTION
## Problem
Nixpacks (default Railway builder) does production-only npm install, so `tsx` wasn't available for `prisma db seed`.

## Fix
Switch to Dockerfile builder which installs all dependencies.

```toml
[build]
builder = "dockerfile"
dockerfilePath = "Dockerfile"
```