### PR TITLE
[Taylor] feat(api): implement generated report storage and download (#226)

### DIFF
--- a/api/prisma/migrations/20260224060000_add_generated_report/migration.sql
+++ b/api/prisma/migrations/20260224060000_add_generated_report/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable: GeneratedReport (#226)
+CREATE TABLE "GeneratedReport" (
+    "id"          TEXT NOT NULL,
+    "reportId"    TEXT NOT NULL,
+    "format"      TEXT NOT NULL,
+    "filename"    TEXT NOT NULL,
+    "r2Key"       TEXT,
+    "localPath"   TEXT,
+    "fileSize"    INTEGER,
+    "pageCount"   INTEGER,
+    "photoCount"  INTEGER,
+    "version"     INTEGER NOT NULL DEFAULT 1,
+    "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GeneratedReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GeneratedReport_reportId_idx" ON "GeneratedReport"("reportId");
+
+-- AddForeignKey
+ALTER TABLE "GeneratedReport" ADD CONSTRAINT "GeneratedReport_reportId_fkey"
+    FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -134,6 +134,9 @@ model Report {
   
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
+
+  // Generated report files
+  generatedReports GeneratedReport[]
   
   auditLogs       ReportAuditLog[]
   
@@ -168,6 +171,30 @@ enum ReportAuditAction {
   CONTENT_UPDATED
   VERSION_CREATED
   DELETED
+}
+
+// ============================================
+// Generated Report Storage — Issue #226
+// ============================================
+
+model GeneratedReport {
+  id          String   @id @default(uuid())
+
+  reportId    String
+  report      Report   @relation(fields: [reportId], references: [id], onDelete: Cascade)
+
+  format      String   // "pdf" | "docx"
+  filename    String
+  r2Key       String?  // Set when stored in R2
+  localPath   String?  // Set when stored locally
+  fileSize    Int?     // bytes
+  pageCount   Int?
+  photoCount  Int?
+  version     Int      @default(1)
+
+  createdAt   DateTime @default(now())
+
+  @@index([reportId])
 }
 
 enum Status {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -30,6 +30,7 @@ import { reportTransitionsRouter } from './routes/report-transitions.js';
 import { reportGenerationRouter } from './routes/report-generation.js';
 import { startReportWorker, stopReportWorker } from './workers/report-worker.js';
 import { reportTemplatesRouter } from './routes/report-templates.js';
+import { generatedReportsRouter } from './routes/generated-reports.js';
 import { openApiRouter } from './openapi/index.js';
 import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
@@ -101,6 +102,7 @@ app.use('/api/companies', authMiddleware, companiesRouter);
 app.use('/api', authMiddleware, reportAuditLogRouter);
 app.use('/api', authMiddleware, reportGenerationRouter);
 app.use('/api', authMiddleware, reportTemplatesRouter);
+app.use('/api/reports', authMiddleware, generatedReportsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/routes/generated-reports.ts
+++ b/api/src/routes/generated-reports.ts
@@ -1,0 +1,117 @@
+/**
+ * Generated Report Storage & Download Routes (#226)
+ *
+ * GET  /api/reports/:id/generated          — list generated files
+ * GET  /api/reports/:id/download/:format   — download latest by format
+ * GET  /api/generated-reports/:id/download — download specific file
+ */
+
+import { Router } from 'express';
+import { createReadStream, existsSync } from 'node:fs';
+import { PrismaClient } from '@prisma/client';
+import {
+  GeneratedReportService,
+  GeneratedReportNotFoundError,
+  ReportNotFoundError,
+} from '../services/generated-report.js';
+
+const prisma = new PrismaClient();
+export const generatedReportsRouter = Router();
+const svc = new GeneratedReportService(prisma);
+const router = generatedReportsRouter;
+
+/**
+ * GET /api/reports/:id/generated
+ * List all generated files for a report.
+ */
+router.get('/:id/generated', async (req, res) => {
+  try {
+    const files = await svc.listByReport(req.params.id);
+    res.json(files);
+  } catch (err) {
+    if (err instanceof ReportNotFoundError) {
+      return res.status(404).json({ error: err.message });
+    }
+    console.error('[generated-reports] list error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/reports/:id/download/:format
+ * Download the latest generated file by format (pdf|docx).
+ * Redirects to presigned R2 URL or streams local file.
+ */
+router.get('/:id/download/:format', async (req, res) => {
+  const { id, format } = req.params;
+
+  if (!['pdf', 'docx'].includes(format)) {
+    return res.status(400).json({ error: 'Invalid format. Use pdf or docx.' });
+  }
+
+  try {
+    const latest = await svc.getLatest(id, format);
+    if (!latest) {
+      return res.status(404).json({ error: `No generated ${format} found for this report` });
+    }
+
+    const { url, filename, contentType, fileSize } = await svc.getDownloadUrl(latest.id);
+
+    // R2 — redirect to presigned URL
+    if (latest.r2Key) {
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.redirect(302, url);
+    }
+
+    // Local — stream file
+    if (latest.localPath && existsSync(latest.localPath)) {
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      if (fileSize) res.setHeader('Content-Length', fileSize);
+      return createReadStream(latest.localPath).pipe(res);
+    }
+
+    res.status(404).json({ error: 'Generated file not found on disk' });
+  } catch (err) {
+    if (err instanceof ReportNotFoundError) {
+      return res.status(404).json({ error: err.message });
+    }
+    console.error('[generated-reports] download error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/generated-reports/:id/download
+ * Download a specific generated report file by its ID.
+ */
+router.get('/file/:id/download', async (req, res) => {
+  try {
+    const { url, filename, contentType, fileSize } = await svc.getDownloadUrl(req.params.id);
+    const gr = await prisma.generatedReport.findUnique({ where: { id: req.params.id } });
+
+    // R2 redirect
+    if (gr?.r2Key) {
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      return res.redirect(302, url);
+    }
+
+    // Local stream
+    if (gr?.localPath && existsSync(gr.localPath)) {
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      if (fileSize) res.setHeader('Content-Length', fileSize);
+      return createReadStream(gr.localPath).pipe(res);
+    }
+
+    res.status(404).json({ error: 'File not found' });
+  } catch (err) {
+    if (err instanceof GeneratedReportNotFoundError) {
+      return res.status(404).json({ error: err.message });
+    }
+    console.error('[generated-reports] file download error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/api/src/services/generated-report.ts
+++ b/api/src/services/generated-report.ts
@@ -1,0 +1,169 @@
+/**
+ * Generated Report Storage Service (#226)
+ * Manages storing and retrieving generated report files (PDF/DOCX).
+ */
+
+import { readFileSync } from 'node:fs';
+import type { PrismaClient, GeneratedReport } from '@prisma/client';
+import {
+  uploadToR2,
+  getPresignedUrl,
+  isR2Configured,
+} from './r2-storage.js';
+
+export class GeneratedReportNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Generated report not found: ${id}`);
+    this.name = 'GeneratedReportNotFoundError';
+  }
+}
+
+export class ReportNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Report not found: ${id}`);
+    this.name = 'ReportNotFoundError';
+  }
+}
+
+const MIME_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+};
+
+/**
+ * Build a standardised filename for a generated report.
+ * Format: {reportId[0:8]}-{type}-v{version}.{format}
+ * e.g. "a1b2c3d4-COA-v2.pdf"
+ */
+export function buildFilename(
+  reportId: string,
+  type: string,
+  version: number,
+  format: string
+): string {
+  const slug = reportId.replace(/-/g, '').slice(0, 8);
+  const safeType = type.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  return `${slug}-${safeType}-v${version}.${format}`;
+}
+
+/**
+ * Build the R2 storage key for a generated report.
+ * Format: reports/{reportId}/{filename}
+ */
+function buildR2Key(reportId: string, filename: string): string {
+  return `reports/${reportId}/${filename}`;
+}
+
+export class GeneratedReportService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Store a generated report file and create a DB record.
+   * Uploads to R2 if configured, otherwise falls back to localPath.
+   */
+  async store(params: {
+    reportId: string;
+    format: string;
+    localPath: string;
+    pageCount?: number;
+    photoCount?: number;
+  }): Promise<GeneratedReport> {
+    const report = await this.prisma.report.findUnique({
+      where: { id: params.reportId },
+    });
+    if (!report) throw new ReportNotFoundError(params.reportId);
+
+    const filename = buildFilename(
+      params.reportId,
+      report.type,
+      report.version,
+      params.format
+    );
+
+    let r2Key: string | null = null;
+    let fileSize: number | null = null;
+
+    // Read file for upload + size
+    const fileBuffer = readFileSync(params.localPath);
+    fileSize = fileBuffer.length;
+
+    // Upload to R2 if configured
+    if (isR2Configured()) {
+      r2Key = buildR2Key(params.reportId, filename);
+      const contentType = MIME_TYPES[params.format] ?? 'application/octet-stream';
+      await uploadToR2(r2Key, fileBuffer, contentType);
+    }
+
+    return this.prisma.generatedReport.create({
+      data: {
+        reportId: params.reportId,
+        format: params.format,
+        filename,
+        r2Key,
+        localPath: r2Key ? null : params.localPath, // prefer R2
+        fileSize,
+        pageCount: params.pageCount ?? null,
+        photoCount: params.photoCount ?? null,
+        version: report.version,
+      },
+    });
+  }
+
+  /**
+   * List all generated files for a report (newest first).
+   */
+  async listByReport(reportId: string): Promise<GeneratedReport[]> {
+    const report = await this.prisma.report.findUnique({ where: { id: reportId } });
+    if (!report) throw new ReportNotFoundError(reportId);
+
+    return this.prisma.generatedReport.findMany({
+      where: { reportId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * Get a download URL for a generated report.
+   * Returns a presigned R2 URL if available, otherwise the local path.
+   */
+  async getDownloadUrl(generatedReportId: string): Promise<{
+    url: string;
+    filename: string;
+    contentType: string;
+    fileSize: number | null;
+  }> {
+    const gr = await this.prisma.generatedReport.findUnique({
+      where: { id: generatedReportId },
+    });
+    if (!gr) throw new GeneratedReportNotFoundError(generatedReportId);
+
+    const contentType = MIME_TYPES[gr.format] ?? 'application/octet-stream';
+
+    if (gr.r2Key) {
+      const url = await getPresignedUrl(gr.r2Key);
+      return { url, filename: gr.filename, contentType, fileSize: gr.fileSize };
+    }
+
+    if (gr.localPath) {
+      // Local fallback — caller streams the file directly
+      return {
+        url: gr.localPath,
+        filename: gr.filename,
+        contentType,
+        fileSize: gr.fileSize,
+      };
+    }
+
+    throw new Error(`Generated report ${generatedReportId} has no storage location`);
+  }
+
+  /**
+   * Get the latest generated file for a report by format.
+   */
+  async getLatest(reportId: string, format: string): Promise<GeneratedReport | null> {
+    return this.prisma.generatedReport.findFirst({
+      where: { reportId, format },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Generated report storage and download for #226.

## Changes
- **Prisma model**: `GeneratedReport` with `reportId`, `format`, `filename`, `r2Key`, `localPath`, `fileSize`, `pageCount`, `photoCount`, `version`
- **Migration**: `20260224060000_add_generated_report`
- **Service**: `GeneratedReportService` — store to R2 (presigned URLs) with local fallback
- **Routes**:
  - `GET /api/reports/:id/generated` — list all generated files
  - `GET /api/reports/:id/download/:format` — download latest by format
  - `GET /api/reports/file/:id/download` — download specific file

## File Naming
`{reportId[0:8]}-{TYPE}-v{version}.{format}`  
e.g. `a1b2c3d4-COA-v2.pdf`

## Storage
- R2 configured → uploads to `reports/{reportId}/{filename}`, redirects to presigned URL
- R2 not configured → stores local path, streams file directly

## Acceptance Criteria
- [x] Store generated files (R2 or local)
- [x] GeneratedReport entity with metadata
- [x] Track file size, page count, photo count
- [x] Download endpoint with proper headers
- [x] File naming convention
- [x] List generated files for report

Closes #226