### PR TITLE
[Alex] feat(api): polish OpenAPI spec (#432)

### DIFF
--- a/api/src/openapi/generator.ts
+++ b/api/src/openapi/generator.ts
@@ -31,9 +31,12 @@ export function generateOpenAPISpec() {
       { name: 'Inspections', description: 'Inspection management' },
       { name: 'Projects', description: 'Project management' },
       { name: 'Properties', description: 'Property management' },
+      { name: 'Clients', description: 'Client management' },
+      { name: 'Inspectors', description: 'Inspector lookup (service auth)' },
       { name: 'Findings', description: 'Inspection findings' },
       { name: 'Photos', description: 'Photo attachments' },
       { name: 'Reports', description: 'Report generation' },
+      { name: 'Building Code', description: 'NZ Building Code reference data' },
     ],
   });
 }

--- a/api/src/openapi/generator.ts
+++ b/api/src/openapi/generator.ts
@@ -4,15 +4,37 @@ import { registry } from './registry.js';
 export function generateOpenAPISpec() {
   const generator = new OpenApiGeneratorV31(registry.definitions);
 
-  return generator.generateDocument({
+  const spec = generator.generateDocument({
     openapi: '3.1.0',
     info: {
       title: 'AI Inspection API',
       version: '1.0.0',
-      description: 'Backend API for the AI Building Inspection Assistant',
+      description: `Backend API for the AI Building Inspection Assistant.
+
+## Overview
+This API powers the AI-assisted building inspection workflow:
+- **Inspections** — Create and manage property inspections
+- **Findings** — Record observations during inspections
+- **Photos** — Attach photos to findings
+- **Reports** — Generate PDF inspection reports
+
+## Authentication
+Most endpoints require JWT authentication via cookie or Bearer token.
+Service endpoints (e.g., inspector lookup) accept X-API-Key header.
+
+## Workflow
+1. Create inspection with address and client info
+2. Navigate through sections (exterior → interior → services)
+3. Add findings with severity levels
+4. Attach photos to findings
+5. Generate final report`,
       contact: {
         name: 'Apexphere',
         url: 'https://github.com/apexphere/ai-inspection',
+        email: 'support@apexphere.co.nz',
+      },
+      license: {
+        name: 'Proprietary',
       },
     },
     servers: [
@@ -39,4 +61,36 @@ export function generateOpenAPISpec() {
       { name: 'Building Code', description: 'NZ Building Code reference data' },
     ],
   });
+
+  // Add security schemes to the generated spec
+  return {
+    ...spec,
+    components: {
+      ...spec.components,
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'JWT token from /api/auth/login',
+        },
+        apiKey: {
+          type: 'apiKey',
+          in: 'header',
+          name: 'X-API-Key',
+          description: 'Service API key for service-to-service auth',
+        },
+        cookieAuth: {
+          type: 'apiKey',
+          in: 'cookie',
+          name: 'token',
+          description: 'JWT token in HTTP-only cookie',
+        },
+      },
+    },
+    security: [
+      { bearerAuth: [] },
+      { cookieAuth: [] },
+    ],
+  };
 }

--- a/api/src/openapi/schemas/building-code.ts
+++ b/api/src/openapi/schemas/building-code.ts
@@ -1,0 +1,272 @@
+/**
+ * OpenAPI Schemas for Building Code Endpoints
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Enums
+// ============================================
+
+export const ClauseCategorySchema = z.enum(['B', 'C', 'D', 'E', 'F', 'G', 'H']).openapi({
+  description: 'Building code clause category',
+  example: 'E',
+});
+
+export const DurabilityPeriodSchema = z.enum(['FIFTY_YEARS', 'FIFTEEN_YEARS', 'FIVE_YEARS', 'NA']).openapi({
+  description: 'Durability period for the clause',
+  example: 'FIFTEEN_YEARS',
+});
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const CreateClauseSchema = z.object({
+  code: z.string().min(1).openapi({
+    description: 'Unique clause code',
+    example: 'E2.3.1',
+  }),
+  title: z.string().min(1).openapi({
+    description: 'Clause title',
+    example: 'External moisture',
+  }),
+  category: ClauseCategorySchema,
+  objective: z.string().optional().openapi({
+    description: 'Clause objective',
+  }),
+  functionalReq: z.string().optional().openapi({
+    description: 'Functional requirement',
+  }),
+  performanceText: z.string().min(1).openapi({
+    description: 'Performance criteria text',
+    example: 'Buildings must be constructed to prevent moisture penetration...',
+  }),
+  durabilityPeriod: DurabilityPeriodSchema.optional(),
+  typicalEvidence: z.array(z.string()).optional().openapi({
+    description: 'List of typical evidence items',
+    example: ['Visual inspection', 'Moisture readings'],
+  }),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().optional().openapi({
+    description: 'Parent clause ID for hierarchy',
+  }),
+}).openapi('CreateClauseRequest');
+
+export const UpdateClauseSchema = z.object({
+  code: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  category: ClauseCategorySchema.optional(),
+  objective: z.string().optional(),
+  functionalReq: z.string().optional(),
+  performanceText: z.string().min(1).optional(),
+  durabilityPeriod: DurabilityPeriodSchema.optional(),
+  typicalEvidence: z.array(z.string()).optional(),
+  sortOrder: z.number().int().optional(),
+  parentId: z.string().uuid().nullable().optional(),
+}).openapi('UpdateClauseRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const ClauseResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Clause ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  code: z.string().openapi({
+    description: 'Clause code',
+    example: 'E2.3.1',
+  }),
+  title: z.string().openapi({
+    description: 'Clause title',
+    example: 'External moisture',
+  }),
+  category: ClauseCategorySchema,
+  objective: z.string().nullable(),
+  functionalReq: z.string().nullable(),
+  performanceText: z.string(),
+  durabilityPeriod: DurabilityPeriodSchema.nullable(),
+  typicalEvidence: z.array(z.string()),
+  sortOrder: z.number().int(),
+  parentId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).openapi('ClauseResponse');
+
+export const ClauseListResponseSchema = z.array(ClauseResponseSchema).openapi('ClauseListResponse');
+
+export const ClauseHierarchyResponseSchema = z.record(
+  ClauseCategorySchema,
+  z.array(ClauseResponseSchema)
+).openapi('ClauseHierarchyResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('ClauseCategory', ClauseCategorySchema);
+registry.register('DurabilityPeriod', DurabilityPeriodSchema);
+registry.register('CreateClauseRequest', CreateClauseSchema);
+registry.register('UpdateClauseRequest', UpdateClauseSchema);
+registry.register('ClauseResponse', ClauseResponseSchema);
+registry.register('ClauseListResponse', ClauseListResponseSchema);
+registry.register('ClauseHierarchyResponse', ClauseHierarchyResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses',
+  tags: ['Building Code'],
+  summary: 'List building code clauses',
+  request: {
+    query: z.object({
+      category: ClauseCategorySchema.optional().openapi({ description: 'Filter by category' }),
+      keyword: z.string().optional().openapi({ description: 'Search in code/title' }),
+      parentId: z.string().optional().openapi({ description: 'Filter by parent ID' }),
+      topLevel: z.string().optional().openapi({ description: 'Set to "true" to get only top-level clauses' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of clauses',
+      content: {
+        'application/json': {
+          schema: ClauseListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses/hierarchy',
+  tags: ['Building Code'],
+  summary: 'Get clauses grouped by category',
+  responses: {
+    200: {
+      description: 'Clauses grouped by category',
+      content: {
+        'application/json': {
+          schema: ClauseHierarchyResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/building-code/clauses/{code}',
+  tags: ['Building Code'],
+  summary: 'Get clause by code',
+  request: {
+    params: z.object({
+      code: z.string().openapi({ description: 'Clause code (e.g., E2.3.1)' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Clause details',
+      content: {
+        'application/json': {
+          schema: ClauseResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Clause not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/building-code/clauses',
+  tags: ['Building Code'],
+  summary: 'Create a new clause (admin only)',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateClauseSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Clause created',
+      content: {
+        'application/json': {
+          schema: ClauseResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+    },
+    403: {
+      description: 'Admin access required',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/building-code/clauses/{id}',
+  tags: ['Building Code'],
+  summary: 'Update a clause (admin only)',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Clause ID' }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateClauseSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Clause updated',
+      content: {
+        'application/json': {
+          schema: ClauseResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Clause not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/building-code/clauses/{id}',
+  tags: ['Building Code'],
+  summary: 'Delete a clause (admin only)',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Clause ID' }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Clause deleted',
+    },
+    404: {
+      description: 'Clause not found',
+    },
+  },
+});

--- a/api/src/openapi/schemas/client.ts
+++ b/api/src/openapi/schemas/client.ts
@@ -1,0 +1,223 @@
+/**
+ * OpenAPI Schemas for Client Endpoints
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const CreateClientSchema = z.object({
+  name: z.string().min(1).openapi({
+    description: 'Client name',
+    example: 'John Smith',
+  }),
+  email: z.string().email().optional().openapi({
+    description: 'Client email',
+    example: 'john@example.com',
+  }),
+  phone: z.string().optional().openapi({
+    description: 'Client phone number',
+    example: '+64 9 123 4567',
+  }),
+  mobile: z.string().optional().openapi({
+    description: 'Client mobile number',
+    example: '+64 21 123 4567',
+  }),
+  address: z.string().optional().openapi({
+    description: 'Client address',
+    example: '123 Main Street, Auckland',
+  }),
+  contactPerson: z.string().optional().openapi({
+    description: 'Primary contact person',
+    example: 'Jane Smith',
+  }),
+}).openapi('CreateClientRequest');
+
+export const UpdateClientSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  phone: z.string().optional(),
+  mobile: z.string().optional(),
+  address: z.string().optional(),
+  contactPerson: z.string().optional(),
+}).openapi('UpdateClientRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const ClientResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Client ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  name: z.string().openapi({
+    description: 'Client name',
+    example: 'John Smith',
+  }),
+  email: z.string().nullable().openapi({
+    description: 'Client email',
+    example: 'john@example.com',
+  }),
+  phone: z.string().nullable().openapi({
+    description: 'Client phone',
+  }),
+  mobile: z.string().nullable().openapi({
+    description: 'Client mobile',
+  }),
+  address: z.string().nullable().openapi({
+    description: 'Client address',
+  }),
+  contactPerson: z.string().nullable().openapi({
+    description: 'Primary contact person',
+  }),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).openapi('ClientResponse');
+
+export const ClientListResponseSchema = z.array(ClientResponseSchema).openapi('ClientListResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('CreateClientRequest', CreateClientSchema);
+registry.register('UpdateClientRequest', UpdateClientSchema);
+registry.register('ClientResponse', ClientResponseSchema);
+registry.register('ClientListResponse', ClientListResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/clients',
+  tags: ['Clients'],
+  summary: 'Create a new client',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateClientSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Client created successfully',
+      content: {
+        'application/json': {
+          schema: ClientResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/clients',
+  tags: ['Clients'],
+  summary: 'List all clients',
+  request: {
+    query: z.object({
+      name: z.string().optional().openapi({ description: 'Filter by name (partial match)' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of clients',
+      content: {
+        'application/json': {
+          schema: ClientListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/clients/{id}',
+  tags: ['Clients'],
+  summary: 'Get client by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Client details',
+      content: {
+        'application/json': {
+          schema: ClientResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Client not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/clients/{id}',
+  tags: ['Clients'],
+  summary: 'Update a client',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateClientSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Client updated',
+      content: {
+        'application/json': {
+          schema: ClientResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Client not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/clients/{id}',
+  tags: ['Clients'],
+  summary: 'Delete a client',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Client ID' }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Client deleted',
+    },
+    404: {
+      description: 'Client not found',
+    },
+  },
+});

--- a/api/src/openapi/schemas/errors.ts
+++ b/api/src/openapi/schemas/errors.ts
@@ -1,0 +1,89 @@
+/**
+ * Standardized Error Response Schemas
+ * Issue #432
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Common Error Schemas
+// ============================================
+
+/**
+ * 400 Bad Request - Validation errors
+ */
+export const BadRequestErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error type',
+    example: 'Validation failed',
+  }),
+  details: z.record(z.array(z.string())).optional().openapi({
+    description: 'Field-specific validation errors',
+    example: {
+      address: ['Address is required'],
+      clientName: ['Client name must be at least 1 character'],
+    },
+  }),
+}).openapi('BadRequestError');
+
+/**
+ * 401 Unauthorized - Authentication required
+ */
+export const UnauthorizedErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Authentication required',
+  }),
+}).openapi('UnauthorizedError');
+
+/**
+ * 403 Forbidden - Insufficient permissions
+ */
+export const ForbiddenErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Admin access required',
+  }),
+}).openapi('ForbiddenError');
+
+/**
+ * 404 Not Found - Resource doesn't exist
+ */
+export const NotFoundErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Resource not found',
+  }),
+}).openapi('NotFoundError');
+
+/**
+ * 409 Conflict - Resource already exists
+ */
+export const ConflictErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Resource already exists',
+  }),
+}).openapi('ConflictError');
+
+/**
+ * 500 Internal Server Error - Unexpected errors
+ */
+export const InternalErrorSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Internal server error',
+  }),
+}).openapi('InternalError');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('BadRequestError', BadRequestErrorSchema);
+registry.register('UnauthorizedError', UnauthorizedErrorSchema);
+registry.register('ForbiddenError', ForbiddenErrorSchema);
+registry.register('NotFoundError', NotFoundErrorSchema);
+registry.register('ConflictError', ConflictErrorSchema);
+registry.register('InternalError', InternalErrorSchema);

