### PR TITLE
[Alex] fix(ci): make Vercel wait optional in CD pipeline (#475)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,8 +128,20 @@ jobs:
     name: Wait for Vercel Auto-Deploy
     runs-on: ubuntu-latest
     needs: ci-check
+    continue-on-error: true
     steps:
+      - name: Check Vercel configuration
+        id: check-config
+        run: |
+          if [ -z "${{ secrets.VERCEL_TOKEN }}" ] || [ -z "${{ secrets.VERCEL_PROJECT_ID }}" ]; then
+            echo "⚠️ Vercel secrets not configured — skipping Vercel wait"
+            echo "configured=false" >> $GITHUB_OUTPUT
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Wait for Vercel (correct version)
+        if: steps.check-config.outputs.configured == 'true'
         env:
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -210,6 +222,7 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     needs: [wait-for-railway, wait-for-vercel]
+    if: always() && needs.wait-for-railway.result == 'success'
     defaults:
       run:
         working-directory: ./test


### PR DESCRIPTION
## Summary
Fixes CD pipeline failing when Vercel webhook/deployment is not configured or slow.

### Changes
- Added config check step: skips Vercel wait if `VERCEL_TOKEN` or `VERCEL_PROJECT_ID` secrets are missing
- Set `continue-on-error: true` on `wait-for-vercel` job so Vercel timeout doesn't block the pipeline
- E2E tests now run if Railway succeeds, regardless of Vercel status

### Root Cause
Vercel auto-deploy wasn't picking up the new commit within the 5-minute timeout window. The CD pipeline hard-failed because `wait-for-vercel` was a required dependency for E2E tests.

Fixes #475