### PR TITLE
[Alex] feat(api): inspector phone lookup (#351)

### DIFF
--- a/api/prisma/migrations/20260221070000_add_user_name_field/migration.sql
+++ b/api/prisma/migrations/20260221070000_add_user_name_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: Add name field to User
+ALTER TABLE "User" ADD COLUMN "name" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -17,6 +17,7 @@ datasource db {
 model User {
   id            String    @id @default(uuid())
   email         String    @unique
+  name          String?
   passwordHash  String
   phoneNumber   String?   @unique
   phoneVerified Boolean   @default(false)

--- a/api/src/__tests__/inspectors.integration.test.ts
+++ b/api/src/__tests__/inspectors.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Inspectors API Integration Tests — Issue #351
+ *
+ * Integration tests for phone number lookup endpoint.
+ * Requires a real Postgres database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+
+describe('Inspector Phone Lookup Integration', () => {
+  let prisma: PrismaClient;
+  let testUserId: string;
+
+  const testUser = {
+    email: 'test-inspector@example.com',
+    name: 'Test Inspector',
+    phoneNumber: '+64211234567',
+    phoneVerified: true,
+    passwordHash: '$2a$12$placeholder',
+  };
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    // Create test user
+    const user = await prisma.user.create({
+      data: testUser,
+    });
+    testUserId = user.id;
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    await prisma.user.deleteMany({
+      where: { email: testUser.email },
+    });
+    await prisma.$disconnect();
+  });
+
+  describe('Database Lookup', () => {
+    it('should find user by phone number', async () => {
+      const user = await prisma.user.findFirst({
+        where: {
+          phoneNumber: '+64211234567',
+          phoneVerified: true,
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      });
+
+      expect(user).not.toBeNull();
+      expect(user?.id).toBe(testUserId);
+      expect(user?.name).toBe('Test Inspector');
+      expect(user?.email).toBe('test-inspector@example.com');
+    });
+
+    it('should not find unverified phone numbers', async () => {
+      // Create unverified user
+      const unverified = await prisma.user.create({
+        data: {
+          email: 'unverified@example.com',
+          name: 'Unverified User',
+          phoneNumber: '+64212222222',
+          phoneVerified: false,
+          passwordHash: '$2a$12$placeholder',
+        },
+      });
+
+      const user = await prisma.user.findFirst({
+        where: {
+          phoneNumber: '+64212222222',
+          phoneVerified: true,
+        },
+      });
+
+      expect(user).toBeNull();
+
+      // Cleanup
+      await prisma.user.delete({ where: { id: unverified.id } });
+    });
+
+    it('should return null for unknown phone number', async () => {
+      const user = await prisma.user.findFirst({
+        where: {
+          phoneNumber: '+64299999999',
+          phoneVerified: true,
+        },
+      });
+
+      expect(user).toBeNull();
+    });
+  });
+});

--- a/api/src/__tests__/inspectors.test.ts
+++ b/api/src/__tests__/inspectors.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Inspectors API Tests — Issue #351
+ *
+ * Tests for phone number lookup endpoint used by WhatsApp agent.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('Inspector Phone Lookup', () => {
+  describe('Phone number normalization', () => {
+    /**
+     * Normalize phone number for consistent lookup
+     */
+    function normalizePhoneNumber(phone: string): string {
+      const hasPlus = phone.startsWith('+');
+      const digits = phone.replace(/\D/g, '');
+      return hasPlus ? `+${digits}` : `+${digits}`;
+    }
+
+    it('should normalize phone with + prefix', () => {
+      expect(normalizePhoneNumber('+64211234567')).toBe('+64211234567');
+    });
+
+    it('should add + prefix if missing', () => {
+      expect(normalizePhoneNumber('64211234567')).toBe('+64211234567');
+    });
+
+    it('should remove spaces and dashes', () => {
+      expect(normalizePhoneNumber('+64 21 123 4567')).toBe('+64211234567');
+      expect(normalizePhoneNumber('+64-21-123-4567')).toBe('+64211234567');
+    });
+
+    it('should handle mixed formatting', () => {
+      expect(normalizePhoneNumber('+64 (21) 123-4567')).toBe('+64211234567');
+    });
+  });
+
+  describe('Phone number validation', () => {
+    const phoneRegex = /^\+?[1-9]\d{9,14}$/;
+
+    it('should accept valid NZ mobile numbers', () => {
+      expect(phoneRegex.test('+64211234567')).toBe(true);
+      expect(phoneRegex.test('+64221234567')).toBe(true);
+      expect(phoneRegex.test('+64271234567')).toBe(true);
+    });
+
+    it('should accept valid international numbers', () => {
+      expect(phoneRegex.test('+14155551234')).toBe(true);
+      expect(phoneRegex.test('+447700900123')).toBe(true);
+      expect(phoneRegex.test('+61412345678')).toBe(true);
+    });
+
+    it('should reject too short numbers', () => {
+      expect(phoneRegex.test('+64123')).toBe(false);
+      expect(phoneRegex.test('123456789')).toBe(false);
+    });
+
+    it('should reject numbers starting with 0', () => {
+      expect(phoneRegex.test('0211234567')).toBe(false);
+      expect(phoneRegex.test('+0211234567')).toBe(false);
+    });
+
+    it('should reject non-numeric', () => {
+      expect(phoneRegex.test('invalid')).toBe(false);
+      expect(phoneRegex.test('')).toBe(false);
+    });
+  });
+
+  describe('Response structure', () => {
+    it('should return expected fields for found inspector', () => {
+      const mockResponse = {
+        id: 'abc123',
+        name: 'Jake Li',
+        email: 'jake@example.com',
+      };
+
+      expect(mockResponse).toHaveProperty('id');
+      expect(mockResponse).toHaveProperty('name');
+      expect(mockResponse).toHaveProperty('email');
+    });
+
+    it('should return appropriate not found message', () => {
+      const notFoundResponse = {
+        error: 'Inspector not found',
+        message: "I don't have you registered. Contact admin to set up your profile.",
+      };
+
+      expect(notFoundResponse.error).toBe('Inspector not found');
+      expect(notFoundResponse.message).toContain("don't have you registered");
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,7 +21,8 @@ import { naReasonTemplatesRouter } from './routes/na-reason-templates.js';
 import { projectPhotosRouter } from './routes/project-photos.js';
 import { buildingHistoryRouter } from './routes/building-history.js';
 import { siteMeasurementsRouter } from './routes/site-measurements.js';
-import { authMiddleware } from './middleware/auth.js';
+import { inspectorsRouter } from './routes/inspectors.js';
+import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
 
@@ -61,6 +62,9 @@ app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 // Public routes (no auth required)
 app.use('/health', healthRouter);
 app.use('/api/auth', authRouter);
+
+// Service routes (JWT or API key auth)
+app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);
 
 // Protected routes (auth required)
 app.use('/api/inspections', authMiddleware, inspectionsRouter);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -13,3 +13,4 @@ export * from './building-code.js';
 export * from './clause-reviews.js';
 export * from './documents.js';
 export * from './na-reason-templates.js';
+export * from './inspectors.js';

--- a/api/src/routes/inspectors.ts
+++ b/api/src/routes/inspectors.ts
@@ -1,0 +1,90 @@
+/**
+ * Inspectors Routes — Issue #351
+ *
+ * Phone number lookup for multi-inspector WhatsApp support.
+ * Used by OpenClaw agent to identify which inspector is messaging.
+ */
+
+import { Router, Request, Response, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const inspectorsRouter: RouterType = Router();
+
+// Validation schema for phone number
+const PhoneSchema = z.string()
+  .min(10, 'Phone number must be at least 10 characters')
+  .max(20, 'Phone number too long')
+  .regex(/^\+?[1-9]\d{9,14}$/, 'Invalid phone number format');
+
+/**
+ * Normalize phone number for consistent lookup
+ * Removes spaces, dashes, and ensures + prefix
+ */
+function normalizePhoneNumber(phone: string): string {
+  // Remove all non-digit characters except leading +
+  const hasPlus = phone.startsWith('+');
+  const digits = phone.replace(/\D/g, '');
+  return hasPlus ? `+${digits}` : `+${digits}`;
+}
+
+/**
+ * GET /api/inspectors/by-phone/:phone
+ * Look up an inspector by their WhatsApp phone number.
+ * 
+ * Returns:
+ * - 200 { id, name, email } if found
+ * - 404 if phone number not registered
+ * - 400 if invalid phone number format
+ */
+inspectorsRouter.get('/by-phone/:phone', async (req: Request, res: Response) => {
+  try {
+    const phoneParam = req.params.phone;
+    const phone = typeof phoneParam === 'string' ? decodeURIComponent(phoneParam) : '';
+    
+    // Validate phone number format
+    const parsed = PhoneSchema.safeParse(phone);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Invalid phone number format',
+        details: parsed.error.flatten().formErrors,
+      });
+      return;
+    }
+
+    // Normalize for lookup
+    const normalizedPhone = normalizePhoneNumber(phone);
+
+    // Find user by phone number (must be verified)
+    const user = await prisma.user.findFirst({
+      where: {
+        phoneNumber: normalizedPhone,
+        phoneVerified: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    });
+
+    if (!user) {
+      res.status(404).json({
+        error: 'Inspector not found',
+        message: "I don't have you registered. Contact admin to set up your profile.",
+      });
+      return;
+    }
+
+    res.json({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    });
+  } catch (err) {
+    console.error('Inspector lookup error:', err);
+    res.status(500).json({ error: 'Failed to look up inspector' });
+  }
+});


### PR DESCRIPTION
## Summary
Adds phone number lookup endpoint for multi-inspector WhatsApp support.

## Changes
- **New endpoint:** `GET /api/inspectors/by-phone/:phone`
  - Returns `{ id, name, email }` for verified phone numbers
  - Returns 404 with friendly message for unregistered phones
- **Service auth middleware:** Allows JWT or API key auth
  - OpenClaw agent can use `X-API-Key` header
  - Regular users can use JWT
- **User model:** Added `name` field for inspector display name
- **Migration:** `20260221070000_add_user_name_field`
- **Tests:** 11 unit tests + integration test

## API Usage

```bash
# With API key (for OpenClaw agent)
curl -H "X-API-Key: $SERVICE_API_KEY" \
  https://api.example.com/api/inspectors/by-phone/+64211234567

# Response
{ "id": "abc123", "name": "Jake Li", "email": "jake@example.com" }

# Not found
{ "error": "Inspector not found", "message": "I don't have you registered..." }
```

## Environment Variables
- `SERVICE_API_KEY` - Required for service-to-service auth

Closes #351
Parent: #290