### PR TITLE
[Alex] fix(api): make Redis/BullMQ optional — API starts without REDIS_URL (#225)

### DIFF
--- a/api/src/__tests__/generation-queue.test.ts
+++ b/api/src/__tests__/generation-queue.test.ts
@@ -42,7 +42,7 @@ vi.mock('@prisma/client', () => ({
 
 // Import after mocks
 import { PrismaClient } from '@prisma/client';
-import { GenerationQueueService, JobNotFoundError, JobAlreadyActiveError } from '../services/generation-queue.js';
+import { GenerationQueueService, JobNotFoundError, JobAlreadyActiveError, QueueUnavailableError } from '../services/generation-queue.js';
 import type { Queue } from 'bullmq';
 import type { GenerationJobData } from '../services/generation-queue.js';
 
@@ -129,6 +129,12 @@ describe('GenerationQueueService', () => {
       mockFindFirst.mockResolvedValue(makeDbJob({ status: 'RETRYING' }));
 
       await expect(service.enqueue('insp-1')).rejects.toThrow(JobAlreadyActiveError);
+    });
+
+    it('throws QueueUnavailableError when queue is null', async () => {
+      const nullQueueService = new GenerationQueueService(prisma, () => null);
+      await expect(nullQueueService.enqueue('insp-1')).rejects.toThrow(QueueUnavailableError);
+      expect(mockCreate).not.toHaveBeenCalled();
     });
 
     it('allows enqueue when previous job is COMPLETED', async () => {

--- a/api/src/config/redis.ts
+++ b/api/src/config/redis.ts
@@ -1,14 +1,31 @@
 /**
  * Redis connection config for BullMQ.
+ * Redis is OPTIONAL — when REDIS_URL is not set, all exports
+ * return null / no-op so the API starts without a queue backend.
  */
 
 import { Redis } from 'ioredis';
 
 let _connection: Redis | null = null;
 
-export function getRedisConnection(): Redis {
+/**
+ * Returns true when a REDIS_URL env var is configured.
+ */
+export function isRedisConfigured(): boolean {
+  return !!process.env.REDIS_URL;
+}
+
+/**
+ * Get the shared Redis connection.
+ * Returns null when REDIS_URL is not set.
+ */
+export function getRedisConnection(): Redis | null {
+  if (!isRedisConfigured()) {
+    return null;
+  }
+
   if (!_connection) {
-    const url = process.env.REDIS_URL || 'redis://localhost:6379';
+    const url = process.env.REDIS_URL!;
     _connection = new Redis(url, {
       maxRetriesPerRequest: null, // Required by BullMQ
       enableReadyCheck: false,
@@ -34,10 +51,11 @@ export async function closeRedisConnection(): Promise<void> {
 }
 
 /**
- * Verify Redis is reachable. Throws if connection fails.
- * Call during startup to fail fast on misconfiguration.
+ * Verify Redis is reachable. Returns false when not configured.
  */
-export async function pingRedis(): Promise<void> {
+export async function pingRedis(): Promise<boolean> {
   const conn = getRedisConnection();
+  if (!conn) return false;
   await conn.ping();
+  return true;
 }

--- a/api/src/routes/report-generation.ts
+++ b/api/src/routes/report-generation.ts
@@ -12,6 +12,7 @@ import {
   GenerationQueueService,
   JobNotFoundError,
   JobAlreadyActiveError,
+  QueueUnavailableError,
 } from '../services/generation-queue.js';
 
 const prisma = new PrismaClient();
@@ -38,6 +39,10 @@ reportGenerationRouter.post(
         message: 'Report generation queued',
       });
     } catch (error) {
+      if (error instanceof QueueUnavailableError) {
+        res.status(503).json({ error: error.message });
+        return;
+      }
       if (error instanceof JobAlreadyActiveError) {
         res.status(409).json({ error: error.message });
         return;

--- a/api/src/services/generation-queue.ts
+++ b/api/src/services/generation-queue.ts
@@ -1,11 +1,12 @@
 /**
  * Report Generation Queue Service
  * Manages BullMQ job queue for async report generation.
+ * When Redis is not configured, enqueue operations throw a clear error.
  */
 
 import { Queue } from 'bullmq';
 import type { PrismaClient } from '@prisma/client';
-import { getRedisConnection } from '../config/redis.js';
+import { getRedisConnection, isRedisConfigured } from '../config/redis.js';
 
 export const QUEUE_NAME = 'report-generation';
 export const MAX_CONCURRENCY = 3;
@@ -29,12 +30,29 @@ export class JobAlreadyActiveError extends Error {
   }
 }
 
+export class QueueUnavailableError extends Error {
+  constructor() {
+    super('Report generation queue is unavailable — REDIS_URL is not configured');
+    this.name = 'QueueUnavailableError';
+  }
+}
+
 let _queue: Queue<GenerationJobData> | null = null;
 
-export function getQueue(): Queue<GenerationJobData> {
+/**
+ * Get the BullMQ queue instance. Returns null when Redis is not configured.
+ */
+export function getQueue(): Queue<GenerationJobData> | null {
+  if (!isRedisConfigured()) {
+    return null;
+  }
+
   if (!_queue) {
+    const connection = getRedisConnection();
+    if (!connection) return null;
+
     _queue = new Queue<GenerationJobData>(QUEUE_NAME, {
-      connection: getRedisConnection(),
+      connection,
       defaultJobOptions: {
         attempts: 2,
         backoff: {
@@ -52,14 +70,20 @@ export function getQueue(): Queue<GenerationJobData> {
 export class GenerationQueueService {
   constructor(
     private prisma: PrismaClient,
-    private getJobQueue: () => Queue<GenerationJobData> = getQueue
+    private getJobQueue: () => Queue<GenerationJobData> | null = getQueue
   ) {}
 
   /**
    * Enqueue a report generation job for an inspection.
    * Rejects if there's already an active job for this inspection.
+   * Throws QueueUnavailableError if Redis is not configured.
    */
   async enqueue(inspectionId: string): Promise<{ jobId: string; status: string }> {
+    const queue = this.getJobQueue();
+    if (!queue) {
+      throw new QueueUnavailableError();
+    }
+
     // Check for active jobs
     const existing = await this.prisma.generationJob.findFirst({
       where: {
@@ -82,7 +106,6 @@ export class GenerationQueueService {
     });
 
     // Enqueue in BullMQ
-    const queue = this.getJobQueue();
     const bullJob = await queue.add(
       'generate',
       { inspectionId, dbJobId: dbJob.id },
@@ -179,9 +202,11 @@ export class GenerationQueueService {
     // Remove from BullMQ queue
     if (job.bullJobId) {
       const queue = this.getJobQueue();
-      const bullJob = await queue.getJob(job.bullJobId);
-      if (bullJob) {
-        await bullJob.remove();
+      if (queue) {
+        const bullJob = await queue.getJob(job.bullJobId);
+        if (bullJob) {
+          await bullJob.remove();
+        }
       }
     }
 

--- a/api/src/workers/report-worker.ts
+++ b/api/src/workers/report-worker.ts
@@ -2,11 +2,14 @@
  * Report Generation Worker
  * Processes BullMQ jobs for async report generation.
  * Max concurrency: 3 concurrent generation jobs.
+ *
+ * When Redis is not configured, the worker is a no-op — the API
+ * starts normally but report generation jobs will not be processed.
  */
 
 import { Worker, type Job } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
-import { getRedisConnection, pingRedis } from '../config/redis.js';
+import { getRedisConnection, isRedisConfigured } from '../config/redis.js';
 import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
 import { ReportService } from '../services/report.js';
 import { QUEUE_NAME, MAX_CONCURRENCY, type GenerationJobData } from '../services/generation-queue.js';
@@ -75,24 +78,34 @@ async function processJob(job: Job<GenerationJobData>): Promise<void> {
   }
 }
 
-export async function startReportWorker(): Promise<Worker<GenerationJobData>> {
+export async function startReportWorker(): Promise<Worker<GenerationJobData> | null> {
   if (_worker) {
     return _worker;
   }
 
+  if (!isRedisConfigured()) {
+    console.log('[Worker] REDIS_URL not set — report generation worker disabled');
+    return null;
+  }
+
+  const connection = getRedisConnection();
+  if (!connection) {
+    console.log('[Worker] Redis connection unavailable — report generation worker disabled');
+    return null;
+  }
+
   // Verify Redis is reachable before starting the worker
   try {
-    await pingRedis();
+    await connection.ping();
     console.log('[Worker] Redis connection verified');
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Worker] ⚠️  Redis unreachable — report generation jobs will not process: ${msg}`);
-    // Return a no-op placeholder; don't crash the server
-    return null as unknown as Worker<GenerationJobData>;
+    console.error(`[Worker] ⚠️  Redis unreachable — report generation worker disabled: ${msg}`);
+    return null;
   }
 
   _worker = new Worker<GenerationJobData>(QUEUE_NAME, processJob, {
-    connection: getRedisConnection(),
+    connection,
     concurrency: MAX_CONCURRENCY,
   });
 


### PR DESCRIPTION
## Summary
Fixes #225 (tested-fail) — Railway deploy crashing with Redis connection error spam.

## Problem
The generation queue code eagerly connects to Redis on startup. When `REDIS_URL` is not set (test environment on Railway), the API spams `[Redis] Connection error:` logs and the deploy is marked as failed.

## Solution
Make Redis fully optional:
- `getRedisConnection()` returns `null` when `REDIS_URL` is not configured
- Worker logs a warning and skips startup — no crash, no error spam
- `enqueue()` returns `503 QueueUnavailableError` if someone tries to generate without Redis
- Status/cancel endpoints still work (they only hit Postgres)

## Changes
- `api/src/config/redis.ts` — `isRedisConfigured()` guard, nullable return
- `api/src/services/generation-queue.ts` — `QueueUnavailableError`, nullable queue
- `api/src/workers/report-worker.ts` — graceful skip when no Redis
- `api/src/routes/report-generation.ts` — 503 handler for `QueueUnavailableError`
- `api/src/__tests__/generation-queue.test.ts` — added test for null queue

## Testing
- 371 tests pass (17 generation-queue tests including new one)
- Typecheck clean, lint clean (warnings only, pre-existing)