### PR TITLE
[Alex] feat(api): implement review comments system (#211)

### DIFF
--- a/api/prisma/migrations/20260225000000_add_review_comments/migration.sql
+++ b/api/prisma/migrations/20260225000000_add_review_comments/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "ReviewCommentPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "ReviewCommentStatus" AS ENUM ('OPEN', 'RESOLVED');
+
+-- CreateTable
+CREATE TABLE "ReviewComment" (
+    "id" TEXT NOT NULL,
+    "reportId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "section" TEXT,
+    "content" TEXT NOT NULL,
+    "priority" "ReviewCommentPriority" NOT NULL DEFAULT 'MEDIUM',
+    "status" "ReviewCommentStatus" NOT NULL DEFAULT 'OPEN',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReviewComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ReviewComment_reportId_idx" ON "ReviewComment"("reportId");
+
+-- CreateIndex
+CREATE INDEX "ReviewComment_reportId_status_idx" ON "ReviewComment"("reportId", "status");
+
+-- CreateIndex
+CREATE INDEX "ReviewComment_authorId_idx" ON "ReviewComment"("authorId");
+
+-- AddForeignKey
+ALTER TABLE "ReviewComment" ADD CONSTRAINT "ReviewComment_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Report {
   generatedReports GeneratedReport[]
   
   auditLogs       ReportAuditLog[]
+  reviewComments  ReviewComment[]
   costEstimate    CostEstimate?
   
   @@index([inspectionId])
@@ -196,6 +197,41 @@ model GeneratedReport {
   createdAt   DateTime @default(now())
 
   @@index([reportId])
+}
+
+// ============================================
+// Review Comments — Issue #211
+// ============================================
+
+model ReviewComment {
+  id        String                @id @default(uuid())
+
+  reportId  String
+  report    Report                @relation(fields: [reportId], references: [id], onDelete: Cascade)
+
+  authorId  String                // Plain UUID — no FK until User linkage is formalised
+  section   String?               // Report section reference (e.g. "findings", "moisture-readings")
+  content   String
+  priority  ReviewCommentPriority @default(MEDIUM)
+  status    ReviewCommentStatus   @default(OPEN)
+
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
+
+  @@index([reportId])
+  @@index([reportId, status])
+  @@index([authorId])
+}
+
+enum ReviewCommentPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum ReviewCommentStatus {
+  OPEN
+  RESOLVED
 }
 
 enum Status {

--- a/api/src/__tests__/review-comment.test.ts
+++ b/api/src/__tests__/review-comment.test.ts
@@ -1,0 +1,246 @@
+/**
+ * ReviewComment Tests — Issue #211
+ *
+ * Tests for review comments service and routes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hoist mock references
+// ──────────────────────────────────────────────────────────────────────────────
+const {
+  mockCreate,
+  mockFindUnique,
+  mockFindMany,
+  mockUpdate,
+  mockDelete,
+} = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockFindUnique: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+// Mock PrismaClient
+vi.mock('@prisma/client', () => ({
+  PrismaClient: class {
+    reviewComment = {
+      create: mockCreate,
+      findUnique: mockFindUnique,
+      findMany: mockFindMany,
+      update: mockUpdate,
+      delete: mockDelete,
+    };
+  },
+}));
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaReviewCommentRepository } from '../repositories/prisma/review-comment.js';
+import { ReviewCommentService, ReviewCommentNotFoundError } from '../services/review-comment.js';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+function makeComment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'comment-1',
+    reportId: 'report-1',
+    authorId: 'user-1',
+    section: 'findings',
+    content: 'This section needs more detail',
+    priority: 'MEDIUM',
+    status: 'OPEN',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Repository Tests
+// ──────────────────────────────────────────────────────────────────────────────
+describe('PrismaReviewCommentRepository', () => {
+  let repo: PrismaReviewCommentRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = new PrismaReviewCommentRepository(new PrismaClient());
+  });
+
+  it('creates a review comment', async () => {
+    const comment = makeComment();
+    mockCreate.mockResolvedValue(comment);
+
+    const result = await repo.create({
+      reportId: 'report-1',
+      authorId: 'user-1',
+      section: 'findings',
+      content: 'This section needs more detail',
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        reportId: 'report-1',
+        authorId: 'user-1',
+        section: 'findings',
+        content: 'This section needs more detail',
+        priority: 'MEDIUM',
+      },
+    });
+    expect(result.id).toBe('comment-1');
+  });
+
+  it('creates with default priority when not specified', async () => {
+    mockCreate.mockResolvedValue(makeComment());
+
+    await repo.create({
+      reportId: 'report-1',
+      authorId: 'user-1',
+      content: 'General comment',
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ priority: 'MEDIUM', section: null }),
+    });
+  });
+
+  it('finds by filter with all params', async () => {
+    mockFindMany.mockResolvedValue([makeComment()]);
+
+    await repo.findByFilter({
+      reportId: 'report-1',
+      status: 'OPEN',
+      priority: 'HIGH',
+      authorId: 'user-1',
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        reportId: 'report-1',
+        status: 'OPEN',
+        priority: 'HIGH',
+        authorId: 'user-1',
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('finds by filter with only reportId', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await repo.findByFilter({ reportId: 'report-1' });
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { reportId: 'report-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Service Tests
+// ──────────────────────────────────────────────────────────────────────────────
+describe('ReviewCommentService', () => {
+  let service: ReviewCommentService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const prisma = new PrismaClient();
+    const repo = new PrismaReviewCommentRepository(prisma);
+    service = new ReviewCommentService(repo);
+  });
+
+  describe('create', () => {
+    it('creates a comment', async () => {
+      const comment = makeComment();
+      mockCreate.mockResolvedValue(comment);
+
+      const result = await service.create({
+        reportId: 'report-1',
+        authorId: 'user-1',
+        content: 'Needs more detail',
+      });
+
+      expect(result.id).toBe('comment-1');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns comment when found', async () => {
+      mockFindUnique.mockResolvedValue(makeComment());
+      const result = await service.getById('comment-1');
+      expect(result.id).toBe('comment-1');
+    });
+
+    it('throws ReviewCommentNotFoundError when not found', async () => {
+      mockFindUnique.mockResolvedValue(null);
+      await expect(service.getById('missing')).rejects.toThrow(ReviewCommentNotFoundError);
+    });
+  });
+
+  describe('list', () => {
+    it('returns filtered comments', async () => {
+      const comments = [makeComment(), makeComment({ id: 'comment-2' })];
+      mockFindMany.mockResolvedValue(comments);
+
+      const result = await service.list({ reportId: 'report-1', status: 'OPEN' });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('update', () => {
+    it('updates an existing comment', async () => {
+      mockFindUnique.mockResolvedValue(makeComment());
+      mockUpdate.mockResolvedValue(makeComment({ content: 'Updated' }));
+
+      const result = await service.update('comment-1', { content: 'Updated' });
+      expect(result.content).toBe('Updated');
+    });
+
+    it('throws when comment not found', async () => {
+      mockFindUnique.mockResolvedValue(null);
+      await expect(service.update('missing', { content: 'x' })).rejects.toThrow(ReviewCommentNotFoundError);
+    });
+  });
+
+  describe('resolve', () => {
+    it('sets status to RESOLVED', async () => {
+      mockFindUnique.mockResolvedValue(makeComment());
+      mockUpdate.mockResolvedValue(makeComment({ status: 'RESOLVED' }));
+
+      const result = await service.resolve('comment-1');
+      expect(result.status).toBe('RESOLVED');
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+        data: { status: 'RESOLVED' },
+      });
+    });
+  });
+
+  describe('reopen', () => {
+    it('sets status to OPEN', async () => {
+      mockFindUnique.mockResolvedValue(makeComment({ status: 'RESOLVED' }));
+      mockUpdate.mockResolvedValue(makeComment({ status: 'OPEN' }));
+
+      const result = await service.reopen('comment-1');
+      expect(result.status).toBe('OPEN');
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes an existing comment', async () => {
+      mockFindUnique.mockResolvedValue(makeComment());
+      mockDelete.mockResolvedValue(makeComment());
+
+      await service.delete('comment-1');
+      expect(mockDelete).toHaveBeenCalledWith({ where: { id: 'comment-1' } });
+    });
+
+    it('throws when comment not found', async () => {
+      mockFindUnique.mockResolvedValue(null);
+      await expect(service.delete('missing')).rejects.toThrow(ReviewCommentNotFoundError);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,6 +32,7 @@ import { costEstimatesRouter } from './routes/cost-estimates.js';
 import { reportGenerationRouter } from './routes/report-generation.js';
 import { startReportWorker, stopReportWorker } from './workers/report-worker.js';
 import { reportTemplatesRouter } from './routes/report-templates.js';
+import { reviewCommentsRouter } from './routes/review-comments.js';
 import { generatedReportsRouter } from './routes/generated-reports.js';
 import { personnelRouter } from './routes/personnel.js';
 import { openApiRouter } from './openapi/index.js';
@@ -108,6 +109,7 @@ app.use('/api', authMiddleware, moistureReadingsRouter);
 app.use('/api', authMiddleware, costEstimatesRouter);
 app.use('/api', authMiddleware, reportGenerationRouter);
 app.use('/api', authMiddleware, reportTemplatesRouter);
+app.use('/api', authMiddleware, reviewCommentsRouter);
 app.use('/api/reports', authMiddleware, generatedReportsRouter);
 
 // Error handling with detailed logging

--- a/api/src/repositories/interfaces/review-comment.ts
+++ b/api/src/repositories/interfaces/review-comment.ts
@@ -1,0 +1,35 @@
+/**
+ * ReviewComment Repository Interface — Issue #211
+ */
+
+import type { ReviewComment } from '@prisma/client';
+
+export interface CreateReviewCommentData {
+  reportId: string;
+  authorId: string;
+  section?: string;
+  content: string;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH';
+}
+
+export interface UpdateReviewCommentData {
+  content?: string;
+  section?: string;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH';
+  status?: 'OPEN' | 'RESOLVED';
+}
+
+export interface ReviewCommentFilter {
+  reportId: string;
+  status?: 'OPEN' | 'RESOLVED';
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH';
+  authorId?: string;
+}
+
+export interface IReviewCommentRepository {
+  create(data: CreateReviewCommentData): Promise<ReviewComment>;
+  findById(id: string): Promise<ReviewComment | null>;
+  findByFilter(filter: ReviewCommentFilter): Promise<ReviewComment[]>;
+  update(id: string, data: UpdateReviewCommentData): Promise<ReviewComment>;
+  delete(id: string): Promise<void>;
+}

--- a/api/src/repositories/interfaces/review-comment.ts
+++ b/api/src/repositories/interfaces/review-comment.ts
@@ -14,7 +14,7 @@ export interface CreateReviewCommentData {
 
 export interface UpdateReviewCommentData {
   content?: string;
-  section?: string;
+  section?: string | null;
   priority?: 'LOW' | 'MEDIUM' | 'HIGH';
   status?: 'OPEN' | 'RESOLVED';
 }

--- a/api/src/repositories/prisma/review-comment.ts
+++ b/api/src/repositories/prisma/review-comment.ts
@@ -1,0 +1,54 @@
+/**
+ * Prisma ReviewComment Repository — Issue #211
+ */
+
+import type { PrismaClient, ReviewComment } from '@prisma/client';
+import type {
+  IReviewCommentRepository,
+  CreateReviewCommentData,
+  UpdateReviewCommentData,
+  ReviewCommentFilter,
+} from '../interfaces/review-comment.js';
+
+export class PrismaReviewCommentRepository implements IReviewCommentRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(data: CreateReviewCommentData): Promise<ReviewComment> {
+    return this.prisma.reviewComment.create({
+      data: {
+        reportId: data.reportId,
+        authorId: data.authorId,
+        section: data.section ?? null,
+        content: data.content,
+        priority: data.priority ?? 'MEDIUM',
+      },
+    });
+  }
+
+  async findById(id: string): Promise<ReviewComment | null> {
+    return this.prisma.reviewComment.findUnique({ where: { id } });
+  }
+
+  async findByFilter(filter: ReviewCommentFilter): Promise<ReviewComment[]> {
+    return this.prisma.reviewComment.findMany({
+      where: {
+        reportId: filter.reportId,
+        ...(filter.status && { status: filter.status }),
+        ...(filter.priority && { priority: filter.priority }),
+        ...(filter.authorId && { authorId: filter.authorId }),
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async update(id: string, data: UpdateReviewCommentData): Promise<ReviewComment> {
+    return this.prisma.reviewComment.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.reviewComment.delete({ where: { id } });
+  }
+}

--- a/api/src/routes/review-comments.ts
+++ b/api/src/routes/review-comments.ts
@@ -6,13 +6,14 @@
  * POST   /api/reports/:reportId/comments            — add a comment
  * GET    /api/reports/:reportId/comments             — list comments (filter: status, priority, authorId)
  * GET    /api/reports/:reportId/comments/:id         — get single comment
- * PATCH  /api/reports/:reportId/comments/:id         — update a comment
+ * PATCH  /api/reports/:reportId/comments/:id         — update a comment (prefer /resolve and /reopen for status changes)
  * POST   /api/reports/:reportId/comments/:id/resolve — resolve a comment
  * POST   /api/reports/:reportId/comments/:id/reopen  — reopen a comment
  * DELETE /api/reports/:reportId/comments/:id         — delete a comment
  */
 
 import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
+import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { PrismaReviewCommentRepository } from '../repositories/prisma/review-comment.js';
 import { ReviewCommentService, ReviewCommentNotFoundError } from '../services/review-comment.js';
@@ -23,25 +24,51 @@ const service = new ReviewCommentService(repository);
 
 export const reviewCommentsRouter: RouterType = Router();
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Validation schemas
+// ──────────────────────────────────────────────────────────────────────────────
+
+const PriorityValues = ['LOW', 'MEDIUM', 'HIGH'] as const;
+const StatusValues = ['OPEN', 'RESOLVED'] as const;
+
+const CreateCommentSchema = z.object({
+  authorId: z.string().uuid('authorId must be a valid UUID'),
+  section: z.string().min(1).optional(),
+  content: z.string().min(1, 'content is required'),
+  priority: z.enum(PriorityValues).default('MEDIUM'),
+});
+
+const UpdateCommentSchema = z.object({
+  content: z.string().min(1).optional(),
+  section: z.string().min(1).nullable().optional(),
+  priority: z.enum(PriorityValues).optional(),
+  status: z.enum(StatusValues).optional(),
+});
+
+const ListQuerySchema = z.object({
+  status: z.enum(StatusValues).optional(),
+  priority: z.enum(PriorityValues).optional(),
+  authorId: z.string().uuid().optional(),
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Routes
+// ──────────────────────────────────────────────────────────────────────────────
+
 /** POST /api/reports/:reportId/comments */
 reviewCommentsRouter.post(
   '/reports/:reportId/comments',
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { reportId } = req.params;
-      const { authorId, section, content, priority } = req.body;
-
-      if (!authorId || !content) {
-        res.status(400).json({ error: 'authorId and content are required' });
+      const parsed = CreateCommentSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten().fieldErrors });
         return;
       }
 
       const comment = await service.create({
-        reportId: reportId as string,
-        authorId,
-        section,
-        content,
-        priority,
+        reportId: req.params.reportId as string,
+        ...parsed.data,
       });
 
       res.status(201).json(comment);
@@ -56,14 +83,15 @@ reviewCommentsRouter.get(
   '/reports/:reportId/comments',
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { reportId } = req.params;
-      const { status, priority, authorId } = req.query;
+      const parsed = ListQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten().fieldErrors });
+        return;
+      }
 
       const comments = await service.list({
-        reportId: reportId as string,
-        ...(status && { status: status as 'OPEN' | 'RESOLVED' }),
-        ...(priority && { priority: priority as 'LOW' | 'MEDIUM' | 'HIGH' }),
-        ...(authorId && { authorId: authorId as string }),
+        reportId: req.params.reportId as string,
+        ...parsed.data,
       });
 
       res.json(comments);
@@ -95,13 +123,13 @@ reviewCommentsRouter.patch(
   '/reports/:reportId/comments/:id',
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { content, section, priority, status } = req.body;
-      const comment = await service.update(req.params.id as string, {
-        content,
-        section,
-        priority,
-        status,
-      });
+      const parsed = UpdateCommentSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten().fieldErrors });
+        return;
+      }
+
+      const comment = await service.update(req.params.id as string, parsed.data);
       res.json(comment);
     } catch (error) {
       if (error instanceof ReviewCommentNotFoundError) {

--- a/api/src/routes/review-comments.ts
+++ b/api/src/routes/review-comments.ts
@@ -1,0 +1,165 @@
+/**
+ * Review Comment Routes — Issue #211
+ *
+ * CRUD for review comments on reports.
+ *
+ * POST   /api/reports/:reportId/comments            — add a comment
+ * GET    /api/reports/:reportId/comments             — list comments (filter: status, priority, authorId)
+ * GET    /api/reports/:reportId/comments/:id         — get single comment
+ * PATCH  /api/reports/:reportId/comments/:id         — update a comment
+ * POST   /api/reports/:reportId/comments/:id/resolve — resolve a comment
+ * POST   /api/reports/:reportId/comments/:id/reopen  — reopen a comment
+ * DELETE /api/reports/:reportId/comments/:id         — delete a comment
+ */
+
+import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { PrismaReviewCommentRepository } from '../repositories/prisma/review-comment.js';
+import { ReviewCommentService, ReviewCommentNotFoundError } from '../services/review-comment.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaReviewCommentRepository(prisma);
+const service = new ReviewCommentService(repository);
+
+export const reviewCommentsRouter: RouterType = Router();
+
+/** POST /api/reports/:reportId/comments */
+reviewCommentsRouter.post(
+  '/reports/:reportId/comments',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+      const { authorId, section, content, priority } = req.body;
+
+      if (!authorId || !content) {
+        res.status(400).json({ error: 'authorId and content are required' });
+        return;
+      }
+
+      const comment = await service.create({
+        reportId: reportId as string,
+        authorId,
+        section,
+        content,
+        priority,
+      });
+
+      res.status(201).json(comment);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/** GET /api/reports/:reportId/comments */
+reviewCommentsRouter.get(
+  '/reports/:reportId/comments',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+      const { status, priority, authorId } = req.query;
+
+      const comments = await service.list({
+        reportId: reportId as string,
+        ...(status && { status: status as 'OPEN' | 'RESOLVED' }),
+        ...(priority && { priority: priority as 'LOW' | 'MEDIUM' | 'HIGH' }),
+        ...(authorId && { authorId: authorId as string }),
+      });
+
+      res.json(comments);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/** GET /api/reports/:reportId/comments/:id */
+reviewCommentsRouter.get(
+  '/reports/:reportId/comments/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const comment = await service.getById(req.params.id as string);
+      res.json(comment);
+    } catch (error) {
+      if (error instanceof ReviewCommentNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+/** PATCH /api/reports/:reportId/comments/:id */
+reviewCommentsRouter.patch(
+  '/reports/:reportId/comments/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { content, section, priority, status } = req.body;
+      const comment = await service.update(req.params.id as string, {
+        content,
+        section,
+        priority,
+        status,
+      });
+      res.json(comment);
+    } catch (error) {
+      if (error instanceof ReviewCommentNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+/** POST /api/reports/:reportId/comments/:id/resolve */
+reviewCommentsRouter.post(
+  '/reports/:reportId/comments/:id/resolve',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const comment = await service.resolve(req.params.id as string);
+      res.json(comment);
+    } catch (error) {
+      if (error instanceof ReviewCommentNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+/** POST /api/reports/:reportId/comments/:id/reopen */
+reviewCommentsRouter.post(
+  '/reports/:reportId/comments/:id/reopen',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const comment = await service.reopen(req.params.id as string);
+      res.json(comment);
+    } catch (error) {
+      if (error instanceof ReviewCommentNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);
+
+/** DELETE /api/reports/:reportId/comments/:id */
+reviewCommentsRouter.delete(
+  '/reports/:reportId/comments/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await service.delete(req.params.id as string);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof ReviewCommentNotFoundError) {
+        res.status(404).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  }
+);

--- a/api/src/services/review-comment.ts
+++ b/api/src/services/review-comment.ts
@@ -1,0 +1,59 @@
+/**
+ * ReviewComment Service — Issue #211
+ *
+ * Business logic for review comments on reports.
+ */
+
+import type {
+  IReviewCommentRepository,
+  CreateReviewCommentData,
+  UpdateReviewCommentData,
+  ReviewCommentFilter,
+} from '../repositories/interfaces/review-comment.js';
+import type { ReviewComment } from '@prisma/client';
+
+export class ReviewCommentNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Review comment not found: ${id}`);
+    this.name = 'ReviewCommentNotFoundError';
+  }
+}
+
+export class ReviewCommentService {
+  constructor(private repository: IReviewCommentRepository) {}
+
+  async create(data: CreateReviewCommentData): Promise<ReviewComment> {
+    return this.repository.create(data);
+  }
+
+  async getById(id: string): Promise<ReviewComment> {
+    const comment = await this.repository.findById(id);
+    if (!comment) throw new ReviewCommentNotFoundError(id);
+    return comment;
+  }
+
+  async list(filter: ReviewCommentFilter): Promise<ReviewComment[]> {
+    return this.repository.findByFilter(filter);
+  }
+
+  async update(id: string, data: UpdateReviewCommentData): Promise<ReviewComment> {
+    // Verify exists
+    await this.getById(id);
+    return this.repository.update(id, data);
+  }
+
+  async resolve(id: string): Promise<ReviewComment> {
+    await this.getById(id);
+    return this.repository.update(id, { status: 'RESOLVED' });
+  }
+
+  async reopen(id: string): Promise<ReviewComment> {
+    await this.getById(id);
+    return this.repository.update(id, { status: 'OPEN' });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.getById(id);
+    return this.repository.delete(id);
+  }
+}


### PR DESCRIPTION
## Summary
Implements #211 — review comments on reports during the review workflow.

## Changes
- **Prisma model:** `ReviewComment` with priority (LOW/MEDIUM/HIGH), status (OPEN/RESOLVED), section linking
- **Migration:** `20260225000000_add_review_comments`
- **Repository:** `PrismaReviewCommentRepository` with filtered queries
- **Service:** `ReviewCommentService` with resolve/reopen convenience methods
- **Routes:**
  - `POST /api/reports/:reportId/comments` — add comment
  - `GET /api/reports/:reportId/comments` — list (filter: status, priority, authorId)
  - `GET /api/reports/:reportId/comments/:id` — get single
  - `PATCH /api/reports/:reportId/comments/:id` — update
  - `POST /api/reports/:reportId/comments/:id/resolve` — resolve
  - `POST /api/reports/:reportId/comments/:id/reopen` — reopen
  - `DELETE /api/reports/:reportId/comments/:id` — delete

## Testing
- 13 new tests (repository + service layers)
- 384 total tests pass
- Typecheck clean, lint clean (warnings only, pre-existing)