### PR TITLE
[Alex] feat(api): implement variable substitution engine (#208)

### DIFF
--- a/api/src/__tests__/variable-substitution.test.ts
+++ b/api/src/__tests__/variable-substitution.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractVariables,
+  substituteVariables,
+  getAvailableVariables,
+  validateVariables,
+  type VariableContext,
+} from '../services/variable-substitution.js';
+
+const createSampleContext = (overrides?: Partial<VariableContext>): VariableContext => ({
+  project: {
+    address: '123 Main Street',
+    activity: 'Inspection',
+    jobNumber: 'JOB-001',
+    reportType: 'COA',
+    ...overrides?.project,
+  },
+  property: {
+    lotDp: 'Lot 1 DP 12345',
+    councilPropertyId: 'CP-001',
+    territorialAuthority: 'Auckland Council',
+    ...overrides?.property,
+  },
+  client: {
+    name: 'John Doe',
+    address: '456 Client Ave',
+    phone: '+64 21 555 1234',
+    email: 'john@example.com',
+    contactPerson: 'John Doe',
+    ...overrides?.client,
+  },
+  company: {
+    name: 'Acme Inspections',
+    address: '789 Company Rd',
+    phone: '+64 9 555 9999',
+    email: 'info@acme.co.nz',
+    ...overrides?.company,
+  },
+  personnel: {
+    inspectorName: 'Jane Inspector',
+    authorName: 'Jane Author',
+    authorCredentials: 'LBP, NZIBS',
+    reviewerName: 'Bob Reviewer',
+    reviewerCredentials: 'LBP',
+    ...overrides?.personnel,
+  },
+  inspection: {
+    date: '25 February 2026',
+    weather: 'Fine',
+    ...overrides?.inspection,
+  },
+});
+
+describe('Variable Substitution Engine', () => {
+  // ─── extractVariables ──────────────────────────────────────────────────────
+
+  describe('extractVariables', () => {
+    it('should find all variables in content', () => {
+      const content = 'Hello [Client Name], your report for [Address] is ready.';
+      const vars = extractVariables(content);
+
+      expect(vars).toContain('Client Name');
+      expect(vars).toContain('Address');
+      expect(vars).toHaveLength(2);
+    });
+
+    it('should handle duplicate variables', () => {
+      const content = '[Client Name] at [Address] and again [Client Name]';
+      const vars = extractVariables(content);
+
+      expect(vars).toContain('Client Name');
+      expect(vars).toContain('Address');
+      expect(vars).toHaveLength(2); // duplicates removed
+    });
+
+    it('should handle empty content', () => {
+      const vars = extractVariables('');
+      expect(vars).toHaveLength(0);
+    });
+
+    it('should handle content with no variables', () => {
+      const content = 'This is plain text without any variables.';
+      const vars = extractVariables(content);
+      expect(vars).toHaveLength(0);
+    });
+
+    it('should extract variables with special characters in names', () => {
+      const content = '[Some Variable] and [Another One]';
+      const vars = extractVariables(content);
+
+      expect(vars).toContain('Some Variable');
+      expect(vars).toContain('Another One');
+    });
+  });
+
+  // ─── substituteVariables ───────────────────────────────────────────────────
+
+  describe('substituteVariables', () => {
+    it('should replace known variables with values', () => {
+      const content = 'Client: [Client Name], Address: [Address]';
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Client: John Doe, Address: 123 Main Street');
+      expect(result.substitutionCount).toBe(2);
+      expect(result.missingVariables).toHaveLength(0);
+    });
+
+    it('should mark unknown variables with [MISSING: ...]', () => {
+      const content = 'Hello [Unknown Variable]';
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Hello [MISSING: Unknown Variable]');
+      expect(result.missingVariables).toContain('Unknown Variable');
+      expect(result.warnings).toContain('Unknown variable: Unknown Variable');
+    });
+
+    it('should handle empty context values as missing', () => {
+      const content = 'Weather: [Weather]';
+      const ctx = createSampleContext({
+        inspection: { date: '25 February 2026', weather: '' },
+      });
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Weather: [MISSING: Weather]');
+      expect(result.missingVariables).toContain('Weather');
+      expect(result.warnings).toContain('Empty value for variable: Weather');
+    });
+
+    it('should escape HTML in substituted values', () => {
+      const content = 'Client: [Client Name]';
+      const ctx = createSampleContext({
+        client: {
+          name: '<script>alert("xss")</script>',
+          address: '456 Client Ave',
+          phone: '+64 21 555 1234',
+          email: 'john@example.com',
+          contactPerson: 'John Doe',
+        },
+      });
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Client: &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+      expect(result.content).not.toContain('<script>');
+    });
+
+    it('should escape special HTML characters', () => {
+      const content = 'Client: [Client Name]';
+      const ctx = createSampleContext({
+        client: {
+          name: "O'Brien & Sons <Inc>",
+          address: '456 Client Ave',
+          phone: '+64 21 555 1234',
+          email: 'john@example.com',
+          contactPerson: 'John Doe',
+        },
+      });
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Client: O&#39;Brien &amp; Sons &lt;Inc&gt;');
+    });
+
+    it('should return warnings for unknown variables', () => {
+      const content = '[Client Name] [Foo Bar]';
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.warnings).toContain('Unknown variable: Foo Bar');
+    });
+
+    it('should count substitutions correctly', () => {
+      const content = '[Client Name] at [Address] on [Inspection Date]';
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.substitutionCount).toBe(3);
+    });
+
+    it('should handle content with no variables', () => {
+      const content = 'Plain text without variables.';
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.content).toBe('Plain text without variables.');
+      expect(result.substitutionCount).toBe(0);
+      expect(result.missingVariables).toHaveLength(0);
+    });
+
+    it('should substitute all known variable types', () => {
+      const content = `
+        Company: [Company Name]
+        Company Address: [Company Address]
+        Company Phone: [Company Phone]
+        Company Email: [Company Email]
+        Client: [Client Name]
+        Client Address: [Client Address]
+        Client Phone: [Client Phone]
+        Client Email: [Client Email]
+        Contact: [Contact Person]
+        Address: [Address]
+        Job: [Job Number]
+        Activity: [Activity]
+        Report Type: [Report Type]
+        Lot: [Lot DP]
+        Council ID: [Council Property ID]
+        Authority: [Territorial Authority]
+        Inspector: [Inspector Name]
+        Author: [Author Name]
+        Author Creds: [Author Credentials]
+        Reviewer: [Reviewer Name]
+        Reviewer Creds: [Reviewer Credentials]
+        Date: [Inspection Date]
+        Weather: [Weather]
+      `;
+      const ctx = createSampleContext();
+
+      const result = substituteVariables(content, ctx);
+
+      expect(result.substitutionCount).toBe(23);
+      expect(result.missingVariables).toHaveLength(0);
+      expect(result.content).toContain('Acme Inspections');
+      expect(result.content).toContain('John Doe');
+      expect(result.content).toContain('123 Main Street');
+      expect(result.content).toContain('Jane Inspector');
+    });
+  });
+
+  // ─── validateVariables ─────────────────────────────────────────────────────
+
+  describe('validateVariables', () => {
+    it('should identify known variables as valid', () => {
+      const result = validateVariables(['Client Name', 'Address', 'Weather']);
+
+      expect(result.valid).toContain('Client Name');
+      expect(result.valid).toContain('Address');
+      expect(result.valid).toContain('Weather');
+      expect(result.unknown).toHaveLength(0);
+    });
+
+    it('should identify unknown variables', () => {
+      const result = validateVariables(['Client Name', 'Unknown Var', 'Another Unknown']);
+
+      expect(result.valid).toContain('Client Name');
+      expect(result.unknown).toContain('Unknown Var');
+      expect(result.unknown).toContain('Another Unknown');
+    });
+
+    it('should handle empty array', () => {
+      const result = validateVariables([]);
+
+      expect(result.valid).toHaveLength(0);
+      expect(result.unknown).toHaveLength(0);
+    });
+
+    it('should handle all unknown variables', () => {
+      const result = validateVariables(['Foo', 'Bar', 'Baz']);
+
+      expect(result.valid).toHaveLength(0);
+      expect(result.unknown).toHaveLength(3);
+    });
+  });
+
+  // ─── getAvailableVariables ─────────────────────────────────────────────────
+
+  describe('getAvailableVariables', () => {
+    it('should return a non-empty list', () => {
+      const variables = getAvailableVariables();
+      expect(variables.length).toBeGreaterThan(0);
+    });
+
+    it('should include name, path, and description for each variable', () => {
+      const variables = getAvailableVariables();
+
+      for (const v of variables) {
+        expect(v.name).toBeDefined();
+        expect(v.path).toBeDefined();
+        expect(v.description).toBeDefined();
+        expect(v.name.length).toBeGreaterThan(0);
+        expect(v.path.length).toBeGreaterThan(0);
+        expect(v.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should include expected variables', () => {
+      const variables = getAvailableVariables();
+      const names = variables.map((v) => v.name);
+
+      expect(names).toContain('Client Name');
+      expect(names).toContain('Address');
+      expect(names).toContain('Company Name');
+      expect(names).toContain('Inspector Name');
+      expect(names).toContain('Weather');
+    });
+
+    it('should have valid paths referencing context structure', () => {
+      const variables = getAvailableVariables();
+
+      const validPrefixes = ['project.', 'property.', 'client.', 'company.', 'personnel.', 'inspection.'];
+
+      for (const v of variables) {
+        const hasValidPrefix = validPrefixes.some((prefix) => v.path.startsWith(prefix));
+        expect(hasValidPrefix).toBe(true);
+      }
+    });
+  });
+});

