### PR TITLE
[Alex] feat(api): register all API routes in OpenAPI spec (#431)

### DIFF
--- a/api/src/openapi/generator.ts
+++ b/api/src/openapi/generator.ts
@@ -31,9 +31,12 @@ export function generateOpenAPISpec() {
       { name: 'Inspections', description: 'Inspection management' },
       { name: 'Projects', description: 'Project management' },
       { name: 'Properties', description: 'Property management' },
+      { name: 'Clients', description: 'Client management' },
+      { name: 'Inspectors', description: 'Inspector lookup (service auth)' },
       { name: 'Findings', description: 'Inspection findings' },
       { name: 'Photos', description: 'Photo attachments' },
       { name: 'Reports', description: 'Report generation' },
+      { name: 'Building Code', description: 'NZ Building Code reference data' },
     ],
   });
 }

--- a/api/src/openapi/routes/building-code.ts
+++ b/api/src/openapi/routes/building-code.ts
@@ -1,0 +1,256 @@
+/**
+ * OpenAPI Route Registration for Building Code
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+import { ErrorResponseSchema } from '../schemas/common.js';
+
+// ============================================
+// Enums
+// ============================================
+
+const ClauseCategorySchema = z.enum(['B', 'C', 'D', 'E', 'F', 'G', 'H']).openapi({
+  description: 'Building code clause category',
+  example: 'E',
+});
+
+const DurabilityPeriodSchema = z.enum(['FIFTY_YEARS', 'FIFTEEN_YEARS', 'FIVE_YEARS', 'NA']).openapi({
+  description: 'Durability period for the clause',
+  example: 'FIFTEEN_YEARS',
+});
+
+// ============================================
+// Schemas
+// ============================================
+
+const CreateClauseSchema = z.object({
+  code: z.string().min(1).openapi({
+    description: 'Unique clause code',
+    example: 'E2.3.1',
+  }),
+  title: z.string().min(1).openapi({
+    description: 'Clause title',
+    example: 'External moisture',
+  }),
+  category: ClauseCategorySchema,
+  objective: z.string().optional(),
+  functionalReq: z.string().optional(),
+  performanceText: z.string().min(1).openapi({
+    description: 'Performance criteria text',
+    example: 'Buildings must be constructed to prevent moisture penetration...',
+  }),
+  durabilityPeriod: DurabilityPeriodSchema.optional(),
+  typicalEvidence: z.array(z.string()).optional().openapi({
+    description: 'List of typical evidence items',
+    example: ['Visual inspection', 'Moisture readings'],
+  }),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().optional(),
+}).openapi('CreateClauseRequest');
+
+const UpdateClauseSchema = z.object({
+  code: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  category: ClauseCategorySchema.optional(),
+  objective: z.string().optional(),
+  functionalReq: z.string().optional(),
+  performanceText: z.string().min(1).optional(),
+  durabilityPeriod: DurabilityPeriodSchema.optional(),
+  typicalEvidence: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().nullable().optional(),
+}).openapi('UpdateClauseRequest');
+
+const ClauseResponseSchema = z.object({
+  id: z.string().uuid(),
+  code: z.string().openapi({ example: 'E2.3.1' }),
+  title: z.string().openapi({ example: 'External moisture' }),
+  category: ClauseCategorySchema,
+  objective: z.string().nullable(),
+  functionalReq: z.string().nullable(),
+  performanceText: z.string(),
+  durabilityPeriod: DurabilityPeriodSchema.nullable(),
+  typicalEvidence: z.array(z.string()),
+  sortOrder: z.number().int(),
+  parentId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).openapi('ClauseResponse');
+
+const ClauseListResponseSchema = z.array(ClauseResponseSchema).openapi('ClauseListResponse');
+
+// Register schemas
+registry.register('ClauseCategory', ClauseCategorySchema);
+registry.register('DurabilityPeriod', DurabilityPeriodSchema);
+registry.register('CreateClauseRequest', CreateClauseSchema);
+registry.register('UpdateClauseRequest', UpdateClauseSchema);
+registry.register('ClauseResponse', ClauseResponseSchema);
+registry.register('ClauseListResponse', ClauseListResponseSchema);
+
+// ============================================
+// Routes
+// ============================================
+
+// GET /api/building-code/clauses - List clauses
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses',
+  summary: 'List building code clauses',
+  description: 'Retrieve NZ Building Code clauses with optional filters.',
+  tags: ['Building Code'],
+  request: {
+    query: z.object({
+      category: ClauseCategorySchema.optional().openapi({ description: 'Filter by category' }),
+      keyword: z.string().optional().openapi({ description: 'Search in code/title' }),
+      parentId: z.string().optional().openapi({ description: 'Filter by parent ID' }),
+      topLevel: z.string().optional().openapi({ description: 'Set to "true" for top-level only' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of clauses',
+      content: {
+        'application/json': { schema: ClauseListResponseSchema },
+      },
+    },
+  },
+});
+
+// GET /api/building-code/clauses/hierarchy - Get hierarchy
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses/hierarchy',
+  summary: 'Get clauses grouped by category',
+  description: 'Returns clauses organized in a hierarchical structure by category.',
+  tags: ['Building Code'],
+  responses: {
+    200: {
+      description: 'Clauses grouped by category',
+      content: {
+        'application/json': {
+          schema: z.record(ClauseCategorySchema, ClauseListResponseSchema),
+        },
+      },
+    },
+  },
+});
+
+// GET /api/building-code/clauses/:code - Get by code
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses/{code}',
+  summary: 'Get clause by code',
+  tags: ['Building Code'],
+  request: {
+    params: z.object({
+      code: z.string().openapi({ description: 'Clause code (e.g., E2.3.1)', example: 'E2.3.1' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Clause details',
+      content: {
+        'application/json': { schema: ClauseResponseSchema },
+      },
+    },
+    404: {
+      description: 'Clause not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// POST /api/building-code/clauses - Create clause (admin)
+registry.registerPath({
+  method: 'post',
+  path: '/api/building-code/clauses',
+  summary: 'Create a new clause (admin only)',
+  tags: ['Building Code'],
+  request: {
+    body: {
+      content: {
+        'application/json': { schema: CreateClauseSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Clause created',
+      content: {
+        'application/json': { schema: ClauseResponseSchema },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+    403: {
+      description: 'Admin access required',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// PUT /api/building-code/clauses/:id - Update clause (admin)
+registry.registerPath({
+  method: 'put',
+  path: '/api/building-code/clauses/{id}',
+  summary: 'Update a clause (admin only)',
+  tags: ['Building Code'],
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Clause ID' }),
+    }),
+    body: {
+      content: {
+        'application/json': { schema: UpdateClauseSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Clause updated',
+      content: {
+        'application/json': { schema: ClauseResponseSchema },
+      },
+    },
+    404: {
+      description: 'Clause not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// DELETE /api/building-code/clauses/:id - Delete clause (admin)
+registry.registerPath({
+  method: 'delete',
+  path: '/api/building-code/clauses/{id}',
+  summary: 'Delete a clause (admin only)',
+  tags: ['Building Code'],
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Clause ID' }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Clause deleted',
+    },
+    404: {
+      description: 'Clause not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});

--- a/api/src/openapi/routes/clients.ts
+++ b/api/src/openapi/routes/clients.ts
@@ -1,0 +1,216 @@
+/**
+ * OpenAPI Route Registration for Clients
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+import { ErrorResponseSchema } from '../schemas/common.js';
+
+// ============================================
+// Schemas
+// ============================================
+
+const CreateClientSchema = z.object({
+  name: z.string().min(1).openapi({
+    description: 'Client name',
+    example: 'Sarah Johnson',
+  }),
+  email: z.string().email().optional().openapi({
+    description: 'Client email',
+    example: 'sarah@example.com',
+  }),
+  phone: z.string().optional().openapi({
+    description: 'Client phone number',
+    example: '+64 9 123 4567',
+  }),
+  mobile: z.string().optional().openapi({
+    description: 'Client mobile number',
+    example: '+64 21 123 4567',
+  }),
+  address: z.string().optional().openapi({
+    description: 'Client address',
+    example: '42 Oak Street, Ponsonby, Auckland',
+  }),
+  contactPerson: z.string().optional().openapi({
+    description: 'Primary contact person',
+    example: 'John Smith',
+  }),
+}).openapi('CreateClientRequest');
+
+const UpdateClientSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  phone: z.string().optional(),
+  mobile: z.string().optional(),
+  address: z.string().optional(),
+  contactPerson: z.string().optional(),
+}).openapi('UpdateClientRequest');
+
+const ClientResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Client ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  }),
+  name: z.string().openapi({
+    description: 'Client name',
+    example: 'Sarah Johnson',
+  }),
+  email: z.string().nullable().openapi({
+    description: 'Client email',
+    example: 'sarah@example.com',
+  }),
+  phone: z.string().nullable(),
+  mobile: z.string().nullable(),
+  address: z.string().nullable(),
+  contactPerson: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).openapi('ClientResponse');
+
+const ClientListResponseSchema = z.array(ClientResponseSchema).openapi('ClientListResponse');
+
+// Register schemas
+registry.register('CreateClientRequest', CreateClientSchema);
+registry.register('UpdateClientRequest', UpdateClientSchema);
+registry.register('ClientResponse', ClientResponseSchema);
+registry.register('ClientListResponse', ClientListResponseSchema);
+
+// ============================================
+// Routes
+// ============================================
+
+// POST /api/clients - Create client
+registry.registerPath({
+  method: 'post',
+  path: '/api/clients',
+  summary: 'Create a new client',
+  description: 'Create a new client record for project association.',
+  tags: ['Clients'],
+  request: {
+    body: {
+      content: {
+        'application/json': { schema: CreateClientSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Client created successfully',
+      content: {
+        'application/json': { schema: ClientResponseSchema },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// GET /api/clients - List clients
+registry.registerPath({
+  method: 'get',
+  path: '/api/clients',
+  summary: 'List all clients',
+  description: 'Retrieve all clients with optional name filter.',
+  tags: ['Clients'],
+  request: {
+    query: z.object({
+      name: z.string().optional().openapi({ description: 'Filter by name (partial match)' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of clients',
+      content: {
+        'application/json': { schema: ClientListResponseSchema },
+      },
+    },
+  },
+});
+
+// GET /api/clients/:id - Get client
+registry.registerPath({
+  method: 'get',
+  path: '/api/clients/{id}',
+  summary: 'Get client by ID',
+  tags: ['Clients'],
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Client details',
+      content: {
+        'application/json': { schema: ClientResponseSchema },
+      },
+    },
+    404: {
+      description: 'Client not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// PUT /api/clients/:id - Update client
+registry.registerPath({
+  method: 'put',
+  path: '/api/clients/{id}',
+  summary: 'Update a client',
+  tags: ['Clients'],
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+    body: {
+      content: {
+        'application/json': { schema: UpdateClientSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Client updated',
+      content: {
+        'application/json': { schema: ClientResponseSchema },
+      },
+    },
+    404: {
+      description: 'Client not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});
+
+// DELETE /api/clients/:id - Delete client
+registry.registerPath({
+  method: 'delete',
+  path: '/api/clients/{id}',
+  summary: 'Delete a client',
+  tags: ['Clients'],
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Client deleted',
+    },
+    404: {
+      description: 'Client not found',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+  },
+});

--- a/api/src/openapi/routes/index.ts
+++ b/api/src/openapi/routes/index.ts
@@ -13,6 +13,9 @@ import './reports.js';
 
 // Supporting routes
 import './projects.js';
+import './clients.js';
+import './inspectors.js';
 
 // Reference routes
 import './health.js';
+import './building-code.js';

--- a/api/src/openapi/routes/inspectors.ts
+++ b/api/src/openapi/routes/inspectors.ts
@@ -1,0 +1,94 @@
+/**
+ * OpenAPI Route Registration for Inspectors
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+import { ErrorResponseSchema } from '../schemas/common.js';
+
+// ============================================
+// Schemas
+// ============================================
+
+const InspectorResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Inspector (user) ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  }),
+  name: z.string().nullable().openapi({
+    description: 'Inspector name',
+    example: 'Jake Li',
+  }),
+  email: z.string().openapi({
+    description: 'Inspector email',
+    example: 'jake@example.com',
+  }),
+}).openapi('InspectorResponse');
+
+const InspectorNotFoundSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Inspector not found',
+  }),
+  message: z.string().openapi({
+    description: 'User-friendly message for WhatsApp response',
+    example: "I don't have you registered. Contact admin to set up your profile.",
+  }),
+}).openapi('InspectorNotFoundError');
+
+// Register schemas
+registry.register('InspectorResponse', InspectorResponseSchema);
+registry.register('InspectorNotFoundError', InspectorNotFoundSchema);
+
+// ============================================
+// Routes
+// ============================================
+
+// GET /api/inspectors/by-phone/:phone - Lookup inspector by phone
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspectors/by-phone/{phone}',
+  summary: 'Look up inspector by phone number',
+  description: `Used by WhatsApp agent to identify which inspector is messaging.
+
+**Authentication:** Requires X-API-Key header (service auth) or JWT token.
+
+**Phone format:** E.164 format with + prefix (URL encoded as %2B).`,
+  tags: ['Inspectors'],
+  security: [{ apiKey: [] }, { bearerAuth: [] }],
+  request: {
+    params: z.object({
+      phone: z.string().openapi({
+        description: 'Phone number in E.164 format (URL encoded)',
+        example: '%2B64211234567',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Inspector found',
+      content: {
+        'application/json': { schema: InspectorResponseSchema },
+      },
+    },
+    400: {
+      description: 'Invalid phone number format',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+    401: {
+      description: 'Authentication required',
+      content: {
+        'application/json': { schema: ErrorResponseSchema },
+      },
+    },
+    404: {
+      description: 'Inspector not found',
+      content: {
+        'application/json': { schema: InspectorNotFoundSchema },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Adds OpenAPI route registrations for remaining endpoints (clients, inspectors, building-code).

Rebased on develop after PR #440 (Archer's core routes).

## Routes Added

### Supporting
- **Clients** — CRUD endpoints
- **Inspectors** — Phone lookup (service auth)

### Reference
- **Building Code** — NZ Building Code clauses CRUD

## Files Added
- `api/src/openapi/routes/clients.ts`
- `api/src/openapi/routes/inspectors.ts`
- `api/src/openapi/routes/building-code.ts`

## Changes
- Updated `routes/index.ts` to import new route files
- Added tags to generator (Clients, Inspectors, Building Code)

Closes #431