### PR TITLE
[Alex] fix(api): move job number to footer and add TOC anchor links (#222)

### DIFF
--- a/api/src/__tests__/pdf-renderer.test.ts
+++ b/api/src/__tests__/pdf-renderer.test.ts
@@ -105,14 +105,7 @@ describe('PdfRendererService', () => {
       );
     });
 
-    it('includes header with job number', async () => {
-      await service.renderPdf(defaultOptions);
-
-      const pdfCall = mockPagePdf.mock.calls[0][0];
-      expect(pdfCall?.headerTemplate).toContain('JOB-2026-001');
-    });
-
-    it('includes header with custom report title', async () => {
+    it('includes header with report title', async () => {
       await service.renderPdf({
         ...defaultOptions,
         reportTitle: 'Custom Report',
@@ -120,6 +113,13 @@ describe('PdfRendererService', () => {
 
       const pdfCall = mockPagePdf.mock.calls[0][0];
       expect(pdfCall?.headerTemplate).toContain('Custom Report');
+    });
+
+    it('includes footer with job number', async () => {
+      await service.renderPdf(defaultOptions);
+
+      const pdfCall = mockPagePdf.mock.calls[0][0];
+      expect(pdfCall?.footerTemplate).toContain('JOB-2026-001');
     });
 
     it('includes footer with page numbers', async () => {
@@ -306,6 +306,15 @@ describe('PdfRendererService', () => {
       expect(html).toContain('toc-entry');
       expect(html).toContain('toc-number');
       expect(html).toContain('toc-title');
+    });
+
+    it('generates clickable anchor links to sections', () => {
+      const sections = ['Executive Summary', 'Introduction'];
+      const html = service.generateTableOfContents(sections);
+
+      expect(html).toContain('href="#section-1"');
+      expect(html).toContain('href="#section-2"');
+      expect(html).toContain('toc-link');
     });
 
     it('escapes HTML in section titles', () => {

--- a/api/src/services/pdf-renderer.ts
+++ b/api/src/services/pdf-renderer.ts
@@ -82,14 +82,14 @@ export class PdfRendererService {
         },
         displayHeaderFooter: true,
         headerTemplate: `
-          <div style="font-size: 8px; width: 100%; padding: 0 20mm; display: flex; justify-content: space-between; color: #666;">
+          <div style="font-size: 8px; width: 100%; padding: 0 20mm; display: flex; justify-content: center; color: #666;">
             <span>${this.escapeHtml(reportTitle)}</span>
-            <span>${this.escapeHtml(jobNumber)}</span>
           </div>
         `,
         footerTemplate: `
           <div style="font-size: 8px; width: 100%; padding: 0 20mm; display: flex; justify-content: space-between; color: #666;">
             <span>Confidential</span>
+            <span>${this.escapeHtml(jobNumber)}</span>
             <span>Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
           </div>
         `,
@@ -164,7 +164,19 @@ export class PdfRendererService {
   }
 
   /**
-   * Generate table of contents HTML.
+   * Generate the anchor ID for a section.
+   * Matches the `id` attributes in the Handlebars section templates
+   * (e.g. `section-1`, `section-2`, …).
+   */
+  static sectionAnchorId(_title: string, index: number): string {
+    return `section-${index + 1}`;
+  }
+
+  /**
+   * Generate table of contents HTML with clickable anchor links.
+   *
+   * Each entry links to the corresponding `id="section-N"` anchor
+   * already present in the Handlebars section templates.
    */
   generateTableOfContents(sectionTitles: string[]): string {
     if (sectionTitles.length === 0) {
@@ -172,10 +184,10 @@ export class PdfRendererService {
     }
 
     const entries = sectionTitles
-      .map(
-        (title, index) =>
-          `<li class="toc-entry"><span class="toc-number">${index + 1}.</span> <span class="toc-title">${this.escapeHtml(title)}</span></li>`,
-      )
+      .map((title, index) => {
+        const anchorId = PdfRendererService.sectionAnchorId(title, index);
+        return `<li class="toc-entry"><a href="#${anchorId}" class="toc-link"><span class="toc-number">${index + 1}.</span> <span class="toc-title">${this.escapeHtml(title)}</span></a></li>`;
+      })
       .join('\n');
 
     return `

--- a/api/templates/coa/styles/report.css
+++ b/api/templates/coa/styles/report.css
@@ -274,6 +274,19 @@ th {
   flex: 1;
 }
 
+.toc-link {
+  display: flex;
+  align-items: baseline;
+  width: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.toc-link:hover {
+  color: #003366;
+  text-decoration: underline;
+}
+
 /* ─── Print: Cover & TOC Pages ─── */
 @media print {
   .cover-page {


### PR DESCRIPTION
## Summary
Fixes tested-fail issues reported by Casey on #222.

### Changes
1. **Job number → footer** — moved from header to footer per AC requirement. Footer now shows: Confidential | Job Number | Page X of Y
2. **TOC clickable cross-references** — TOC entries now generate `<a href="#section-N">` links matching the existing `id="section-N"` attributes on section elements
3. **TOC link CSS** — added `.toc-link` styling for hover states

### Tests
All 31 pdf-renderer tests pass (updated to verify new layout).

Fixes #222