### PR TITLE
[Sage] docs(guides): add photo source and clause linking (#406)

### DIFF
--- a/docs/guides/inspector-workflow.md
+++ b/docs/guides/inspector-workflow.md
@@ -143,6 +143,32 @@ You: [photo] "Water damage on soffit"
 Assistant: Noted — water damage on soffit (minor). Photo saved.
 ```
 
+### Photo Source
+
+Specify who provided the photo:
+
+| Source | When to use |
+|--------|-------------|
+| **Site Inspection** | You took it on-site (default) |
+| **Owner Provided** | Client/homeowner supplied it |
+| **Contractor Provided** | Builder or tradesperson supplied it |
+
+```
+You: [photo] "Owner provided this photo of the original work"
+Assistant: Photo saved (owner provided). Caption: original work.
+```
+
+### Linking Photos to Clauses
+
+For COA/CCC inspections, link photos to Building Code clauses:
+
+```
+You: [photo] "E3 evidence - tanking installed"
+Assistant: Photo saved and linked to E3 (Internal Moisture).
+```
+
+The photo will appear in the report appendix with the clause reference.
+
 ### Severity Levels
 
 The assistant infers severity, but you can specify:

--- a/docs/guides/web-ui.md
+++ b/docs/guides/web-ui.md
@@ -164,6 +164,28 @@ Photos are shown in the **Photos** section of each project and within each inspe
 3. Add a caption describing what it shows
 4. The photo is linked to the current section
 
+### Photo Source
+
+Set who provided the photo:
+
+| Source | Use for |
+|--------|---------|
+| **Site Inspection** | Photos you took on-site |
+| **Owner Provided** | Photos from the client/homeowner |
+| **Contractor Provided** | Photos from the builder/trades |
+
+The source appears in reports: "(Photo provided by owner)"
+
+### Linking to Clauses
+
+For COA/CCC reports, link photos to Building Code clauses:
+
+1. Open the photo details
+2. Click **Link to Clause**
+3. Select relevant clauses (B1, E2, E3, etc.)
+
+Linked photos appear in the report appendix with clause references.
+
 ---
 
 ## Reports


### PR DESCRIPTION
## Summary
Documents photo source selection and clause linking features.

## Changes
**inspector-workflow.md:**
- Photo Source section (Site/Owner/Contractor)
- Linking Photos to Clauses section for COA/CCC

**web-ui.md:**
- Photo Source section with usage table
- Linking to Clauses instructions

## Context
Alex confirmed both features are implemented in MVP:
- `ProjectPhoto.source` field with `PhotoSource` enum
- `ProjectPhoto.linkedClauses` field (string array)

## Related
Closes #406
Part of #391

---
🌿 **Sage** — Tech Writer