### PR TITLE
[Sam] fix(web): pass API token in Authorization header (#339)

### DIFF
--- a/web/app/inspections/[id]/page.tsx
+++ b/web/app/inspections/[id]/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, use, useCallback } from 'react';
 import Link from 'next/link';
-import { api, InspectionDetail, Finding, ApiError } from '@/lib/api';
+import { InspectionDetail, Finding, ApiError } from '@/lib/api';
+import { useApi } from '@/lib/use-api';
 import { StatusBadge, LoadingPage, ErrorPage, SectionList, FindingEditor } from '@/components';
 
 interface PageProps {
@@ -11,6 +12,7 @@ interface PageProps {
 
 export default function InspectionDetailPage({ params }: PageProps): React.ReactElement {
   const { id } = use(params);
+  const api = useApi();
   const [inspection, setInspection] = useState<InspectionDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -27,6 +29,8 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
       if (err instanceof ApiError) {
         if (err.status === 404) {
           setError('Inspection not found');
+        } else if (err.status === 401) {
+          setError('Session expired. Please log in again.');
         } else {
           setError(err.message);
         }
@@ -36,7 +40,7 @@ export default function InspectionDetailPage({ params }: PageProps): React.React
     } finally {
       setLoading(false);
     }
-  }, [id]);
+  }, [api, id]);
 
   const handleGenerateReport = async (): Promise<void> => {
     if (!inspection) return;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -161,9 +161,12 @@ export function createApiClient(token?: string) {
 
 // ============================================================================
 // Legacy API object (for backward compatibility)
-// Note: These calls won't have auth token - use createApiClient(token) instead
+// @deprecated Use useApi() hook or createApiClient(token) instead.
+// This export has NO authentication and will fail on protected endpoints.
+// TODO: Remove once all usages are migrated to useApi()
 // ============================================================================
 
+/** @deprecated Use useApi() hook instead */
 export const api = createApiClient();
 
 export { ApiError };

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,8 +1,10 @@
 /**
- * API Client - Issue #34, #35, #42
+ * API Client - Issue #34, #35, #42, #339
  *
  * Centralized HTTP client for backend API communication.
  * Types imported from @ai-inspection/shared.
+ * 
+ * Authentication: Pass apiToken from session to authenticate requests.
  */
 
 import type {
@@ -38,6 +40,7 @@ interface RequestOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: unknown;
   headers?: Record<string, string>;
+  token?: string; // API token for authentication
 }
 
 class ApiError extends Error {
@@ -52,13 +55,13 @@ class ApiError extends Error {
 }
 
 async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
-  const { method = 'GET', body, headers = {} } = options;
+  const { method = 'GET', body, headers = {}, token } = options;
 
   const config: RequestInit = {
     method,
-    credentials: 'include', // Send cookies for authentication
     headers: {
       'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
       ...headers,
     },
   };
@@ -87,67 +90,81 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
 }
 
 // ============================================================================
-// API Methods
+// API Factory - Creates authenticated API client
 // ============================================================================
 
-export const api = {
-  // Inspections
-  inspections: {
-    list: (): Promise<Inspection[]> =>
-      request('/api/inspections'),
+export function createApiClient(token?: string) {
+  const opts = (options: RequestOptions = {}): RequestOptions => ({
+    ...options,
+    token: options.token ?? token,
+  });
 
-    get: (id: string): Promise<InspectionDetail> =>
-      request(`/api/inspections/${id}`),
+  return {
+    // Inspections
+    inspections: {
+      list: (): Promise<Inspection[]> =>
+        request('/api/inspections', opts()),
 
-    create: (data: CreateInspectionInput): Promise<Inspection> =>
-      request('/api/inspections', { method: 'POST', body: data }),
+      get: (id: string): Promise<InspectionDetail> =>
+        request(`/api/inspections/${id}`, opts()),
 
-    update: (id: string, data: Partial<CreateInspectionInput>): Promise<Inspection> =>
-      request(`/api/inspections/${id}`, { method: 'PATCH', body: data }),
+      create: (data: CreateInspectionInput): Promise<Inspection> =>
+        request('/api/inspections', opts({ method: 'POST', body: data })),
 
-    delete: (id: string): Promise<void> =>
-      request(`/api/inspections/${id}`, { method: 'DELETE' }),
-  },
+      update: (id: string, data: Partial<CreateInspectionInput>): Promise<Inspection> =>
+        request(`/api/inspections/${id}`, opts({ method: 'PATCH', body: data })),
 
-  // Findings
-  findings: {
-    list: (inspectionId: string): Promise<Finding[]> =>
-      request(`/api/inspections/${inspectionId}/findings`),
+      delete: (id: string): Promise<void> =>
+        request(`/api/inspections/${id}`, opts({ method: 'DELETE' })),
+    },
 
-    create: (inspectionId: string, data: CreateFindingInput): Promise<Finding> =>
-      request(`/api/inspections/${inspectionId}/findings`, { method: 'POST', body: data }),
+    // Findings
+    findings: {
+      list: (inspectionId: string): Promise<Finding[]> =>
+        request(`/api/inspections/${inspectionId}/findings`, opts()),
 
-    update: (inspectionId: string, findingId: string, data: UpdateFindingInput): Promise<Finding> =>
-      request(`/api/inspections/${inspectionId}/findings/${findingId}`, {
-        method: 'PATCH',
-        body: data,
-      }),
+      create: (inspectionId: string, data: CreateFindingInput): Promise<Finding> =>
+        request(`/api/inspections/${inspectionId}/findings`, opts({ method: 'POST', body: data })),
 
-    delete: (inspectionId: string, findingId: string): Promise<void> =>
-      request(`/api/inspections/${inspectionId}/findings/${findingId}`, { method: 'DELETE' }),
-  },
+      update: (inspectionId: string, findingId: string, data: UpdateFindingInput): Promise<Finding> =>
+        request(`/api/inspections/${inspectionId}/findings/${findingId}`, opts({
+          method: 'PATCH',
+          body: data,
+        })),
 
-  // Reports
-  reports: {
-    generate: (inspectionId: string): Promise<{ url: string }> =>
-      request(`/api/inspections/${inspectionId}/report`, { method: 'POST' }),
-  },
+      delete: (inspectionId: string, findingId: string): Promise<void> =>
+        request(`/api/inspections/${inspectionId}/findings/${findingId}`, opts({ method: 'DELETE' })),
+    },
 
-  // Photos
-  photos: {
-    upload: (findingId: string, base64Data: string, mimeType?: string): Promise<Photo> =>
-      request(`/api/findings/${findingId}/photos`, {
-        method: 'POST',
-        body: { base64Data, mimeType },
-      }),
+    // Reports
+    reports: {
+      generate: (inspectionId: string): Promise<{ url: string }> =>
+        request(`/api/inspections/${inspectionId}/report`, opts({ method: 'POST' })),
+    },
 
-    delete: (photoId: string): Promise<void> =>
-      request(`/api/photos/${photoId}`, { method: 'DELETE' }),
+    // Photos
+    photos: {
+      upload: (findingId: string, base64Data: string, mimeType?: string): Promise<Photo> =>
+        request(`/api/findings/${findingId}/photos`, opts({
+          method: 'POST',
+          body: { base64Data, mimeType },
+        })),
 
-    getUrl: (photoId: string): string =>
-      `${API_URL}/api/photos/${photoId}`,
-  },
-};
+      delete: (photoId: string): Promise<void> =>
+        request(`/api/photos/${photoId}`, opts({ method: 'DELETE' })),
+
+      getUrl: (photoId: string): string =>
+        `${API_URL}/api/photos/${photoId}`,
+    },
+  };
+}
+
+// ============================================================================
+// Legacy API object (for backward compatibility)
+// Note: These calls won't have auth token - use createApiClient(token) instead
+// ============================================================================
+
+export const api = createApiClient();
 
 export { ApiError };
 export default api;

--- a/web/lib/use-api.ts
+++ b/web/lib/use-api.ts
@@ -1,0 +1,34 @@
+/**
+ * useApi Hook — Issue #339
+ *
+ * Provides an authenticated API client using the session token.
+ * Use this in client components for authenticated API calls.
+ *
+ * @example
+ * const api = useApi();
+ * const inspections = await api.inspections.list();
+ */
+
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+import { createApiClient } from './api';
+
+export function useApi() {
+  const { data: session } = useSession();
+  
+  const api = useMemo(() => {
+    return createApiClient(session?.apiToken);
+  }, [session?.apiToken]);
+
+  return api;
+}
+
+/**
+ * Hook to get just the API token from session
+ */
+export function useApiToken(): string | undefined {
+  const { data: session } = useSession();
+  return session?.apiToken;
+}

--- a/web/lib/use-api.ts
+++ b/web/lib/use-api.ts
@@ -15,12 +15,18 @@ import { useSession } from 'next-auth/react';
 import { useMemo } from 'react';
 import { createApiClient } from './api';
 
+// Extended session type with apiToken
+interface ExtendedSession {
+  apiToken?: string;
+}
+
 export function useApi() {
   const { data: session } = useSession();
+  const extSession = session as ExtendedSession | null;
   
   const api = useMemo(() => {
-    return createApiClient(session?.apiToken);
-  }, [session?.apiToken]);
+    return createApiClient(extSession?.apiToken);
+  }, [extSession?.apiToken]);
 
   return api;
 }
