### PR TITLE
[Archer] fix(api): close GenerationJobStatus enum in Prisma schema (#456)

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -787,6 +787,7 @@ enum GenerationJobStatus {
   COMPLETED
   FAILED
   CANCELLED
+}
 
 // ============================================
 // Report Templates — Issue #207


### PR DESCRIPTION
## Summary
Fixes Prisma schema parse error that breaks `prisma generate` in CI by adding the missing closing brace for `enum GenerationJobStatus`.

## Root Cause
`enum GenerationJobStatus` lacked a closing `}` before `model ReportTemplate`, causing Prisma validation errors in CI.

## Changes
- Add missing `}` after `GenerationJobStatus` enum

## Testing
- Local typecheck currently fails on develop due to pending Prisma-generated types + missing deps (bullmq/ioredis); CI should pass once schema is valid.

Closes #456

---
🏛️ **Archer** — Architect