### PR TITLE
fix(vercel): only deploy from develop and main branches

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -5,6 +5,7 @@
   "outputDirectory": ".next",
   "framework": "nextjs",
   "regions": ["syd1"],
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"develop\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
Adds `ignoreCommand` to vercel.json to skip builds on feature branches.

## Problem
Vercel hitting build rate limit due to deploys on every feature branch push.

## Solution
```json
"ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"develop\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]"
```

- `develop` → builds (staging preview)
- `main` → builds (production)
- Feature branches → skipped

## Notes
Preserves existing vercel.json config (install, build, headers, regions).