--- a/api/src/routes/report-templates.ts
+++ b/api/src/routes/report-templates.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { PrismaReportTemplateRepository } from '../repositories/prisma/report-template.js';
 import { ReportTemplateService, ReportTemplateNotFoundError } from '../services/report-template.js';
+import {
+  substituteVariables,
+  getAvailableVariables,
+  type VariableContext,
+} from '../services/variable-substitution.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaReportTemplateRepository(prisma);
@@ -35,6 +40,85 @@ const CreateVersionSchema = z.object({
   variables: z.array(z.string()).optional(),
   isDefault: z.boolean().optional(),
 });
+
+const RenderContextSchema = z.object({
+  context: z.object({
+    project: z.object({
+      address: z.string(),
+      activity: z.string(),
+      jobNumber: z.string(),
+      reportType: z.string(),
+    }),
+    property: z.object({
+      lotDp: z.string(),
+      councilPropertyId: z.string(),
+      territorialAuthority: z.string(),
+    }),
+    client: z.object({
+      name: z.string(),
+      address: z.string(),
+      phone: z.string(),
+      email: z.string(),
+      contactPerson: z.string(),
+    }),
+    company: z.object({
+      name: z.string(),
+      address: z.string(),
+      phone: z.string(),
+      email: z.string(),
+    }),
+    personnel: z.object({
+      inspectorName: z.string(),
+      authorName: z.string(),
+      authorCredentials: z.string(),
+      reviewerName: z.string(),
+      reviewerCredentials: z.string(),
+    }),
+    inspection: z.object({
+      date: z.string(),
+      weather: z.string(),
+    }),
+  }),
+});
+
+// Sample context for preview endpoint
+const SAMPLE_CONTEXT: VariableContext = {
+  project: {
+    address: '123 Sample Street, Auckland 1010',
+    activity: 'Pre-Purchase Inspection',
+    jobNumber: 'JOB-2026-001',
+    reportType: 'COA',
+  },
+  property: {
+    lotDp: 'Lot 1 DP 12345',
+    councilPropertyId: 'AKL-12345',
+    territorialAuthority: 'Auckland Council',
+  },
+  client: {
+    name: 'John Smith',
+    address: '456 Client Road, Wellington 6011',
+    phone: '+64 21 123 4567',
+    email: 'john.smith@example.com',
+    contactPerson: 'John Smith',
+  },
+  company: {
+    name: 'Acme Inspections Ltd',
+    address: '789 Inspector Lane, Christchurch 8011',
+    phone: '+64 3 987 6543',
+    email: 'info@acme-inspections.co.nz',
+  },
+  personnel: {
+    inspectorName: 'Jane Inspector',
+    authorName: 'Jane Inspector',
+    authorCredentials: 'LBP, NZIBS',
+    reviewerName: 'Bob Reviewer',
+    reviewerCredentials: 'LBP, NZIBS, BOINZ',
+  },
+  inspection: {
+    date: '25 February 2026',
+    weather: 'Fine, 22°C',
+  },
+};
 
 function notFound(res: Response, err: unknown): void {
   if (err instanceof ReportTemplateNotFoundError) {
@@ -79,6 +163,16 @@ reportTemplatesRouter.get(
     } catch (error) {
       next(error);
     }
+  }
+);
+
+// GET /api/templates/variables — List all available variables
+// IMPORTANT: This route MUST be registered BEFORE /templates/:id to avoid :id capturing "variables"
+reportTemplatesRouter.get(
+  '/templates/variables',
+  (_req: Request, res: Response) => {
+    const variables = getAvailableVariables();
+    res.json({ variables });
   }
 );
 