--- a/api/src/openapi/schemas/health.ts
+++ b/api/src/openapi/schemas/health.ts
@@ -1,0 +1,58 @@
+/**
+ * OpenAPI Schemas for Health Endpoints
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const HealthResponseSchema = z.object({
+  status: z.enum(['ok', 'error']).openapi({
+    description: 'Health status',
+    example: 'ok',
+  }),
+  version: z.string().optional().openapi({
+    description: 'Git commit SHA',
+    example: 'abc123',
+  }),
+  branch: z.string().optional().openapi({
+    description: 'Git branch name',
+    example: 'develop',
+  }),
+  timestamp: z.string().datetime().openapi({
+    description: 'Current server timestamp',
+    example: '2026-02-23T10:00:00Z',
+  }),
+}).openapi('HealthResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('HealthResponse', HealthResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'get',
+  path: '/health',
+  tags: ['Health'],
+  summary: 'Health check endpoint',
+  description: 'Returns server health status and version info',
+  responses: {
+    200: {
+      description: 'Server is healthy',
+      content: {
+        'application/json': {
+          schema: HealthResponseSchema,
+        },
+      },
+    },
+  },
+});

--- a/api/src/openapi/schemas/index.ts
+++ b/api/src/openapi/schemas/index.ts
@@ -2,7 +2,7 @@
  * OpenAPI Schema Registry
  * 
  * Import all schema files to register them with the OpenAPI registry.
- * Issue #429
+ * Issues #429, #431
  */
 
 // Core endpoint schemas
