### PR TITLE
feat(deploy): add Railway configuration for openclaw-inspector

### DIFF
--- a/deploy/openclaw-inspector/SETUP.md
+++ b/deploy/openclaw-inspector/SETUP.md
@@ -1,0 +1,111 @@
+# Railway Setup: openclaw-inspector
+
+Step-by-step guide to deploy the OpenClaw inspector service on Railway.
+
+## Prerequisites
+
+- Railway account with project access
+- Anthropic API key
+- Backend API deployed (API_URL, API_KEY)
+
+## 1. Create Service
+
+```bash
+# Via CLI
+railway add --service openclaw-inspector
+
+# Or via Dashboard:
+# Project → New Service → Empty Service → Name: "openclaw-inspector"
+```
+
+## 2. Link to GitHub
+
+Connect the service to the repository:
+- Source: `apexphere/ai-inspection`
+- Branch: `develop`
+- Root Directory: `/` (Dockerfile path is in railway.toml)
+
+## 3. Configure Environment Variables
+
+Add these in Railway Dashboard → Service → Variables:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `ANTHROPIC_API_KEY` | `sk-ant-...` | Claude API key |
+| `API_URL` | `https://ai-inspection-api.up.railway.app` | Backend API URL |
+| `API_KEY` | `(generate)` | Backend API auth key |
+| `NODE_ENV` | `production` | |
+
+## 4. Add Persistent Volume
+
+WhatsApp auth must persist across deploys:
+
+```bash
+# Via CLI
+railway volume add --mount /app/auth
+
+# Or via Dashboard:
+# Service → Settings → Volumes → Add Volume
+# Mount Path: /app/auth
+```
+
+## 5. Configure Networking
+
+- Port: `3000` (auto-detected from EXPOSE)
+- Health Check: `/health` (configured in railway.toml)
+
+## 6. Deploy
+
+```bash
+railway up
+```
+
+Or push to `develop` branch for auto-deploy.
+
+## 7. WhatsApp Pairing
+
+After first deploy, pair WhatsApp:
+
+```bash
+# SSH into service
+railway run bash
+
+# Start pairing
+openclaw whatsapp pair
+
+# Scan QR code with phone
+# Session stored in /app/auth volume
+```
+
+## Verification
+
+```bash
+# Check health
+curl https://openclaw-inspector.up.railway.app/health
+
+# Check logs
+railway logs -f
+```
+
+## Troubleshooting
+
+### Container restarts repeatedly
+- Check `railway logs` for errors
+- Verify ANTHROPIC_API_KEY is valid
+- Ensure volume is mounted at `/app/auth`
+
+### WhatsApp disconnected
+- SSH in and run `openclaw whatsapp pair` again
+- Check if phone has WhatsApp Web disabled
+
+### Health check failing
+- Gateway takes ~60s to start (healthcheckTimeout: 120s)
+- Check if port 3000 is exposed correctly
+
+## Cost Estimate
+
+| Component | Cost |
+|-----------|------|
+| Railway (Starter) | ~$5/mo |
+| Volume (1GB) | Included |
+| **Total** | **~$5/mo** |

--- a/deploy/openclaw-inspector/railway.toml
+++ b/deploy/openclaw-inspector/railway.toml
@@ -1,0 +1,16 @@
+# Railway configuration for openclaw-inspector service
+# See: https://docs.railway.app/reference/config-as-code
+
+[build]
+# Use Dockerfile from repo root context
+dockerfilePath = "deploy/openclaw-inspector/Dockerfile"
+
+[deploy]
+# Health check
+healthcheckPath = "/health"
+healthcheckTimeout = 120
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
+
+# Single replica (WhatsApp session is stateful)
+numReplicas = 1


### PR DESCRIPTION
## Summary
Railway configuration and setup guide for the OpenClaw inspector service.

## Changes
- `deploy/openclaw-inspector/railway.toml` — Build and deploy settings
- `deploy/openclaw-inspector/SETUP.md` — Step-by-step deployment guide

## Railway Configuration
- Health check: `/health` with 120s timeout
- Restart policy: ON_FAILURE (max 3 retries)
- Single replica (WhatsApp session is stateful)

## Setup Guide Covers
1. Service creation
2. GitHub linking
3. Environment variables
4. Persistent volume for WhatsApp auth
5. WhatsApp pairing workflow
6. Troubleshooting

## Dependencies
- Requires #347 (Dockerfile) — PR #355

## Cost Estimate
~$5/mo (Railway Starter)

Closes #348

Parent: #290