### PR TITLE
fix(dockerfile): copy tsconfig.json for tsx seed execution

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
 
 # Set environment
 ENV NODE_ENV=production


### PR DESCRIPTION
## Problem
`tsx prisma/seed.ts` fails because `tsconfig.json` wasn't copied to production image.

## Fix
Add `tsconfig.json` to Dockerfile COPY commands.