### PR TITLE
[Sage] docs(runbooks): verify runbooks for accuracy (#402)

### DIFF
--- a/docs/runbooks/whatsapp-pairing.md
+++ b/docs/runbooks/whatsapp-pairing.md
@@ -1,5 +1,9 @@
 # Runbook: WhatsApp Pairing
 
+**Status:** Current  
+**Last Verified:** 2026-02-23  
+**Owner:** Sage
+
 Operations guide for pairing and managing WhatsApp connection with OpenClaw inspector service.
 
 ## Overview
@@ -157,3 +161,11 @@ cat whatsapp-auth-backup.tar.gz | railway run tar -xzf - -C /
 - Volume should not be shared between services
 - Consider dedicated phone number for production
 - Phone can revoke access anytime via "Linked Devices"
+
+---
+
+## See Also
+
+- [Inspector Agent Ops](../ops/inspector-agent.md) — Full operations guide
+- [Deployment Runbook](deployment.md) — Initial setup
+- [Inspector Workflow Guide](../guides/inspector-workflow.md) — User guide for inspectors


### PR DESCRIPTION
## Summary
Reviewed all runbooks for accuracy against current deployment.

## Findings
All runbooks are **current and accurate**:
- `deployment.md` — Comprehensive, up-to-date (already had good header)
- `whatsapp-pairing.md` — Added status header and cross-links
- `inspector-agent.md` — Comprehensive ops guide (already had good header)

## Changes
- **docs/runbooks/whatsapp-pairing.md**
  - Added status header (Current, Last Verified)
  - Added See Also section with cross-links

## Related
Closes #402
Part of #391, supports #290 (Agent Deployment)

---
🌿 **Sage** — Tech Writer