### PR TITLE
[Sam] feat(api): create Credential entity and management (#200)

### DIFF
--- a/api/prisma/migrations/20260224000000_add_credential_entity/migration.sql
+++ b/api/prisma/migrations/20260224000000_add_credential_entity/migration.sql
@@ -1,0 +1,59 @@
+-- CreateEnum
+CREATE TYPE "PersonnelRole" AS ENUM ('REGISTERED_BUILDING_SURVEYOR', 'BUILDING_SURVEYOR', 'INSPECTOR', 'ADMIN');
+
+-- CreateEnum
+CREATE TYPE "CredentialType" AS ENUM ('NZIBS', 'LBP', 'ENG_NZ', 'ACADEMIC', 'OTHER');
+
+-- CreateTable
+CREATE TABLE "Personnel" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "mobile" TEXT,
+    "role" "PersonnelRole" NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Personnel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Credential" (
+    "id" TEXT NOT NULL,
+    "personnelId" TEXT NOT NULL,
+    "credentialType" "CredentialType" NOT NULL,
+    "membershipCode" TEXT,
+    "registrationTitle" TEXT,
+    "licenseNumber" TEXT,
+    "qualifications" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "issuedDate" TIMESTAMP(3),
+    "expiryDate" TIMESTAMP(3),
+    "verified" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Credential_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Personnel_email_key" ON "Personnel"("email");
+
+-- CreateIndex
+CREATE INDEX "Personnel_role_idx" ON "Personnel"("role");
+
+-- CreateIndex
+CREATE INDEX "Personnel_active_idx" ON "Personnel"("active");
+
+-- CreateIndex
+CREATE INDEX "Personnel_email_idx" ON "Personnel"("email");
+
+-- CreateIndex
+CREATE INDEX "Credential_personnelId_idx" ON "Credential"("personnelId");
+
+-- CreateIndex
+CREATE INDEX "Credential_expiryDate_idx" ON "Credential"("expiryDate");
+
+-- AddForeignKey
+ALTER TABLE "Credential" ADD CONSTRAINT "Credential_personnelId_fkey" FOREIGN KEY ("personnelId") REFERENCES "Personnel"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -248,6 +248,62 @@ enum Severity {
 }
 
 // ============================================
+// Personnel & Credentials — Issue #200
+// ============================================
+
+enum PersonnelRole {
+  REGISTERED_BUILDING_SURVEYOR
+  BUILDING_SURVEYOR
+  INSPECTOR
+  ADMIN
+}
+
+model Personnel {
+  id        String        @id @default(uuid())
+  name      String
+  email     String        @unique
+  phone     String?
+  mobile    String?
+  role      PersonnelRole
+  active    Boolean       @default(true)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  credentials Credential[]
+
+  @@index([role])
+  @@index([active])
+  @@index([email])
+}
+
+enum CredentialType {
+  NZIBS       // NZ Institute of Building Surveyors
+  LBP         // Licensed Building Practitioner
+  ENG_NZ      // Engineering New Zealand
+  ACADEMIC    // Degree/Diploma
+  OTHER       // Other certification
+}
+
+model Credential {
+  id                String         @id @default(uuid())
+  personnelId       String
+  personnel         Personnel      @relation(fields: [personnelId], references: [id], onDelete: Cascade)
+  credentialType    CredentialType
+  membershipCode    String?        // "MNZIBS", "MEngNZ"
+  registrationTitle String?        // "Registered Building Surveyor"
+  licenseNumber     String?        // LBP or other license
+  qualifications    String[]       @default([])  // ["BE (Hons)", "MBA"]
+  issuedDate        DateTime?
+  expiryDate        DateTime?
+  verified          Boolean        @default(false)
+  createdAt         DateTime       @default(now())
+  updatedAt         DateTime       @updatedAt
+
+  @@index([personnelId])
+  @@index([expiryDate])
+}
+
+// ============================================
 // Project Management Entities
 // ============================================
 

--- a/api/src/__tests__/credential.test.ts
+++ b/api/src/__tests__/credential.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  CredentialService,
+  CredentialNotFoundError,
+  PersonnelNotFoundError,
+  InvalidLBPLicenseError,
+} from '../services/credential.js';
+import type { ICredentialRepository } from '../repositories/interfaces/credential.js';
+import type { Credential, PrismaClient, Personnel } from '@prisma/client';
+
+// Mock repository
+const createMockRepository = (): ICredentialRepository => ({
+  create: vi.fn(),
+  findById: vi.fn(),
+  findByPersonnelId: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+// Mock Prisma client with personnel.findUnique
+const createMockPrisma = (): { personnel: { findUnique: ReturnType<typeof vi.fn> } } => ({
+  personnel: {
+    findUnique: vi.fn(),
+  },
+});
+
+const mockPersonnel: Personnel = {
+  id: 'personnel-1',
+  name: 'John Smith',
+  email: 'john@example.com',
+  phone: null,
+  mobile: null,
+  role: 'BUILDING_SURVEYOR',
+  active: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockCredential: Credential = {
+  id: 'cred-1',
+  personnelId: 'personnel-1',
+  credentialType: 'NZIBS',
+  membershipCode: 'MNZIBS',
+  registrationTitle: null,
+  licenseNumber: null,
+  qualifications: ['BE (Hons)'],
+  issuedDate: new Date('2025-01-15'),
+  expiryDate: new Date('2027-01-15'),
+  verified: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('CredentialService', () => {
+  let repository: ICredentialRepository;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let service: CredentialService;
+
+  beforeEach(() => {
+    repository = createMockRepository();
+    mockPrisma = createMockPrisma();
+    service = new CredentialService(repository, mockPrisma as unknown as PrismaClient);
+  });
+
+  describe('create', () => {
+    it('should create a credential with valid input', async () => {
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+      vi.mocked(repository.create).mockResolvedValue(mockCredential);
+
+      const result = await service.create({
+        personnelId: 'personnel-1',
+        credentialType: 'NZIBS',
+        membershipCode: 'MNZIBS',
+        qualifications: ['BE (Hons)'],
+      });
+
+      expect(mockPrisma.personnel.findUnique).toHaveBeenCalledWith({
+        where: { id: 'personnel-1' },
+      });
+      expect(repository.create).toHaveBeenCalledWith({
+        personnelId: 'personnel-1',
+        credentialType: 'NZIBS',
+        membershipCode: 'MNZIBS',
+        qualifications: ['BE (Hons)'],
+      });
+      expect(result).toEqual(mockCredential);
+    });
+
+    it('should throw PersonnelNotFoundError for non-existent personnel', async () => {
+      mockPrisma.personnel.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          personnelId: 'non-existent',
+          credentialType: 'NZIBS',
+        })
+      ).rejects.toThrow(PersonnelNotFoundError);
+    });
+
+    it('should create LBP credential with valid license number', async () => {
+      const lbpCredential = {
+        ...mockCredential,
+        credentialType: 'LBP' as const,
+        licenseNumber: 'BP123456',
+      };
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+      vi.mocked(repository.create).mockResolvedValue(lbpCredential);
+
+      const result = await service.create({
+        personnelId: 'personnel-1',
+        credentialType: 'LBP',
+        licenseNumber: 'BP123456',
+      });
+
+      expect(result.licenseNumber).toBe('BP123456');
+    });
+
+    it('should throw InvalidLBPLicenseError for invalid LBP license format', async () => {
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+
+      await expect(
+        service.create({
+          personnelId: 'personnel-1',
+          credentialType: 'LBP',
+          licenseNumber: 'INVALID123',
+        })
+      ).rejects.toThrow(InvalidLBPLicenseError);
+    });
+
+    it('should throw InvalidLBPLicenseError for LBP license with wrong digit count', async () => {
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+
+      await expect(
+        service.create({
+          personnelId: 'personnel-1',
+          credentialType: 'LBP',
+          licenseNumber: 'BP12345', // Only 5 digits
+        })
+      ).rejects.toThrow(InvalidLBPLicenseError);
+    });
+
+    it('should throw InvalidLBPLicenseError for LBP license with too many digits', async () => {
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+
+      await expect(
+        service.create({
+          personnelId: 'personnel-1',
+          credentialType: 'LBP',
+          licenseNumber: 'BP1234567', // 7 digits
+        })
+      ).rejects.toThrow(InvalidLBPLicenseError);
+    });
+
+    it('should allow non-LBP credential without validating license format', async () => {
+      const otherCredential = {
+        ...mockCredential,
+        credentialType: 'OTHER' as const,
+        licenseNumber: 'ANY-FORMAT-123',
+      };
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+      vi.mocked(repository.create).mockResolvedValue(otherCredential);
+
+      const result = await service.create({
+        personnelId: 'personnel-1',
+        credentialType: 'OTHER',
+        licenseNumber: 'ANY-FORMAT-123',
+      });
+
+      expect(result.licenseNumber).toBe('ANY-FORMAT-123');
+    });
+
+    it('should allow LBP credential without license number', async () => {
+      const lbpNoLicense = {
+        ...mockCredential,
+        credentialType: 'LBP' as const,
+        licenseNumber: null,
+      };
+      mockPrisma.personnel.findUnique.mockResolvedValue(mockPersonnel);
+      vi.mocked(repository.create).mockResolvedValue(lbpNoLicense);
+
+      const result = await service.create({
+        personnelId: 'personnel-1',
+        credentialType: 'LBP',
+      });
+
+      expect(result.credentialType).toBe('LBP');
+    });
+  });
+
+  describe('findById', () => {
+    it('should return credential by id', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockCredential);
+
+      const result = await service.findById('cred-1');
+      expect(result).toEqual(mockCredential);
+    });
+
+    it('should throw CredentialNotFoundError for non-existent credential', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.findById('non-existent')).rejects.toThrow(
+        CredentialNotFoundError
+      );
+    });
+  });
+
+  describe('findByPersonnelId', () => {
+    it('should return all credentials for personnel', async () => {
+      vi.mocked(repository.findByPersonnelId).mockResolvedValue([mockCredential]);
+
+      const result = await service.findByPersonnelId('personnel-1');
+      expect(result).toEqual([mockCredential]);
+    });
+
+    it('should return empty array when no credentials', async () => {
+      vi.mocked(repository.findByPersonnelId).mockResolvedValue([]);
+
+      const result = await service.findByPersonnelId('personnel-1');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('should update credential', async () => {
+      const updatedCred = { ...mockCredential, verified: true };
+      vi.mocked(repository.findById).mockResolvedValue(mockCredential);
+      vi.mocked(repository.update).mockResolvedValue(updatedCred);
+
+      const result = await service.update('cred-1', { verified: true });
+      expect(result.verified).toBe(true);
+    });
+
+    it('should throw CredentialNotFoundError for non-existent credential', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(
+        service.update('non-existent', { verified: true })
+      ).rejects.toThrow(CredentialNotFoundError);
+    });
+
+    it('should validate LBP license when updating license number on LBP credential', async () => {
+      const lbpCredential = { ...mockCredential, credentialType: 'LBP' as const };
+      vi.mocked(repository.findById).mockResolvedValue(lbpCredential);
+
+      await expect(
+        service.update('cred-1', { licenseNumber: 'INVALID' })
+      ).rejects.toThrow(InvalidLBPLicenseError);
+    });
+
+    it('should validate LBP license when changing credential type to LBP', async () => {
+      const otherCredential = {
+        ...mockCredential,
+        credentialType: 'OTHER' as const,
+        licenseNumber: 'INVALID',
+      };
+      vi.mocked(repository.findById).mockResolvedValue(otherCredential);
+
+      await expect(
+        service.update('cred-1', { credentialType: 'LBP' })
+      ).rejects.toThrow(InvalidLBPLicenseError);
+    });
+
+    it('should allow valid LBP license update', async () => {
+      const lbpCredential = { ...mockCredential, credentialType: 'LBP' as const };
+      const updatedCred = { ...lbpCredential, licenseNumber: 'BP654321' };
+      vi.mocked(repository.findById).mockResolvedValue(lbpCredential);
+      vi.mocked(repository.update).mockResolvedValue(updatedCred);
+
+      const result = await service.update('cred-1', { licenseNumber: 'BP654321' });
+      expect(result.licenseNumber).toBe('BP654321');
+    });
+
+    it('should allow clearing license number on LBP credential', async () => {
+      const lbpCredential = {
+        ...mockCredential,
+        credentialType: 'LBP' as const,
+        licenseNumber: 'BP123456',
+      };
+      const updatedCred = { ...lbpCredential, licenseNumber: null };
+      vi.mocked(repository.findById).mockResolvedValue(lbpCredential);
+      vi.mocked(repository.update).mockResolvedValue(updatedCred);
+
+      const result = await service.update('cred-1', { licenseNumber: null });
+      expect(result.licenseNumber).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing credential', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(mockCredential);
+      vi.mocked(repository.delete).mockResolvedValue();
+
+      await expect(service.delete('cred-1')).resolves.toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith('cred-1');
+    });
+
+    it('should throw CredentialNotFoundError for non-existent credential', async () => {
+      vi.mocked(repository.findById).mockResolvedValue(null);
+
+      await expect(service.delete('non-existent')).rejects.toThrow(
+        CredentialNotFoundError
+      );
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -35,6 +35,7 @@ import { reportTemplatesRouter } from './routes/report-templates.js';
 import { reviewCommentsRouter } from './routes/review-comments.js';
 import { generatedReportsRouter } from './routes/generated-reports.js';
 import { personnelRouter } from './routes/personnel.js';
+import { credentialsRouter } from './routes/credentials.js';
 import { openApiRouter } from './openapi/index.js';
 import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
@@ -111,6 +112,7 @@ app.use('/api', authMiddleware, reportGenerationRouter);
 app.use('/api', authMiddleware, reportTemplatesRouter);
 app.use('/api', authMiddleware, reviewCommentsRouter);
 app.use('/api/reports', authMiddleware, generatedReportsRouter);
+app.use('/api', authMiddleware, credentialsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/repositories/interfaces/credential.ts
+++ b/api/src/repositories/interfaces/credential.ts
@@ -1,0 +1,32 @@
+import type { Credential, CredentialType } from '@prisma/client';
+
+export interface CreateCredentialInput {
+  personnelId: string;
+  credentialType: CredentialType;
+  membershipCode?: string;
+  registrationTitle?: string;
+  licenseNumber?: string;
+  qualifications?: string[];
+  issuedDate?: Date;
+  expiryDate?: Date;
+  verified?: boolean;
+}
+
+export interface UpdateCredentialInput {
+  credentialType?: CredentialType;
+  membershipCode?: string | null;
+  registrationTitle?: string | null;
+  licenseNumber?: string | null;
+  qualifications?: string[];
+  issuedDate?: Date | null;
+  expiryDate?: Date | null;
+  verified?: boolean;
+}
+
+export interface ICredentialRepository {
+  create(input: CreateCredentialInput): Promise<Credential>;
+  findById(id: string): Promise<Credential | null>;
+  findByPersonnelId(personnelId: string): Promise<Credential[]>;
+  update(id: string, input: UpdateCredentialInput): Promise<Credential>;
+  delete(id: string): Promise<void>;
+}

--- a/api/src/repositories/prisma/credential.ts
+++ b/api/src/repositories/prisma/credential.ts
@@ -1,0 +1,45 @@
+import { PrismaClient, type Credential } from '@prisma/client';
+import type {
+  ICredentialRepository,
+  CreateCredentialInput,
+  UpdateCredentialInput,
+} from '../interfaces/credential.js';
+
+export class PrismaCredentialRepository implements ICredentialRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(input: CreateCredentialInput): Promise<Credential> {
+    return this.prisma.credential.create({
+      data: {
+        ...input,
+        qualifications: input.qualifications || [],
+      },
+    });
+  }
+
+  async findById(id: string): Promise<Credential | null> {
+    return this.prisma.credential.findUnique({
+      where: { id },
+    });
+  }
+
+  async findByPersonnelId(personnelId: string): Promise<Credential[]> {
+    return this.prisma.credential.findMany({
+      where: { personnelId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async update(id: string, input: UpdateCredentialInput): Promise<Credential> {
+    return this.prisma.credential.update({
+      where: { id },
+      data: input,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.credential.delete({
+      where: { id },
+    });
+  }
+}

--- a/api/src/routes/credentials.ts
+++ b/api/src/routes/credentials.ts
@@ -1,0 +1,156 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import { PrismaCredentialRepository } from '../repositories/prisma/credential.js';
+import {
+  CredentialService,
+  CredentialNotFoundError,
+  PersonnelNotFoundError,
+  InvalidLBPLicenseError,
+} from '../services/credential.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaCredentialRepository(prisma);
+const service = new CredentialService(repository, prisma);
+
+export const credentialsRouter = Router();
+
+// Validation schemas
+const CredentialTypeEnum = z.enum(['NZIBS', 'LBP', 'ENG_NZ', 'ACADEMIC', 'OTHER']);
+
+const CreateCredentialSchema = z.object({
+  credentialType: CredentialTypeEnum,
+  membershipCode: z.string().optional(),
+  registrationTitle: z.string().optional(),
+  licenseNumber: z.string().optional(),
+  qualifications: z.array(z.string()).optional(),
+  issuedDate: z.string().datetime().optional(),
+  expiryDate: z.string().datetime().optional(),
+  verified: z.boolean().optional(),
+});
+
+const UpdateCredentialSchema = z.object({
+  credentialType: CredentialTypeEnum.optional(),
+  membershipCode: z.string().nullable().optional(),
+  registrationTitle: z.string().nullable().optional(),
+  licenseNumber: z.string().nullable().optional(),
+  qualifications: z.array(z.string()).optional(),
+  issuedDate: z.string().datetime().nullable().optional(),
+  expiryDate: z.string().datetime().nullable().optional(),
+  verified: z.boolean().optional(),
+});
+
+// POST /api/personnel/:personnelId/credentials - Create credential
+credentialsRouter.post(
+  '/personnel/:personnelId/credentials',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const personnelId = req.params.personnelId as string;
+      const parsed = CreateCredentialSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const credential = await service.create({
+        ...parsed.data,
+        personnelId,
+        issuedDate: parsed.data.issuedDate ? new Date(parsed.data.issuedDate) : undefined,
+        expiryDate: parsed.data.expiryDate ? new Date(parsed.data.expiryDate) : undefined,
+      });
+      res.status(201).json(credential);
+    } catch (error) {
+      if (error instanceof PersonnelNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof InvalidLBPLicenseError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// GET /api/personnel/:personnelId/credentials - List credentials for personnel
+credentialsRouter.get(
+  '/personnel/:personnelId/credentials',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const personnelId = req.params.personnelId as string;
+      const credentials = await service.findByPersonnelId(personnelId);
+      res.json(credentials);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// PUT /api/credentials/:id - Update credential
+credentialsRouter.put(
+  '/credentials/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      const parsed = UpdateCredentialSchema.safeParse(req.body);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const updateData = {
+        ...parsed.data,
+        issuedDate: parsed.data.issuedDate === null
+          ? null
+          : parsed.data.issuedDate
+            ? new Date(parsed.data.issuedDate)
+            : undefined,
+        expiryDate: parsed.data.expiryDate === null
+          ? null
+          : parsed.data.expiryDate
+            ? new Date(parsed.data.expiryDate)
+            : undefined,
+      };
+
+      const credential = await service.update(id, updateData);
+      res.json(credential);
+    } catch (error) {
+      if (error instanceof CredentialNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      if (error instanceof InvalidLBPLicenseError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/credentials/:id - Delete credential (hard delete)
+credentialsRouter.delete(
+  '/credentials/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = req.params.id as string;
+      await service.delete(id);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof CredentialNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -17,3 +17,4 @@ export * from './inspectors.js';
 export * from './defects.js';
 export * from './report-generation.js';
 export * from './personnel.js';
+export * from './credentials.js';

--- a/api/src/services/credential.ts
+++ b/api/src/services/credential.ts
@@ -1,0 +1,93 @@
+import type { Credential, PrismaClient } from '@prisma/client';
+import type {
+  ICredentialRepository,
+  CreateCredentialInput,
+  UpdateCredentialInput,
+} from '../repositories/interfaces/credential.js';
+
+export class CredentialNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Credential not found: ${id}`);
+    this.name = 'CredentialNotFoundError';
+  }
+}
+
+export class PersonnelNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Personnel not found: ${id}`);
+    this.name = 'PersonnelNotFoundError';
+  }
+}
+
+export class InvalidLBPLicenseError extends Error {
+  constructor(licenseNumber: string) {
+    super(`Invalid LBP license number format: ${licenseNumber}. Must be BP followed by exactly 6 digits (e.g., BP123456)`);
+    this.name = 'InvalidLBPLicenseError';
+  }
+}
+
+// LBP license number format: BP followed by exactly 6 digits
+const LBP_LICENSE_PATTERN = /^BP\d{6}$/;
+
+function validateLBPLicense(licenseNumber: string): boolean {
+  return LBP_LICENSE_PATTERN.test(licenseNumber);
+}
+
+export class CredentialService {
+  constructor(
+    private repository: ICredentialRepository,
+    private prisma: PrismaClient
+  ) {}
+
+  async create(input: CreateCredentialInput): Promise<Credential> {
+    // Verify personnel exists
+    const personnel = await this.prisma.personnel.findUnique({
+      where: { id: input.personnelId },
+    });
+    if (!personnel) {
+      throw new PersonnelNotFoundError(input.personnelId);
+    }
+
+    // Validate LBP license number format if credential type is LBP
+    if (input.credentialType === 'LBP' && input.licenseNumber) {
+      if (!validateLBPLicense(input.licenseNumber)) {
+        throw new InvalidLBPLicenseError(input.licenseNumber);
+      }
+    }
+
+    return this.repository.create(input);
+  }
+
+  async findByPersonnelId(personnelId: string): Promise<Credential[]> {
+    return this.repository.findByPersonnelId(personnelId);
+  }
+
+  async findById(id: string): Promise<Credential> {
+    const credential = await this.repository.findById(id);
+    if (!credential) {
+      throw new CredentialNotFoundError(id);
+    }
+    return credential;
+  }
+
+  async update(id: string, input: UpdateCredentialInput): Promise<Credential> {
+    const credential = await this.findById(id);
+
+    // Validate LBP license number format if updating to LBP type or updating license number
+    const effectiveType = input.credentialType ?? credential.credentialType;
+    const effectiveLicense = input.licenseNumber !== undefined ? input.licenseNumber : credential.licenseNumber;
+
+    if (effectiveType === 'LBP' && effectiveLicense) {
+      if (!validateLBPLicense(effectiveLicense)) {
+        throw new InvalidLBPLicenseError(effectiveLicense);
+      }
+    }
+
+    return this.repository.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    await this.repository.delete(id);
+  }
+}


### PR DESCRIPTION
## Summary

Implements #200 — Credential entity with full CRUD API.

## Changes

- **Prisma schema**: Added `CredentialType` enum (NZIBS, LBP, ENG_NZ, ACADEMIC, OTHER) and `Credential` model with 1:N relation to Personnel (cascade delete)
- **Migration**: SQL migration for Credential table with indexes
- **Repository interface**: `ICredentialRepository` with typed inputs
- **Prisma repository**: `PrismaCredentialRepository` implementation
- **Service**: `CredentialService` with `CredentialNotFoundError`, `PersonnelNotFoundError`, `InvalidLBPLicenseError`; LBP license validation (regex `/^BP\d{6}$/`)
- **Routes**: Mounted at both `/api/personnel/:personnelId/credentials` and `/api/credentials/:id`
- **Tests**: 20 unit tests — CRUD, LBP validation, error cases

## Acceptance Criteria

- [x] Add multiple credentials per person
- [x] Credential types: NZIBS, LBP, ENG_NZ, ACADEMIC, OTHER
- [x] Record membership code, registration title, license number, qualifications array, issued/expiry dates
- [x] Mark credential as verified
- [x] Update/delete credentials
- [x] Validate LBP license number format (BP + 6 digits)
- [x] 1:N relationship with Personnel, cascade delete

## Testing

- 242 tests pass (20 new)
- Lint ✅
- Typecheck ✅

Closes #200