### PR TITLE
[Sage] docs(design): add cross-links (#403)

### DIFF
--- a/docs/design/001-mvp-inspection-workflow.md
+++ b/docs/design/001-mvp-inspection-workflow.md
@@ -723,3 +723,12 @@ All resolved for MVP:
 ## Appendix: Example Interaction
 
 See User Workflow section above for detailed interaction examples.
+---
+
+## See Also
+
+- [Inspection Checklist System](004-inspection-checklist-system.md) — Checklist data model
+- [Document & Photo Attachments](006-document-photo-attachments.md) — Photo handling
+- [COA Report Generation](008-coa-report-generation.md) — Report generation
+- [Agent Deployment](013-agent-deployment.md) — OpenClaw agent setup
+- [Inspector Workflow Guide](../guides/inspector-workflow.md) — User guide

--- a/docs/design/002-backend-service-architecture.md
+++ b/docs/design/002-backend-service-architecture.md
@@ -264,3 +264,12 @@ enum Severity {
 - [Sprint 1 MVP Design](001-mvp-inspection-workflow.md)
 - [MCP Specification](https://modelcontextprotocol.io)
 - [Prisma Docs](https://www.prisma.io/docs)
+
+---
+
+## See Also
+
+- [CI/CD Pipeline](003-ci-cd-pipeline.md) — Build and deploy
+- [Web Interface](005-web-interface.md) — Frontend architecture
+- [API Reference](../api/README.md) — Endpoint documentation *(coming soon)*
+- [Developer Setup](../setup/developer.md) — Local development

--- a/docs/design/013-agent-deployment.md
+++ b/docs/design/013-agent-deployment.md
@@ -325,3 +325,13 @@ No Twilio or WhatsApp Business API fees.
 - [OpenClaw WhatsApp Docs](https://docs.openclaw.ai/channels/whatsapp)
 - [MCP Protocol](https://modelcontextprotocol.io)
 - [Baileys Library](https://github.com/WhiskeySockets/Baileys)
+
+---
+
+## See Also
+
+- [MVP Inspection Workflow](001-mvp-inspection-workflow.md) — Core workflow design
+- [Deployment Runbook](../runbooks/deployment.md) — Production deployment
+- [WhatsApp Pairing](../runbooks/whatsapp-pairing.md) — WhatsApp setup
+- [Inspector Agent Ops](../ops/inspector-agent.md) — Operations guide
+- [Inspector Workflow Guide](../guides/inspector-workflow.md) — User guide

--- a/docs/design/014-design-system.md
+++ b/docs/design/014-design-system.md
@@ -363,3 +363,12 @@ Add to `web/AGENTS.md`:
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Radix UI](https://www.radix-ui.com/)
 - [Stripe Dashboard](https://dashboard.stripe.com/) (visual reference)
+
+---
+
+## See Also
+
+- [Web Interface](005-web-interface.md) — Frontend architecture
+- [UI Audit](ui-audit.md) — Current state audit
+- [Design Tokens](tokens.yaml) — Token definitions
+- [UI Specs](ui/) — Page specifications


### PR DESCRIPTION
## Summary
Adds See Also sections to key design docs for easier navigation.

## Changes
Added cross-links to:
- **001-mvp-inspection-workflow.md** → checklist, photos, reports, agent, user guide
- **002-backend-service-architecture.md** → CI/CD, web, API, dev setup
- **013-agent-deployment.md** → workflow, runbooks, ops guide, user guide
- **014-design-system.md** → web interface, UI audit, tokens, specs

## Related
Closes #403
Part of #391

---
🌿 **Sage** — Tech Writer