### PR TITLE
[Archer] feat(api): setup OpenAPI foundation with zod-to-openapi

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "db:studio": "prisma studio"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@aws-sdk/client-s3": "^3.994.0",
     "@aws-sdk/s3-request-presigner": "^3.994.0",
     "@prisma/client": "^6.0.0",
@@ -35,6 +36,7 @@
     "multer": "^1.4.5-lts.2",
     "puppeteer": "^24.37.3",
     "sharp": "^0.33.0",
+    "swagger-ui-express": "^5.0.1",
     "tsx": "^4.21.0",
     "yaml": "^2.8.2",
     "zod": "^3.24.0"
@@ -49,6 +51,7 @@
     "@types/multer": "^1.4.12",
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.39.2",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ import { projectPhotosRouter } from './routes/project-photos.js';
 import { buildingHistoryRouter } from './routes/building-history.js';
 import { siteMeasurementsRouter } from './routes/site-measurements.js';
 import { inspectorsRouter } from './routes/inspectors.js';
+import { openApiRouter } from './openapi/index.js';
 import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
@@ -61,6 +62,7 @@ app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 
 // Public routes (no auth required)
 app.use('/health', healthRouter);
+app.use('/api', openApiRouter);  // OpenAPI docs (no auth required)
 app.use('/api/auth', authRouter);
 
 // Service routes (JWT or API key auth)

--- a/api/src/openapi/generator.ts
+++ b/api/src/openapi/generator.ts
@@ -1,0 +1,39 @@
+import { OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
+import { registry } from './registry.js';
+
+export function generateOpenAPISpec() {
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+
+  return generator.generateDocument({
+    openapi: '3.1.0',
+    info: {
+      title: 'AI Inspection API',
+      version: '1.0.0',
+      description: 'Backend API for the AI Building Inspection Assistant',
+      contact: {
+        name: 'Apexphere',
+        url: 'https://github.com/apexphere/ai-inspection',
+      },
+    },
+    servers: [
+      {
+        url: 'https://api-test-ai-inspection.apexphere.co.nz',
+        description: 'Test environment',
+      },
+      {
+        url: 'http://localhost:3000',
+        description: 'Local development',
+      },
+    ],
+    tags: [
+      { name: 'Health', description: 'Health check endpoints' },
+      { name: 'Auth', description: 'Authentication endpoints' },
+      { name: 'Inspections', description: 'Inspection management' },
+      { name: 'Projects', description: 'Project management' },
+      { name: 'Properties', description: 'Property management' },
+      { name: 'Findings', description: 'Inspection findings' },
+      { name: 'Photos', description: 'Photo attachments' },
+      { name: 'Reports', description: 'Report generation' },
+    ],
+  });
+}

--- a/api/src/openapi/index.ts
+++ b/api/src/openapi/index.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { generateOpenAPISpec } from './generator.js';
+
+export const openApiRouter = Router();
+
+// Generate spec once at startup
+const spec = generateOpenAPISpec();
+
+// Serve OpenAPI JSON spec
+openApiRouter.get('/openapi.json', (_req, res) => {
+  res.json(spec);
+});
+
+// Serve Swagger UI
+openApiRouter.use('/docs', swaggerUi.serve, swaggerUi.setup(spec, {
+  customCss: '.swagger-ui .topbar { display: none }',
+  customSiteTitle: 'AI Inspection API Docs',
+}));
+
+// Re-export for convenience
+export { registry } from './registry.js';
+export { generateOpenAPISpec } from './generator.js';

--- a/api/src/openapi/registry.ts
+++ b/api/src/openapi/registry.ts
@@ -1,0 +1,4 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+
+// Global registry for all OpenAPI schemas and routes
+export const registry = new OpenAPIRegistry();

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@aws-sdk/client-s3": "^3.994.0",
         "@aws-sdk/s3-request-presigner": "^3.994.0",
         "@prisma/client": "^6.0.0",
@@ -40,6 +41,7 @@
         "multer": "^1.4.5-lts.2",
         "puppeteer": "^24.37.3",
         "sharp": "^0.33.0",
+        "swagger-ui-express": "^5.0.1",
         "tsx": "^4.21.0",
         "yaml": "^2.8.2",
         "zod": "^3.24.0"
@@ -54,6 +56,7 @@
         "@types/multer": "^1.4.12",
         "@types/node": "^22.0.0",
         "@types/supertest": "^6.0.3",
+        "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.39.2",
@@ -494,6 +497,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
       }
     },
     "node_modules/@auth/core": {
@@ -4079,6 +4094,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
@@ -5375,6 +5397,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/yauzl": {
@@ -8456,6 +8489,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -11039,6 +11073,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12700,6 +12743,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.2.tgz",
+      "integrity": "sha512-uIoesCjDcxnAKj/C/HG5pjHZMQs2K/qmqpUlwLxxaVryGKlgm8Ri+VOza5xywAqf//pgg/hW16RYa6dDuTCOSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tailwind-merge": {


### PR DESCRIPTION
## Summary

Setup OpenAPI tooling foundation for API documentation.

## Changes

### Dependencies
- `@asteasolutions/zod-to-openapi@7.3.4` — Generate OpenAPI from Zod schemas
- `swagger-ui-express` — Interactive API docs

### New Files
- `api/src/openapi/registry.ts` — Global schema registry
- `api/src/openapi/generator.ts` — OpenAPI 3.1 spec generator
- `api/src/openapi/index.ts` — Router with Swagger UI

### Endpoints
| Endpoint | Description |
|----------|-------------|
| `GET /api/openapi.json` | Raw OpenAPI spec |
| `GET /api/docs` | Swagger UI |

## Testing

Start the API and visit:
- http://localhost:3000/api/docs — Interactive docs
- http://localhost:3000/api/openapi.json — Raw spec

Currently returns empty spec (no schemas registered yet — that's #429).

---
Closes #428
Parent: #426