### PR TITLE
[Sam] fix(api): return token in login/register response (#339)

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -93,9 +93,11 @@ authRouter.post('/register', authLimiter, async (req: Request, res: Response) =>
     // Set HttpOnly cookie
     setTokenCookie(res, token);
 
+    // Return token in response for cross-origin clients (NextAuth)
     res.status(201).json({
       message: 'Registration successful',
       user: { id: user.id, email: user.email },
+      token,
     });
   } catch (err) {
     console.error('Registration error:', err);
@@ -150,9 +152,11 @@ authRouter.post('/login', authLimiter, async (req: Request, res: Response) => {
     // Set HttpOnly cookie
     setTokenCookie(res, token);
 
+    // Return token in response for cross-origin clients (NextAuth)
     res.json({
       message: 'Login successful',
       user: { id: user.id, email: user.email },
+      token,
     });
   } catch (err) {
     console.error('Login error:', err);


### PR DESCRIPTION
## Summary
Fixes the 'Invalid email or password' error by returning the token in the API response body.

## Root Cause
The API was setting the token as an HttpOnly cookie but NOT returning it in the response body. NextAuth (running on a different domain) can't read cookies, so it couldn't get the token.

## Changes
- Add `token` to login response
- Add `token` to register response

## Before
```json
{"message":"Login successful","user":{...}}
```

## After
```json
{"message":"Login successful","user":{...},"token":"eyJ..."}
```

## Testing
- [ ] Login returns token in response
- [ ] Register returns token in response
- [ ] Web app can log in and access inspections

Fixes #339 (companion to PR #341)