@@ -10,3 +10,12 @@ export * from './inspection.js';
 export * from './finding.js';
 export * from './photo.js';
 export * from './report.js';
+
+// Supporting endpoint schemas
+export * from './project.js';
+export * from './client.js';
+export * from './inspector.js';
+
+// Reference endpoint schemas
+export * from './health.js';
+export * from './building-code.js';

--- a/api/src/openapi/schemas/index.ts
+++ b/api/src/openapi/schemas/index.ts
@@ -2,8 +2,11 @@
  * OpenAPI Schema Registry
  * 
  * Import all schema files to register them with the OpenAPI registry.
- * Issues #429, #431
+ * Issues #429, #431, #432
  */
+
+// Common schemas
+export * from './errors.js';
 
 // Core endpoint schemas
 export * from './inspection.js';

--- a/api/src/openapi/schemas/inspection.ts
+++ b/api/src/openapi/schemas/inspection.ts
@@ -1,10 +1,11 @@
 /**
  * OpenAPI Schemas for Inspection Endpoints
- * Issue #429
+ * Issue #429, #432
  */
 
 import { z } from '../setup.js';
 import { registry } from '../registry.js';
+import { BadRequestErrorSchema, NotFoundErrorSchema } from './errors.js';
 
 // ============================================
 // Enums
