### PR TITLE
[Archer] feat(api): add Company entity and API

### DIFF
--- a/api/prisma/migrations/20260223192307_add_company/migration.sql
+++ b/api/prisma/migrations/20260223192307_add_company/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Company" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "logoPath" TEXT,
+    "address" TEXT,
+    "phone" TEXT,
+    "email" TEXT,
+    "website" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Company_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Company_name_idx" ON "Company"("name");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -713,3 +713,22 @@ enum ReportStatus {
   GENERATED
   SUBMITTED
 }
+
+// ============================================
+// Personnel & Credentials (Issue #155)
+// ============================================
+
+model Company {
+  id          String      @id @default(uuid())
+  name        String
+  logoPath    String?
+  address     String?
+  phone       String?
+  email       String?
+  website     String?
+  
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+  
+  @@index([name])
+}

--- a/api/src/__tests__/company.test.ts
+++ b/api/src/__tests__/company.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CompanyService } from '../services/company.js';
+import type { Company } from '@prisma/client';
+
+// Mock the repository module
+vi.mock('../repositories/prisma/company.js', () => ({
+  createCompany: vi.fn(),
+  getCompanyById: vi.fn(),
+  listCompanies: vi.fn(),
+  updateCompany: vi.fn(),
+  deleteCompany: vi.fn(),
+}));
+
+import {
+  createCompany,
+  getCompanyById,
+  listCompanies,
+  updateCompany,
+  deleteCompany,
+} from '../repositories/prisma/company.js';
+
+const mockCreate = vi.mocked(createCompany);
+const mockGetById = vi.mocked(getCompanyById);
+const mockList = vi.mocked(listCompanies);
+const mockUpdate = vi.mocked(updateCompany);
+const mockDelete = vi.mocked(deleteCompany);
+
+const mockCompany: Company = {
+  id: 'company-1',
+  name: 'Acme Inspections Ltd',
+  address: '123 Main St',
+  phone: '+64 21 555 0100',
+  email: 'info@acme.co.nz',
+  website: 'https://acme.co.nz',
+  logoPath: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+describe('CompanyService', () => {
+  let service: CompanyService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new CompanyService();
+  });
+
+  describe('create', () => {
+    it('should create a company with valid input', async () => {
+      mockCreate.mockResolvedValue(mockCompany);
+
+      const result = await service.create({
+        name: 'Acme Inspections Ltd',
+        address: '123 Main St',
+        phone: '+64 21 555 0100',
+        email: 'info@acme.co.nz',
+        website: 'https://acme.co.nz',
+      });
+
+      expect(result).toEqual(mockCompany);
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: 'Acme Inspections Ltd',
+        address: '123 Main St',
+        phone: '+64 21 555 0100',
+        email: 'info@acme.co.nz',
+        website: 'https://acme.co.nz',
+      });
+    });
+
+    it('should create a company with only required fields', async () => {
+      const minimalCompany = { ...mockCompany, address: null, phone: null, email: null, website: null };
+      mockCreate.mockResolvedValue(minimalCompany);
+
+      const result = await service.create({ name: 'Minimal Co' });
+
+      expect(result).toEqual(minimalCompany);
+      expect(mockCreate).toHaveBeenCalledWith({ name: 'Minimal Co' });
+    });
+
+    it('should propagate repository errors', async () => {
+      mockCreate.mockRejectedValue(new Error('Unique constraint failed'));
+
+      await expect(service.create({ name: 'Duplicate Co' })).rejects.toThrow(
+        'Unique constraint failed',
+      );
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a company when found', async () => {
+      mockGetById.mockResolvedValue(mockCompany);
+
+      const result = await service.getById('company-1');
+
+      expect(result).toEqual(mockCompany);
+      expect(mockGetById).toHaveBeenCalledWith('company-1');
+    });
+
+    it('should throw when company not found', async () => {
+      mockGetById.mockResolvedValue(null);
+
+      await expect(service.getById('nonexistent')).rejects.toThrow('Company not found');
+    });
+  });
+
+  describe('list', () => {
+    it('should return all companies', async () => {
+      const companies = [mockCompany, { ...mockCompany, id: 'company-2', name: 'Beta Corp' }];
+      mockList.mockResolvedValue(companies);
+
+      const result = await service.list();
+
+      expect(result).toEqual(companies);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when no companies exist', async () => {
+      mockList.mockResolvedValue([]);
+
+      const result = await service.list();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a company when it exists', async () => {
+      const updated = { ...mockCompany, name: 'Updated Name' };
+      mockGetById.mockResolvedValue(mockCompany);
+      mockUpdate.mockResolvedValue(updated);
+
+      const result = await service.update('company-1', { name: 'Updated Name' });
+
+      expect(result).toEqual(updated);
+      expect(mockGetById).toHaveBeenCalledWith('company-1');
+      expect(mockUpdate).toHaveBeenCalledWith('company-1', { name: 'Updated Name' });
+    });
+
+    it('should throw when company not found', async () => {
+      mockGetById.mockResolvedValue(null);
+
+      await expect(service.update('nonexistent', { name: 'New' })).rejects.toThrow(
+        'Company not found',
+      );
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a company when it exists', async () => {
+      mockGetById.mockResolvedValue(mockCompany);
+      mockDelete.mockResolvedValue(mockCompany);
+
+      await service.delete('company-1');
+
+      expect(mockGetById).toHaveBeenCalledWith('company-1');
+      expect(mockDelete).toHaveBeenCalledWith('company-1');
+    });
+
+    it('should throw when company not found', async () => {
+      mockGetById.mockResolvedValue(null);
+
+      await expect(service.delete('nonexistent')).rejects.toThrow('Company not found');
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('should propagate foreign key constraint errors', async () => {
+      mockGetById.mockResolvedValue(mockCompany);
+      mockDelete.mockRejectedValue(new Error('Foreign key constraint failed'));
+
+      await expect(service.delete('company-1')).rejects.toThrow(
+        'Foreign key constraint failed',
+      );
+    });
+  });
+
+  describe('updateLogo', () => {
+    it('should update logo path when company exists', async () => {
+      const withLogo = { ...mockCompany, logoPath: '/uploads/logo.png' };
+      mockGetById.mockResolvedValue(mockCompany);
+      mockUpdate.mockResolvedValue(withLogo);
+
+      const result = await service.updateLogo('company-1', '/uploads/logo.png');
+
+      expect(result).toEqual(withLogo);
+      expect(mockUpdate).toHaveBeenCalledWith('company-1', { logoPath: '/uploads/logo.png' });
+    });
+
+    it('should throw when company not found', async () => {
+      mockGetById.mockResolvedValue(null);
+
+      await expect(service.updateLogo('nonexistent', '/logo.png')).rejects.toThrow(
+        'Company not found',
+      );
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,6 +24,7 @@ import { buildingHistoryRouter } from './routes/building-history.js';
 import { siteMeasurementsRouter } from './routes/site-measurements.js';
 import { inspectorsRouter } from './routes/inspectors.js';
 import { defectsRouter } from './routes/defects.js';
+import { companiesRouter } from './routes/companies.js';
 import { openApiRouter } from './openapi/index.js';
 import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
@@ -90,6 +91,7 @@ app.use('/api', authMiddleware, projectPhotosRouter);
 app.use('/api', authMiddleware, buildingHistoryRouter);
 app.use('/api', authMiddleware, siteMeasurementsRouter);
 app.use('/api', authMiddleware, defectsRouter);
+app.use('/api/companies', authMiddleware, companiesRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/prisma/company.ts
+++ b/api/src/repositories/prisma/company.ts
@@ -1,0 +1,45 @@
+import { PrismaClient, type Company } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export interface CreateCompanyInput {
+  name: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  website?: string;
+}
+
+export interface UpdateCompanyInput {
+  name?: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  website?: string;
+  logoPath?: string;
+}
+
+export async function createCompany(data: CreateCompanyInput): Promise<Company> {
+  return prisma.company.create({ data });
+}
+
+export async function getCompanyById(id: string): Promise<Company | null> {
+  return prisma.company.findUnique({ where: { id } });
+}
+
+export async function listCompanies(): Promise<Company[]> {
+  return prisma.company.findMany({
+    orderBy: { name: 'asc' },
+  });
+}
+
+export async function updateCompany(id: string, data: UpdateCompanyInput): Promise<Company> {
+  return prisma.company.update({
+    where: { id },
+    data,
+  });
+}
+
+export async function deleteCompany(id: string): Promise<Company> {
+  return prisma.company.delete({ where: { id } });
+}

--- a/api/src/routes/companies.ts
+++ b/api/src/routes/companies.ts
@@ -108,8 +108,8 @@ companiesRouter.post('/:id/logo', async (req, res) => {
   try {
     // For now, accept logoPath in body. File upload will be added later.
     const { logoPath } = req.body;
-    if (!logoPath || typeof logoPath !== 'string') {
-      res.status(400).json({ error: 'logoPath is required' });
+    if (!logoPath || typeof logoPath !== 'string' || logoPath.trim().length === 0) {
+      res.status(400).json({ error: 'logoPath is required and must be a non-empty string' });
       return;
     }
     const company = await companyService.updateLogo(req.params.id, logoPath);

--- a/api/src/routes/companies.ts
+++ b/api/src/routes/companies.ts
@@ -1,0 +1,125 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { CompanyService } from '../services/company.js';
+
+const companyService = new CompanyService();
+export const companiesRouter = Router();
+
+const CreateCompanySchema = z.object({
+  name: z.string().min(1, 'Company name is required'),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email().optional(),
+  website: z.string().url().optional(),
+});
+
+const UpdateCompanySchema = z.object({
+  name: z.string().min(1).optional(),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email().optional(),
+  website: z.string().url().optional(),
+});
+
+// POST /api/companies
+companiesRouter.post('/', async (req, res) => {
+  try {
+    const parsed = CreateCompanySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.flatten() });
+      return;
+    }
+    const company = await companyService.create(parsed.data);
+    res.status(201).json(company);
+  } catch (error) {
+    console.error('Create company error:', error);
+    res.status(500).json({ error: 'Failed to create company' });
+  }
+});
+
+// GET /api/companies
+companiesRouter.get('/', async (_req, res) => {
+  try {
+    const companies = await companyService.list();
+    res.json(companies);
+  } catch (error) {
+    console.error('List companies error:', error);
+    res.status(500).json({ error: 'Failed to list companies' });
+  }
+});
+
+// GET /api/companies/:id
+companiesRouter.get('/:id', async (req, res) => {
+  try {
+    const company = await companyService.getById(req.params.id);
+    res.json(company);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Company not found') {
+      res.status(404).json({ error: 'Company not found' });
+      return;
+    }
+    console.error('Get company error:', error);
+    res.status(500).json({ error: 'Failed to get company' });
+  }
+});
+
+// PUT /api/companies/:id
+companiesRouter.put('/:id', async (req, res) => {
+  try {
+    const parsed = UpdateCompanySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.flatten() });
+      return;
+    }
+    const company = await companyService.update(req.params.id, parsed.data);
+    res.json(company);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Company not found') {
+      res.status(404).json({ error: 'Company not found' });
+      return;
+    }
+    console.error('Update company error:', error);
+    res.status(500).json({ error: 'Failed to update company' });
+  }
+});
+
+// DELETE /api/companies/:id
+companiesRouter.delete('/:id', async (req, res) => {
+  try {
+    await companyService.delete(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Company not found') {
+      res.status(404).json({ error: 'Company not found' });
+      return;
+    }
+    // Prisma foreign key constraint error
+    if (error instanceof Error && error.message.includes('Foreign key constraint')) {
+      res.status(409).json({ error: 'Cannot delete company with linked personnel' });
+      return;
+    }
+    console.error('Delete company error:', error);
+    res.status(500).json({ error: 'Failed to delete company' });
+  }
+});
+
+// POST /api/companies/:id/logo
+companiesRouter.post('/:id/logo', async (req, res) => {
+  try {
+    // For now, accept logoPath in body. File upload will be added later.
+    const { logoPath } = req.body;
+    if (!logoPath || typeof logoPath !== 'string') {
+      res.status(400).json({ error: 'logoPath is required' });
+      return;
+    }
+    const company = await companyService.updateLogo(req.params.id, logoPath);
+    res.json(company);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Company not found') {
+      res.status(404).json({ error: 'Company not found' });
+      return;
+    }
+    console.error('Update logo error:', error);
+    res.status(500).json({ error: 'Failed to update logo' });
+  }
+});

--- a/api/src/services/company.ts
+++ b/api/src/services/company.ts
@@ -1,0 +1,42 @@
+import {
+  createCompany,
+  getCompanyById,
+  listCompanies,
+  updateCompany,
+  deleteCompany,
+  type CreateCompanyInput,
+  type UpdateCompanyInput,
+} from '../repositories/prisma/company.js';
+
+export class CompanyService {
+  async create(data: CreateCompanyInput) {
+    return createCompany(data);
+  }
+
+  async getById(id: string) {
+    const company = await getCompanyById(id);
+    if (!company) {
+      throw new Error('Company not found');
+    }
+    return company;
+  }
+
+  async list() {
+    return listCompanies();
+  }
+
+  async update(id: string, data: UpdateCompanyInput) {
+    await this.getById(id); // Verify exists
+    return updateCompany(id, data);
+  }
+
+  async delete(id: string) {
+    await this.getById(id); // Verify exists
+    return deleteCompany(id);
+  }
+
+  async updateLogo(id: string, logoPath: string) {
+    await this.getById(id); // Verify exists
+    return updateCompany(id, { logoPath });
+  }
+}


### PR DESCRIPTION
## Summary

Create Company entity for the Personnel & Credentials system (#155).

## Changes

### Database
- `Company` model with name, address, phone, email, website, logoPath
- Index on name for search

### API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | /api/companies | Create company |
| GET | /api/companies | List all companies |
| GET | /api/companies/:id | Get by ID |
| PUT | /api/companies/:id | Update details |
| DELETE | /api/companies/:id | Delete (409 if has personnel) |
| POST | /api/companies/:id/logo | Upload logo path |

### Validation
- Name required (min 1 char)
- Email validated if provided
- Website URL validated if provided

---
Closes #198
Parent: #155