### PR TITLE
[Alex] feat(api): add OpenAPI schemas for core endpoints (#429)

### DIFF
--- a/api/src/openapi/index.ts
+++ b/api/src/openapi/index.ts
@@ -2,6 +2,9 @@ import { Router } from 'express';
 import swaggerUi from 'swagger-ui-express';
 import { generateOpenAPISpec } from './generator.js';
 
+// Import schemas to register them with the registry
+import './schemas/index.js';
+
 export const openApiRouter = Router();
 
 // Generate spec once at startup

--- a/api/src/openapi/schemas/finding.ts
+++ b/api/src/openapi/schemas/finding.ts
@@ -1,0 +1,209 @@
+/**
+ * OpenAPI Schemas for Finding Endpoints
+ * Issue #429
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Enums
+// ============================================
+
+export const SeveritySchema = z.enum(['INFO', 'MINOR', 'MAJOR', 'URGENT']).openapi({
+  description: 'Severity level of the finding',
+  example: 'MAJOR',
+});
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const CreateFindingSchema = z.object({
+  inspectionId: z.string().uuid().openapi({
+    description: 'ID of the inspection this finding belongs to',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  section: z.string().min(1).openapi({
+    description: 'Section of the inspection where finding was observed',
+    example: 'exterior',
+  }),
+  text: z.string().min(1).openapi({
+    description: 'Description of the finding',
+    example: 'Cracked weatherboard on north wall',
+  }),
+  severity: SeveritySchema.default('INFO'),
+  matchedComment: z.string().optional().openapi({
+    description: 'Matched template comment if any',
+  }),
+}).openapi('CreateFindingRequest');
+
+export const UpdateFindingSchema = z.object({
+  section: z.string().min(1).optional().openapi({
+    description: 'Updated section',
+  }),
+  text: z.string().min(1).optional().openapi({
+    description: 'Updated finding text',
+  }),
+  severity: SeveritySchema.optional(),
+  matchedComment: z.string().optional().openapi({
+    description: 'Updated matched comment',
+  }),
+}).openapi('UpdateFindingRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const PhotoSummarySchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Photo ID',
+  }),
+  filename: z.string().openapi({
+    description: 'Original filename',
+    example: 'IMG_001.jpg',
+  }),
+  path: z.string().openapi({
+    description: 'Storage path',
+  }),
+  mimeType: z.string().openapi({
+    description: 'MIME type',
+    example: 'image/jpeg',
+  }),
+}).openapi('PhotoSummary');
+
+export const FindingResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Finding ID',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  }),
+  inspectionId: z.string().uuid().openapi({
+    description: 'Parent inspection ID',
+  }),
+  section: z.string().openapi({
+    description: 'Inspection section',
+    example: 'exterior',
+  }),
+  text: z.string().openapi({
+    description: 'Finding description',
+    example: 'Cracked weatherboard on north wall',
+  }),
+  severity: SeveritySchema,
+  matchedComment: z.string().nullable().openapi({
+    description: 'Matched template comment',
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: 'Creation timestamp',
+  }),
+  updatedAt: z.string().datetime().openapi({
+    description: 'Last update timestamp',
+  }),
+  photos: z.array(PhotoSummarySchema).optional().openapi({
+    description: 'Associated photos',
+  }),
+}).openapi('FindingResponse');
+
+export const FindingListResponseSchema = z.array(FindingResponseSchema).openapi('FindingListResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('Severity', SeveritySchema);
+registry.register('CreateFindingRequest', CreateFindingSchema);
+registry.register('UpdateFindingRequest', UpdateFindingSchema);
+registry.register('PhotoSummary', PhotoSummarySchema);
+registry.register('FindingResponse', FindingResponseSchema);
+registry.register('FindingListResponse', FindingListResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/findings',
+  tags: ['Findings'],
+  summary: 'Create a new finding',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateFindingSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Finding created successfully',
+      content: {
+        'application/json': {
+          schema: FindingResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            details: z.record(z.array(z.string())).optional(),
+          }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspections/{inspectionId}/findings',
+  tags: ['Findings'],
+  summary: 'List findings for an inspection',
+  request: {
+    params: z.object({
+      inspectionId: z.string().uuid().openapi({
+        description: 'Inspection ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of findings',
+      content: {
+        'application/json': {
+          schema: FindingListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/findings/{id}',
+  tags: ['Findings'],
+  summary: 'Get finding by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Finding ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Finding details',
+      content: {
+        'application/json': {
+          schema: FindingResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Finding not found',
+    },
+  },
+});

--- a/api/src/openapi/schemas/index.ts
+++ b/api/src/openapi/schemas/index.ts
@@ -1,0 +1,12 @@
+/**
+ * OpenAPI Schema Registry
+ * 
+ * Import all schema files to register them with the OpenAPI registry.
+ * Issue #429
+ */
+
+// Core endpoint schemas
+export * from './inspection.js';
+export * from './finding.js';
+export * from './photo.js';
+export * from './report.js';

--- a/api/src/openapi/schemas/inspection.ts
+++ b/api/src/openapi/schemas/inspection.ts
@@ -1,0 +1,287 @@
+/**
+ * OpenAPI Schemas for Inspection Endpoints
+ * Issue #429
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Enums
+// ============================================
+
+export const InspectionStatusSchema = z.enum(['STARTED', 'IN_PROGRESS', 'COMPLETED']).openapi({
+  description: 'Current status of the inspection',
+  example: 'IN_PROGRESS',
+});
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const CreateInspectionSchema = z.object({
+  address: z.string().min(1).openapi({
+    description: 'Property address being inspected',
+    example: '123 Main Street, Auckland',
+  }),
+  clientName: z.string().min(1).openapi({
+    description: 'Name of the client requesting the inspection',
+    example: 'John Smith',
+  }),
+  inspectorName: z.string().optional().openapi({
+    description: 'Name of the inspector conducting the inspection',
+    example: 'Jane Doe',
+  }),
+  checklistId: z.string().min(1).openapi({
+    description: 'ID of the checklist template to use',
+    example: 'nz-ppi',
+  }),
+  currentSection: z.string().default('exterior').openapi({
+    description: 'Current section of the inspection',
+    example: 'exterior',
+  }),
+  metadata: z.any().optional().openapi({
+    description: 'Additional metadata for the inspection',
+  }),
+}).openapi('CreateInspectionRequest');
+
+export const UpdateInspectionSchema = z.object({
+  address: z.string().min(1).optional().openapi({
+    description: 'Updated property address',
+  }),
+  clientName: z.string().min(1).optional().openapi({
+    description: 'Updated client name',
+  }),
+  inspectorName: z.string().optional().openapi({
+    description: 'Updated inspector name',
+  }),
+  status: InspectionStatusSchema.optional(),
+  currentSection: z.string().optional().openapi({
+    description: 'Current section of the inspection',
+  }),
+  metadata: z.any().optional().openapi({
+    description: 'Additional metadata',
+  }),
+  completedAt: z.string().datetime().optional().openapi({
+    description: 'Completion timestamp (ISO 8601)',
+    example: '2026-02-23T10:00:00Z',
+  }),
+}).openapi('UpdateInspectionRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const InspectionResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Unique identifier for the inspection',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  address: z.string().openapi({
+    description: 'Property address',
+    example: '123 Main Street, Auckland',
+  }),
+  clientName: z.string().openapi({
+    description: 'Client name',
+    example: 'John Smith',
+  }),
+  inspectorName: z.string().nullable().openapi({
+    description: 'Inspector name',
+    example: 'Jane Doe',
+  }),
+  checklistId: z.string().openapi({
+    description: 'Checklist template ID',
+    example: 'nz-ppi',
+  }),
+  status: InspectionStatusSchema,
+  currentSection: z.string().openapi({
+    description: 'Current section',
+    example: 'exterior',
+  }),
+  metadata: z.any().nullable().openapi({
+    description: 'Additional metadata',
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: 'Creation timestamp',
+    example: '2026-02-23T09:00:00Z',
+  }),
+  updatedAt: z.string().datetime().openapi({
+    description: 'Last update timestamp',
+    example: '2026-02-23T10:00:00Z',
+  }),
+  completedAt: z.string().datetime().nullable().openapi({
+    description: 'Completion timestamp',
+    example: '2026-02-23T12:00:00Z',
+  }),
+}).openapi('InspectionResponse');
+
+export const InspectionListResponseSchema = z.array(InspectionResponseSchema).openapi('InspectionListResponse');
+
+// ============================================
+// Error Schemas
+// ============================================
+
+export const ValidationErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Validation failed',
+  }),
+  details: z.record(z.array(z.string())).optional().openapi({
+    description: 'Field-specific validation errors',
+    example: { address: ['Address is required'] },
+  }),
+}).openapi('ValidationError');
+
+export const NotFoundErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Inspection not found',
+  }),
+}).openapi('NotFoundError');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('InspectionStatus', InspectionStatusSchema);
+registry.register('CreateInspectionRequest', CreateInspectionSchema);
+registry.register('UpdateInspectionRequest', UpdateInspectionSchema);
+registry.register('InspectionResponse', InspectionResponseSchema);
+registry.register('InspectionListResponse', InspectionListResponseSchema);
+registry.register('ValidationError', ValidationErrorSchema);
+registry.register('NotFoundError', NotFoundErrorSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/inspections',
+  tags: ['Inspections'],
+  summary: 'Create a new inspection',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateInspectionSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Inspection created successfully',
+      content: {
+        'application/json': {
+          schema: InspectionResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': {
+          schema: ValidationErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspections',
+  tags: ['Inspections'],
+  summary: 'List all inspections',
+  responses: {
+    200: {
+      description: 'List of inspections',
+      content: {
+        'application/json': {
+          schema: InspectionListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspections/{id}',
+  tags: ['Inspections'],
+  summary: 'Get inspection by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Inspection ID',
+        example: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Inspection details',
+      content: {
+        'application/json': {
+          schema: InspectionResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Inspection not found',
+      content: {
+        'application/json': {
+          schema: NotFoundErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/inspections/{id}',
+  tags: ['Inspections'],
+  summary: 'Update an inspection',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Inspection ID',
+      }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateInspectionSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Inspection updated',
+      content: {
+        'application/json': {
+          schema: InspectionResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': {
+          schema: ValidationErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Inspection not found',
+      content: {
+        'application/json': {
+          schema: NotFoundErrorSchema,
+        },
+      },
+    },
+  },
+});

--- a/api/src/openapi/schemas/photo.ts
+++ b/api/src/openapi/schemas/photo.ts
@@ -1,0 +1,177 @@
+/**
+ * OpenAPI Schemas for Photo Endpoints
+ * Issue #429
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const PhotoResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Photo ID',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+  }),
+  findingId: z.string().uuid().openapi({
+    description: 'Associated finding ID',
+  }),
+  filename: z.string().openapi({
+    description: 'Original filename',
+    example: 'IMG_0123.jpg',
+  }),
+  path: z.string().openapi({
+    description: 'Storage path or URL',
+    example: '/photos/abc123.jpg',
+  }),
+  mimeType: z.string().openapi({
+    description: 'MIME type of the image',
+    example: 'image/jpeg',
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: 'Upload timestamp',
+  }),
+}).openapi('PhotoResponse');
+
+export const PhotoUploadResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Photo ID',
+  }),
+  filename: z.string().openapi({
+    description: 'Stored filename',
+  }),
+  path: z.string().openapi({
+    description: 'Storage path',
+  }),
+  url: z.string().url().optional().openapi({
+    description: 'Public URL if available',
+  }),
+}).openapi('PhotoUploadResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('PhotoResponse', PhotoResponseSchema);
+registry.register('PhotoUploadResponse', PhotoUploadResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/photos',
+  tags: ['Photos'],
+  summary: 'Upload a photo',
+  description: 'Upload a photo and associate it with a finding',
+  request: {
+    body: {
+      content: {
+        'multipart/form-data': {
+          schema: z.object({
+            file: z.any().openapi({
+              description: 'Image file (JPEG, PNG)',
+              type: 'string',
+              format: 'binary',
+            }),
+            findingId: z.string().uuid().openapi({
+              description: 'Finding to attach photo to',
+            }),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Photo uploaded successfully',
+      content: {
+        'application/json': {
+          schema: PhotoUploadResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid file or missing findingId',
+    },
+    413: {
+      description: 'File too large (max 10MB)',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/findings/{findingId}/photos',
+  tags: ['Photos'],
+  summary: 'List photos for a finding',
+  request: {
+    params: z.object({
+      findingId: z.string().uuid().openapi({
+        description: 'Finding ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of photos',
+      content: {
+        'application/json': {
+          schema: z.array(PhotoResponseSchema),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/photos/{id}',
+  tags: ['Photos'],
+  summary: 'Get photo by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Photo ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Photo details',
+      content: {
+        'application/json': {
+          schema: PhotoResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Photo not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/photos/{id}',
+  tags: ['Photos'],
+  summary: 'Delete a photo',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Photo ID',
+      }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Photo deleted successfully',
+    },
+    404: {
+      description: 'Photo not found',
+    },
+  },
+});

--- a/api/src/openapi/schemas/report.ts
+++ b/api/src/openapi/schemas/report.ts
@@ -1,0 +1,207 @@
+/**
+ * OpenAPI Schemas for Report Endpoints
+ * Issue #429
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const GenerateReportSchema = z.object({
+  format: z.enum(['pdf', 'docx']).default('pdf').openapi({
+    description: 'Report output format',
+    example: 'pdf',
+  }),
+  includePhotos: z.boolean().default(true).openapi({
+    description: 'Whether to include photos in the report',
+  }),
+  template: z.string().optional().openapi({
+    description: 'Report template ID (uses default if not specified)',
+    example: 'nz-ppi-standard',
+  }),
+}).openapi('GenerateReportRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const ReportResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Report ID',
+    example: '550e8400-e29b-41d4-a716-446655440003',
+  }),
+  inspectionId: z.string().uuid().openapi({
+    description: 'Associated inspection ID',
+  }),
+  format: z.string().openapi({
+    description: 'Report format',
+    example: 'pdf',
+  }),
+  path: z.string().openapi({
+    description: 'Storage path to the report file',
+    example: '/reports/inspection-abc123.pdf',
+  }),
+  url: z.string().url().optional().openapi({
+    description: 'Download URL (if available)',
+    example: 'https://storage.example.com/reports/inspection-abc123.pdf',
+  }),
+  createdAt: z.string().datetime().openapi({
+    description: 'Generation timestamp',
+  }),
+}).openapi('ReportResponse');
+
+export const ReportListResponseSchema = z.array(ReportResponseSchema).openapi('ReportListResponse');
+
+export const ReportGenerationStatusSchema = z.object({
+  status: z.enum(['pending', 'processing', 'completed', 'failed']).openapi({
+    description: 'Current generation status',
+    example: 'completed',
+  }),
+  report: ReportResponseSchema.optional().openapi({
+    description: 'Report details if completed',
+  }),
+  error: z.string().optional().openapi({
+    description: 'Error message if failed',
+  }),
+}).openapi('ReportGenerationStatus');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('GenerateReportRequest', GenerateReportSchema);
+registry.register('ReportResponse', ReportResponseSchema);
+registry.register('ReportListResponse', ReportListResponseSchema);
+registry.register('ReportGenerationStatus', ReportGenerationStatusSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/inspections/{inspectionId}/reports',
+  tags: ['Reports'],
+  summary: 'Generate a report for an inspection',
+  description: 'Generates a PDF or DOCX report for the specified inspection',
+  request: {
+    params: z.object({
+      inspectionId: z.string().uuid().openapi({
+        description: 'Inspection ID',
+      }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: GenerateReportSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Report generated successfully',
+      content: {
+        'application/json': {
+          schema: ReportResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid request',
+    },
+    404: {
+      description: 'Inspection not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspections/{inspectionId}/reports',
+  tags: ['Reports'],
+  summary: 'List reports for an inspection',
+  request: {
+    params: z.object({
+      inspectionId: z.string().uuid().openapi({
+        description: 'Inspection ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of reports',
+      content: {
+        'application/json': {
+          schema: ReportListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/reports/{id}',
+  tags: ['Reports'],
+  summary: 'Get report by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Report ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Report details',
+      content: {
+        'application/json': {
+          schema: ReportResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Report not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/reports/{id}/download',
+  tags: ['Reports'],
+  summary: 'Download report file',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({
+        description: 'Report ID',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Report file',
+      content: {
+        'application/pdf': {
+          schema: z.any().openapi({
+            type: 'string',
+            format: 'binary',
+          }),
+        },
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
+          schema: z.any().openapi({
+            type: 'string',
+            format: 'binary',
+          }),
+        },
+      },
+    },
+    404: {
+      description: 'Report not found',
+    },
+  },
+});

--- a/api/src/openapi/setup.ts
+++ b/api/src/openapi/setup.ts
@@ -1,0 +1,13 @@
+/**
+ * OpenAPI Setup
+ * 
+ * Extends Zod with OpenAPI methods. Must be imported before any schemas.
+ */
+
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+// Extend Zod globally with OpenAPI methods
+extendZodWithOpenApi(z);
+
+export { z };


### PR DESCRIPTION
## Summary
Adds OpenAPI schemas with `.openapi()` metadata for core inspection workflow endpoints.

## Changes
- **Inspection schemas**: Create, Update, Response with full metadata
- **Finding schemas**: With severity enum and photo associations
- **Photo schemas**: Upload (multipart) and response schemas
- **Report schemas**: Generation request and status tracking

## Endpoints Documented
- `POST/GET/PUT /api/inspections`
- `POST/GET /api/findings`
- `POST/GET/DELETE /api/photos`
- `POST/GET /api/reports`

## Technical Notes
- Uses `@asteasolutions/zod-to-openapi` for schema registration
- All schemas registered with the OpenAPI registry
- Includes examples for Swagger UI display

## Dependencies
⚠️ **Depends on PR #433** (#428 - OpenAPI foundation setup)

## Linked Issue
Closes #429

Parent: #426