### PR TITLE
feat(config): configure WhatsApp channel and MCP server

### DIFF
--- a/agents/inspector/openclaw.yml
+++ b/agents/inspector/openclaw.yml
@@ -1,5 +1,13 @@
 # OpenClaw configuration for Building Inspection Agent
-# Copy this to ~/.openclaw/openclaw.yml or merge with existing config
+# Local development config - copy to ~/.openclaw/openclaw.yml
+#
+# Required environment variables:
+#   ANTHROPIC_API_KEY  - Claude API key
+#   API_URL            - Backend API (e.g., http://localhost:3001)
+#   API_KEY            - Backend API auth key
+#
+# Optional environment variables:
+#   WHATSAPP_ALLOW     - Comma-separated phone numbers in E.164 format
 
 # Agent definition
 agents:
@@ -7,33 +15,35 @@ agents:
     enabled: true
     model: claude-sonnet-4
     workspace: ./workspace
-    
-# WhatsApp channel
+
+# WhatsApp channel (#345)
 channels:
   whatsapp:
     enabled: true
+    
+    # Access control - only allowlisted numbers can message
     dmPolicy: allowlist
-    allowFrom:
-      # Add inspector phone numbers (E.164 format)
-      # - "+64211234567"
+    allowFrom: ${WHATSAPP_ALLOW:-[]}
+    # For local dev, add your number:
+    # allowFrom:
+    #   - "+64211234567"
+    
+    # Session isolation - each phone number gets own conversation
     session:
-      dmScope: agent  # Each phone gets own session
+      dmScope: agent
+    
+    # Acknowledge receipt with 👀 reaction
     ackReaction:
       emoji: "👀"
       direct: true
+      group: never
 
-# MCP server for inspection tools
+# MCP server for inspection tools (#346)
 mcp:
   servers:
     inspection:
-      command: ["node", "server/dist/index.js"]
-      cwd: "${INSPECTION_SERVER_PATH}"  # Set to path of server/
+      command: ["node", "dist/index.js"]
+      cwd: "../server"  # Relative to agents/inspector/
       env:
         API_URL: "${API_URL}"
         API_KEY: "${API_KEY}"
-
-# Environment variables needed:
-# - ANTHROPIC_API_KEY: Claude API key
-# - API_URL: Backend API (e.g., https://api-test-ai-inspection.apexphere.co.nz)
-# - API_KEY: Backend API auth key
-# - INSPECTION_SERVER_PATH: Path to server/ directory (e.g., /path/to/ai-inspection/server)

--- a/deploy/openclaw-inspector/README.md
+++ b/deploy/openclaw-inspector/README.md
@@ -29,9 +29,23 @@ docker run -it --rm \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ANTHROPIC_API_KEY` | Yes | Claude API key |
-| `API_URL` | Yes | Backend API URL |
+| `API_URL` | Yes | Backend API URL (e.g., `https://api.example.com`) |
 | `API_KEY` | Yes | Backend API auth key |
-| `OPENCLAW_WHATSAPP_ALLOWLIST` | No | Comma-separated allowed phone numbers |
+| `WHATSAPP_ALLOW` | Yes | Allowed phone numbers in E.164 format |
+
+### Configuring WhatsApp Allowlist
+
+Only numbers in `WHATSAPP_ALLOW` can message the inspector:
+
+```bash
+# Single number
+WHATSAPP_ALLOW="+64211234567"
+
+# Multiple numbers (comma-separated)
+WHATSAPP_ALLOW="+64211234567,+64221234567,+64231234567"
+```
+
+**Note:** Numbers must be in E.164 format (+ country code, no spaces/dashes).
 
 ## WhatsApp Pairing
 

--- a/deploy/openclaw-inspector/SETUP.md
+++ b/deploy/openclaw-inspector/SETUP.md
@@ -34,7 +34,11 @@ Add these in Railway Dashboard → Service → Variables:
 | `ANTHROPIC_API_KEY` | `sk-ant-...` | Claude API key |
 | `API_URL` | `https://ai-inspection-api.up.railway.app` | Backend API URL |
 | `API_KEY` | `(generate)` | Backend API auth key |
+| `WHATSAPP_ALLOW` | `+64211234567,+64221234567` | Allowed phone numbers (E.164) |
 | `NODE_ENV` | `production` | |
+
+**Note:** `WHATSAPP_ALLOW` controls which phone numbers can message the inspector.
+Format: comma-separated E.164 numbers (e.g., `+64211234567`).
 
 ## 4. Add Persistent Volume
 

--- a/deploy/openclaw-inspector/openclaw.yml
+++ b/deploy/openclaw-inspector/openclaw.yml
@@ -1,24 +1,42 @@
 # OpenClaw Inspector Configuration
-# Environment variables: ANTHROPIC_API_KEY, API_URL, API_KEY
+# Production config for Railway deployment
+#
+# Required environment variables:
+#   ANTHROPIC_API_KEY  - Claude API key
+#   API_URL            - Backend API (e.g., https://api.example.com)
+#   API_KEY            - Backend API auth key
+#
+# Optional environment variables:
+#   WHATSAPP_ALLOW     - Comma-separated phone numbers in E.164 format
+#                        e.g., "+64211234567,+64221234567"
 
+# Agent configuration
 agents:
   inspector:
     enabled: true
     model: claude-sonnet-4
     workspace: /app/agents/inspector/workspace
 
+# WhatsApp channel (#345)
 channels:
   whatsapp:
     enabled: true
+    
+    # Access control - only allowlisted numbers can message
     dmPolicy: allowlist
-    # allowFrom configured via OPENCLAW_WHATSAPP_ALLOWLIST env var
-    # Format: comma-separated phone numbers (+6421...,+6422...)
+    allowFrom: ${WHATSAPP_ALLOW:-[]}
+    
+    # Session isolation - each phone number gets own conversation
     session:
-      dmScope: agent  # Each phone number gets own session
+      dmScope: agent
+    
+    # Acknowledge receipt with 👀 reaction
     ackReaction:
       emoji: "👀"
       direct: true
+      group: never  # Not used in groups
 
+# MCP server for inspection tools (#346)
 mcp:
   servers:
     inspection:
@@ -26,7 +44,9 @@ mcp:
       env:
         API_URL: "${API_URL}"
         API_KEY: "${API_KEY}"
+        NODE_ENV: "production"
 
+# Gateway settings
 gateway:
   host: "0.0.0.0"
   port: 3000


### PR DESCRIPTION
## Summary
Complete WhatsApp channel and MCP server configuration for the inspector agent.

## Changes

### WhatsApp Channel (#345)
- `dmPolicy: allowlist` with `WHATSAPP_ALLOW` env var
- `dmScope: agent` for session isolation (each phone = own conversation)
- `ackReaction: 👀` on message receipt
- Documented E.164 phone number format

### MCP Server (#346)
- stdio transport: `node server/dist/index.js`
- Environment: `API_URL`, `API_KEY`, `NODE_ENV`
- Local dev config uses relative paths
- Production config uses absolute container paths

### Documentation
- Updated README with `WHATSAPP_ALLOW` config examples
- Updated SETUP.md with Railway env var table

## Acceptance Criteria

### #345
- [x] WhatsApp channel enabled
- [x] dmPolicy: allowlist
- [x] allowFrom via WHATSAPP_ALLOW env var
- [x] ackReaction: 👀
- [x] Session isolation (dmScope: agent)

### #346
- [x] MCP server configured
- [x] stdio transport
- [x] API_URL and API_KEY passed
- [x] inspection_* tools accessible (via server)

Closes #345, closes #346

Parent: #290