@@ -22,15 +23,15 @@ export const InspectionStatusSchema = z.enum(['STARTED', 'IN_PROGRESS', 'COMPLET
 export const CreateInspectionSchema = z.object({
   address: z.string().min(1).openapi({
     description: 'Property address being inspected',
-    example: '123 Main Street, Auckland',
+    example: '42 Oak Street, Ponsonby, Auckland',
   }),
   clientName: z.string().min(1).openapi({
     description: 'Name of the client requesting the inspection',
-    example: 'John Smith',
+    example: 'Sarah Johnson',
   }),
   inspectorName: z.string().optional().openapi({
     description: 'Name of the inspector conducting the inspection',
-    example: 'Jane Doe',
+    example: 'Jake Li',
   }),
   checklistId: z.string().min(1).openapi({
     description: 'ID of the checklist template to use',
@@ -64,7 +65,7 @@ export const UpdateInspectionSchema = z.object({
   }),
   completedAt: z.string().datetime().optional().openapi({
     description: 'Completion timestamp (ISO 8601)',
-    example: '2026-02-23T10:00:00Z',
+    example: '2026-02-23T14:30:00Z',
   }),
 }).openapi('UpdateInspectionRequest');
 
@@ -79,15 +80,15 @@ export const InspectionResponseSchema = z.object({
   }),
   address: z.string().openapi({
     description: 'Property address',
-    example: '123 Main Street, Auckland',
+    example: '42 Oak Street, Ponsonby, Auckland',
   }),
   clientName: z.string().openapi({
     description: 'Client name',
-    example: 'John Smith',
+    example: 'Sarah Johnson',
   }),
   inspectorName: z.string().nullable().openapi({
     description: 'Inspector name',
-    example: 'Jane Doe',
+    example: 'Jake Li',
   }),
   checklistId: z.string().openapi({
     description: 'Checklist template ID',
@@ -96,7 +97,7 @@ export const InspectionResponseSchema = z.object({
   status: InspectionStatusSchema,
   currentSection: z.string().openapi({
     description: 'Current section',
-    example: 'exterior',
+    example: 'interior',
   }),
   metadata: z.any().nullable().openapi({
     description: 'Additional metadata',
@@ -107,37 +108,15 @@ export const InspectionResponseSchema = z.object({
   }),
   updatedAt: z.string().datetime().openapi({
     description: 'Last update timestamp',
-    example: '2026-02-23T10:00:00Z',
+    example: '2026-02-23T11:30:00Z',
   }),
   completedAt: z.string().datetime().nullable().openapi({
     description: 'Completion timestamp',
-    example: '2026-02-23T12:00:00Z',
+    example: '2026-02-23T14:30:00Z',
   }),
 }).openapi('InspectionResponse');
 
 export const InspectionListResponseSchema = z.array(InspectionResponseSchema).openapi('InspectionListResponse');
-
-// ============================================
-// Error Schemas
-// ============================================
-
-export const ValidationErrorSchema = z.object({
-  error: z.string().openapi({
-    description: 'Error message',
-    example: 'Validation failed',
-  }),
-  details: z.record(z.array(z.string())).optional().openapi({
-    description: 'Field-specific validation errors',
-    example: { address: ['Address is required'] },
-  }),
-}).openapi('ValidationError');
-
-export const NotFoundErrorSchema = z.object({
-  error: z.string().openapi({
-    description: 'Error message',
-    example: 'Inspection not found',
-  }),
-}).openapi('NotFoundError');
 
 // ============================================
 // Register Schemas
@@ -148,8 +127,6 @@ registry.register('CreateInspectionRequest', CreateInspectionSchema);
 registry.register('UpdateInspectionRequest', UpdateInspectionSchema);
 registry.register('InspectionResponse', InspectionResponseSchema);
 registry.register('InspectionListResponse', InspectionListResponseSchema);
-registry.register('ValidationError', ValidationErrorSchema);
-registry.register('NotFoundError', NotFoundErrorSchema);
 
 // ============================================
 // Register Routes
@@ -160,6 +137,7 @@ registry.registerPath({
   path: '/api/inspections',
   tags: ['Inspections'],
   summary: 'Create a new inspection',
+  description: 'Start a new property inspection with address, client info, and checklist.',
   request: {
     body: {
       content: {
@@ -182,7 +160,7 @@ registry.registerPath({
       description: 'Validation error',
       content: {
         'application/json': {
-          schema: ValidationErrorSchema,
+          schema: BadRequestErrorSchema,
         },
       },
     },
@@ -194,6 +172,7 @@ registry.registerPath({
   path: '/api/inspections',
   tags: ['Inspections'],
   summary: 'List all inspections',
+  description: 'Retrieve all inspections, optionally filtered by status.',
   responses: {
     200: {
       description: 'List of inspections',
@@ -211,6 +190,7 @@ registry.registerPath({
   path: '/api/inspections/{id}',
   tags: ['Inspections'],
   summary: 'Get inspection by ID',
+  description: 'Retrieve details of a specific inspection.',
   request: {
     params: z.object({
       id: z.string().uuid().openapi({
@@ -244,6 +224,7 @@ registry.registerPath({
   path: '/api/inspections/{id}',
   tags: ['Inspections'],
   summary: 'Update an inspection',
+  description: 'Update inspection details, status, or mark as completed.',
   request: {
     params: z.object({
       id: z.string().uuid().openapi({
@@ -271,7 +252,7 @@ registry.registerPath({
       description: 'Validation error',
       content: {
         'application/json': {
-          schema: ValidationErrorSchema,
+          schema: BadRequestErrorSchema,
         },
       },
     },

--- a/api/src/openapi/schemas/inspector.ts
+++ b/api/src/openapi/schemas/inspector.ts
@@ -1,0 +1,88 @@
+/**
+ * OpenAPI Schemas for Inspector Endpoints
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const InspectorResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Inspector (user) ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  name: z.string().nullable().openapi({
+    description: 'Inspector name',
+    example: 'Jake Li',
+  }),
+  email: z.string().openapi({
+    description: 'Inspector email',
+    example: 'jake@example.com',
+  }),
+}).openapi('InspectorResponse');
+
+export const InspectorNotFoundSchema = z.object({
+  error: z.string().openapi({
+    description: 'Error message',
+    example: 'Inspector not found',
+  }),
+  message: z.string().openapi({
+    description: 'User-friendly message',
+    example: "I don't have you registered. Contact admin to set up your profile.",
+  }),
+}).openapi('InspectorNotFoundError');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('InspectorResponse', InspectorResponseSchema);
+registry.register('InspectorNotFoundError', InspectorNotFoundSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/inspectors/by-phone/{phone}',
+  tags: ['Inspectors'],
+  summary: 'Look up inspector by phone number',
+  description: 'Used by WhatsApp agent to identify which inspector is messaging. Requires service API key authentication.',
+  request: {
+    params: z.object({
+      phone: z.string().openapi({
+        description: 'Phone number in E.164 format (URL encoded)',
+        example: '+64211234567',
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Inspector found',
+      content: {
+        'application/json': {
+          schema: InspectorResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Invalid phone number format',
+    },
+    401: {
+      description: 'Authentication required',
+    },
+    404: {
+      description: 'Inspector not found',
+      content: {
+        'application/json': {
+          schema: InspectorNotFoundSchema,
+        },
+      },
+    },
+  },
+});

--- a/api/src/openapi/schemas/project.ts
+++ b/api/src/openapi/schemas/project.ts
@@ -1,0 +1,243 @@
+/**
+ * OpenAPI Schemas for Project Endpoints
+ * Issue #431
+ */
+
+import { z } from '../setup.js';
+import { registry } from '../registry.js';
+
+// ============================================
+// Enums
+// ============================================
+
+export const ReportTypeSchema = z.enum(['COA', 'CCC_GAP', 'PPI', 'SAFE_SANITARY', 'TFA']).openapi({
+  description: 'Type of inspection report',
+  example: 'PPI',
+});
+
+export const ProjectStatusSchema = z.enum(['DRAFT', 'IN_PROGRESS', 'REVIEW', 'COMPLETED']).openapi({
+  description: 'Current status of the project',
+  example: 'IN_PROGRESS',
+});
+
+// ============================================
+// Request Schemas
+// ============================================
+
+export const CreateProjectSchema = z.object({
+  jobNumber: z.string().min(1).optional().openapi({
+    description: 'Unique job number (auto-generated if not provided)',
+    example: 'JOB-2026-001',
+  }),
+  activity: z.string().min(1).openapi({
+    description: 'Activity description',
+    example: 'Pre-purchase inspection',
+  }),
+  reportType: ReportTypeSchema,
+  propertyId: z.string().uuid().openapi({
+    description: 'Property ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  clientId: z.string().uuid().openapi({
+    description: 'Client ID',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  }),
+}).openapi('CreateProjectRequest');
+
+export const UpdateProjectSchema = z.object({
+  jobNumber: z.string().min(1).optional(),
+  activity: z.string().min(1).optional(),
+  reportType: ReportTypeSchema.optional(),
+  status: ProjectStatusSchema.optional(),
+  propertyId: z.string().uuid().optional(),
+  clientId: z.string().uuid().optional(),
+}).openapi('UpdateProjectRequest');
+
+// ============================================
+// Response Schemas
+// ============================================
+
+export const ProjectResponseSchema = z.object({
+  id: z.string().uuid().openapi({
+    description: 'Project ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  }),
+  jobNumber: z.string().openapi({
+    description: 'Job number',
+    example: 'JOB-2026-001',
+  }),
+  activity: z.string().openapi({
+    description: 'Activity description',
+    example: 'Pre-purchase inspection',
+  }),
+  reportType: ReportTypeSchema,
+  status: ProjectStatusSchema,
+  propertyId: z.string().uuid(),
+  clientId: z.string().uuid(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  property: z.object({
+    id: z.string().uuid(),
+    streetAddress: z.string(),
+    suburb: z.string().nullable(),
+    city: z.string().nullable(),
+  }).optional().openapi({
+    description: 'Associated property (when expanded)',
+  }),
+  client: z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+    email: z.string().nullable(),
+  }).optional().openapi({
+    description: 'Associated client (when expanded)',
+  }),
+}).openapi('ProjectResponse');
+
+export const ProjectListResponseSchema = z.array(ProjectResponseSchema).openapi('ProjectListResponse');
+
+// ============================================
+// Register Schemas
+// ============================================
+
+registry.register('ReportType', ReportTypeSchema);
+registry.register('ProjectStatus', ProjectStatusSchema);
+registry.register('CreateProjectRequest', CreateProjectSchema);
+registry.register('UpdateProjectRequest', UpdateProjectSchema);
+registry.register('ProjectResponse', ProjectResponseSchema);
+registry.register('ProjectListResponse', ProjectListResponseSchema);
+
+// ============================================
+// Register Routes
+// ============================================
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/projects',
+  tags: ['Projects'],
+  summary: 'Create a new project',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateProjectSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Project created successfully',
+      content: {
+        'application/json': {
+          schema: ProjectResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/projects',
+  tags: ['Projects'],
+  summary: 'List all projects',
+  request: {
+    query: z.object({
+      jobNumber: z.string().optional().openapi({ description: 'Filter by job number' }),
+      address: z.string().optional().openapi({ description: 'Filter by property address' }),
+      clientName: z.string().optional().openapi({ description: 'Filter by client name' }),
+      status: ProjectStatusSchema.optional(),
+      reportType: ReportTypeSchema.optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of projects',
+      content: {
+        'application/json': {
+          schema: ProjectListResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/projects/{id}',
+  tags: ['Projects'],
+  summary: 'Get project by ID',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Project ID' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Project details',
+      content: {
+        'application/json': {
+          schema: ProjectResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Project not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/projects/{id}',
+  tags: ['Projects'],
+  summary: 'Update a project',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Project ID' }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateProjectSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Project updated',
+      content: {
+        'application/json': {
+          schema: ProjectResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Project not found',
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/projects/{id}',
+  tags: ['Projects'],
+  summary: 'Delete a project',
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: 'Project ID' }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'Project deleted',
+    },
+    404: {
+      description: 'Project not found',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Polish OpenAPI spec with standardized error schemas, better examples, and documentation.

## Changes

### Standardized Error Schemas
- `BadRequestError` — 400 validation errors
- `UnauthorizedError` — 401 auth required
- `ForbiddenError` — 403 insufficient permissions
- `NotFoundError` — 404 resource not found
- `ConflictError` — 409 already exists
- `InternalError` — 500 server error

### API Documentation
- Overview section explaining workflow
- Authentication methods (JWT, cookie, API key)
- Step-by-step inspection workflow

### Security Schemes
- `bearerAuth` — JWT Bearer token
- `cookieAuth` — HTTP-only cookie
- `apiKey` — X-API-Key header

### Improved Examples
- Realistic NZ addresses and names
- Consistent timestamps
- Better field descriptions

## Dependencies
- Depends on PR #438 (#431)

Closes #432