@@ -30,5 +36,6 @@ export function useApi() {
  */
 export function useApiToken(): string | undefined {
   const { data: session } = useSession();
-  return session?.apiToken;
+  const extSession = session as ExtendedSession | null;
+  return extSession?.apiToken;
 }


### PR DESCRIPTION
## Summary
Fixes cross-origin API authentication by passing the API token in the Authorization header instead of relying on cookies.

## Root Cause
Web app (Vercel) and API (Railway) are on different domains. Cookies don't work cross-origin, so API calls returned 401 Unauthorized.

## Changes

### auth-config.ts
- Store API token from login response in NextAuth JWT
- Expose `apiToken` in session for client components

### api.ts
- Add `token` option to request function
- Send `Authorization: Bearer <token>` header when token provided
- Create `createApiClient(token)` factory for authenticated clients

### use-api.ts (NEW)
- `useApi()` hook that returns authenticated API client
- Reads token from session automatically

### Inspection Pages
- Use `useApi()` hook instead of importing `api` directly
- Add 401 error handling with "Session expired" message

## Security (per Quinn's review on #339)
- ✅ Token encrypted inside NextAuth JWT (httpOnly cookie)
- ✅ Token expiry matches session expiry (24h)
- ⚠️ Token exposed to client (acceptable for MVP per Quinn)

## Testing
- [ ] Login stores API token
- [ ] Inspections list loads after login
- [ ] Inspection detail loads
- [ ] 401 errors show helpful message

Fixes #339