@@ -169,6 +263,44 @@ reportTemplatesRouter.post(
     try {
       const template = await service.setDefault(req.params.id as string);
       res.json(template);
+    } catch (error) {
+      if (error instanceof ReportTemplateNotFoundError) { notFound(res, error); return; }
+      next(error);
+    }
+  }
+);
+
+// POST /api/templates/:id/render — Render template with provided context
+reportTemplatesRouter.post(
+  '/templates/:id/render',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = RenderContextSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten().fieldErrors });
+        return;
+      }
+
+      const template = await service.findById(req.params.id as string);
+      const result = substituteVariables(template.content, parsed.data.context as VariableContext);
+
+      res.json(result);
+    } catch (error) {
+      if (error instanceof ReportTemplateNotFoundError) { notFound(res, error); return; }
+      next(error);
+    }
+  }
+);
+
+// POST /api/templates/:id/preview — Preview template with sample data
+reportTemplatesRouter.post(
+  '/templates/:id/preview',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const template = await service.findById(req.params.id as string);
+      const result = substituteVariables(template.content, SAMPLE_CONTEXT);
+
+      res.json(result);
     } catch (error) {
       if (error instanceof ReportTemplateNotFoundError) { notFound(res, error); return; }
       next(error);

--- a/api/src/services/variable-substitution.ts
+++ b/api/src/services/variable-substitution.ts
@@ -1,0 +1,260 @@
+/**
+ * Variable Substitution Engine
+ *
+ * Resolves [Variable Name] placeholders in report templates to actual values.
+ * Uses an allowlist approach for security — only known variables are substituted.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface VariableContext {
+  project: {
+    address: string;
+    activity: string;
+    jobNumber: string;
+    reportType: string;
+  };
+  property: {
+    lotDp: string;
+    councilPropertyId: string;
+    territorialAuthority: string;
+  };
+  client: {
+    name: string;
+    address: string;
+    phone: string;
+    email: string;
+    contactPerson: string;
+  };
+  company: {
+    name: string;
+    address: string;
+    phone: string;
+    email: string;
+  };
+  personnel: {
+    inspectorName: string;
+    authorName: string;
+    authorCredentials: string;
+    reviewerName: string;
+    reviewerCredentials: string;
+  };
+  inspection: {
+    date: string;
+    weather: string;
+  };
+}
+
+export interface SubstitutionResult {
+  content: string;
+  warnings: string[];
+  substitutionCount: number;
+  missingVariables: string[];
+}
+
+export interface VariableInfo {
+  name: string;
+  path: string;
+  description: string;
+}
+
+export interface ValidationResult {
+  valid: string[];
+  unknown: string[];
+}
+
+// ─── HTML Escaping ───────────────────────────────────────────────────────────
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// ─── Variable Map ────────────────────────────────────────────────────────────
+
+type VariableResolver = (ctx: VariableContext) => string;
+
+const VARIABLE_MAP: Record<string, VariableResolver> = {
+  // Company
+  'Company Name': (ctx) => ctx.company.name,
+  'Company Address': (ctx) => ctx.company.address,
+  'Company Phone': (ctx) => ctx.company.phone,
+  'Company Email': (ctx) => ctx.company.email,
+
+  // Project / Property
+  'Address': (ctx) => ctx.project.address,
+  'Territorial Authority': (ctx) => ctx.property.territorialAuthority,
+  'Report Type': (ctx) => ctx.project.reportType,
+  'Job Number': (ctx) => ctx.project.jobNumber,
+  'Activity': (ctx) => ctx.project.activity,
+  'Lot DP': (ctx) => ctx.property.lotDp,
+  'Council Property ID': (ctx) => ctx.property.councilPropertyId,
+
+  // Client
+  'Client Name': (ctx) => ctx.client.name,
+  'Client Address': (ctx) => ctx.client.address,
+  'Client Phone': (ctx) => ctx.client.phone,
+  'Client Email': (ctx) => ctx.client.email,
+  'Contact Person': (ctx) => ctx.client.contactPerson,
+
+  // Personnel
+  'Inspector Name': (ctx) => ctx.personnel.inspectorName,
+  'Author Name': (ctx) => ctx.personnel.authorName,
+  'Author Credentials': (ctx) => ctx.personnel.authorCredentials,
+  'Reviewer Name': (ctx) => ctx.personnel.reviewerName,
+  'Reviewer Credentials': (ctx) => ctx.personnel.reviewerCredentials,
+
+  // Inspection
+  'Inspection Date': (ctx) => ctx.inspection.date,
+  'Weather': (ctx) => ctx.inspection.weather,
+};
+
+// Variable descriptions for documentation
+const VARIABLE_DESCRIPTIONS: Record<string, string> = {
+  'Company Name': 'The name of the inspection company',
+  'Company Address': 'The address of the inspection company',
+  'Company Phone': 'The phone number of the inspection company',
+  'Company Email': 'The email address of the inspection company',
+  'Address': 'The property address being inspected',
+  'Territorial Authority': 'The local council or territorial authority',
+  'Report Type': 'The type of report (COA, PPI, etc.)',
+  'Job Number': 'The unique job reference number',
+  'Activity': 'The type of activity or inspection purpose',
+  'Lot DP': 'The lot and deposited plan reference',
+  'Council Property ID': 'The council property identifier',
+  'Client Name': 'The name of the client',
+  'Client Address': 'The address of the client',
+  'Client Phone': 'The phone number of the client',
+  'Client Email': 'The email address of the client',
+  'Contact Person': 'The primary contact person for the client',
+  'Inspector Name': 'The name of the inspector who conducted the inspection',
+  'Author Name': 'The name of the report author',
+  'Author Credentials': 'The professional credentials of the author',
+  'Reviewer Name': 'The name of the report reviewer',
+  'Reviewer Credentials': 'The professional credentials of the reviewer',
+  'Inspection Date': 'The date of the inspection',
+  'Weather': 'The weather conditions during the inspection',
+};
+
+// Variable paths for documentation
+const VARIABLE_PATHS: Record<string, string> = {
+  'Company Name': 'company.name',
+  'Company Address': 'company.address',
+  'Company Phone': 'company.phone',
+  'Company Email': 'company.email',
+  'Address': 'project.address',
+  'Territorial Authority': 'property.territorialAuthority',
+  'Report Type': 'project.reportType',
+  'Job Number': 'project.jobNumber',
+  'Activity': 'project.activity',
+  'Lot DP': 'property.lotDp',
+  'Council Property ID': 'property.councilPropertyId',
+  'Client Name': 'client.name',
+  'Client Address': 'client.address',
+  'Client Phone': 'client.phone',
+  'Client Email': 'client.email',
+  'Contact Person': 'client.contactPerson',
+  'Inspector Name': 'personnel.inspectorName',
+  'Author Name': 'personnel.authorName',
+  'Author Credentials': 'personnel.authorCredentials',
+  'Reviewer Name': 'personnel.reviewerName',
+  'Reviewer Credentials': 'personnel.reviewerCredentials',
+  'Inspection Date': 'inspection.date',
+  'Weather': 'inspection.weather',
+};
+
+// ─── Public Functions ────────────────────────────────────────────────────────
+
+/**
+ * Extract all [Variable Name] placeholders from content.
+ * Returns a unique list of variable names (without brackets).
+ */
+export function extractVariables(content: string): string[] {
+  if (!content) return [];
+
+  const regex = /\[([^\]]+)\]/g;
+  const matches = new Set<string>();
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    matches.add(match[1]);
+  }
+
+  return Array.from(matches);
+}
+
+/**
+ * Substitute all [Variable Name] placeholders with actual values.
+ * Unknown variables are replaced with [MISSING: variableName].
+ * All substituted values are HTML-escaped.
+ */
+export function substituteVariables(
+  content: string,
+  context: VariableContext
+): SubstitutionResult {
+  const warnings: string[] = [];
+  const missingVariables: string[] = [];
+  let substitutionCount = 0;
+
+  const result = content.replace(/\[([^\]]+)\]/g, (_match, variableName: string) => {
+    const resolver = VARIABLE_MAP[variableName];
+
+    if (!resolver) {
+      warnings.push(`Unknown variable: ${variableName}`);
+      missingVariables.push(variableName);
+      return `[MISSING: ${variableName}]`;
+    }
+
+    const value = resolver(context);
+
+    if (!value) {
+      warnings.push(`Empty value for variable: ${variableName}`);
+      missingVariables.push(variableName);
+      return `[MISSING: ${variableName}]`;
+    }
+
+    substitutionCount++;
+    return escapeHtml(value);
+  });
+
+  return {
+    content: result,
+    warnings,
+    substitutionCount,
+    missingVariables,
+  };
+}
+
+/**
+ * Get list of all available variables with their paths and descriptions.
+ */
+export function getAvailableVariables(): VariableInfo[] {
+  return Object.keys(VARIABLE_MAP).map((name) => ({
+    name,
+    path: VARIABLE_PATHS[name],
+    description: VARIABLE_DESCRIPTIONS[name],
+  }));
+}
+
+/**
+ * Validate a list of variable names.
+ * Returns which are known (valid) and which are unknown.
+ */
+export function validateVariables(variableNames: string[]): ValidationResult {
+  const valid: string[] = [];
+  const unknown: string[] = [];
+
+  for (const name of variableNames) {
+    if (VARIABLE_MAP[name]) {
+      valid.push(name);
+    } else {
+      unknown.push(name);
+    }
+  }
+
+  return { valid, unknown };
+}


### PR DESCRIPTION
## Summary
Implements the variable substitution engine for DB-stored report templates.

### Changes
- **New:** `api/src/services/variable-substitution.ts` — core engine with allowlist-based `[Variable Name]` substitution, HTML escaping, missing variable detection
- **Modified:** `api/src/routes/report-templates.ts` — added `GET /api/templates/variables`, `POST /api/templates/:id/render`, `POST /api/templates/:id/preview` endpoints  
- **New:** `api/src/__tests__/variable-substitution.test.ts` — 22 tests covering extraction, substitution, validation, escaping, edge cases

### Security
- Allowlist-only variable resolution (no arbitrary code execution)
- HTML escaping of all substituted values
- Missing variables → `[MISSING: variableName]` placeholder
- Warnings for unknown variable names

### Tests
All 22 tests pass.

Closes #208