### PR TITLE
[Alex] feat(api): implement report validation service (#195)

### DIFF
--- a/api/src/__tests__/report-validation.test.ts
+++ b/api/src/__tests__/report-validation.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Report Validation Tests — Issue #195
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReportValidationService, ReportNotFoundError } from '../services/report-validation.js';
+import type { PrismaClient } from '@prisma/client';
+
+// Mock factories
+function createMockReport(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'report-1',
+    status: 'APPROVED',
+    siteInspection: {
+      id: 'inspection-1',
+      inspectorName: 'John Smith',
+      clauseReviews: [
+        {
+          id: 'cr-1',
+          clauseId: 'B1',
+          applicability: 'APPLICABLE',
+          observations: 'All conditions met',
+        },
+      ],
+      project: {
+        id: 'project-1',
+        photos: [
+          {
+            id: 'photo-1',
+            reportNumber: 1,
+            caption: 'Front elevation',
+          },
+        ],
+        documents: [
+          {
+            id: 'doc-1',
+            description: 'PS1 Certificate',
+            status: 'RECEIVED',
+          },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createMockPrisma(): PrismaClient {
+  return {
+    report: {
+      findUnique: vi.fn(),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe('ReportValidationService', () => {
+  let service: ReportValidationService;
+  let prisma: PrismaClient;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ReportValidationService(prisma);
+  });
+
+  describe('validate', () => {
+    it('should return valid when all checks pass', async () => {
+      const report = createMockReport();
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should throw ReportNotFoundError when report does not exist', async () => {
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(null);
+
+      await expect(service.validate('nonexistent')).rejects.toThrow(ReportNotFoundError);
+    });
+
+    it('should return not_approved error for DRAFT report', async () => {
+      const report = createMockReport({ status: 'DRAFT' });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'not_approved',
+          field: 'status',
+        })
+      );
+    });
+
+    it('should return not_approved error for IN_REVIEW report', async () => {
+      const report = createMockReport({ status: 'IN_REVIEW' });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'not_approved',
+        })
+      );
+    });
+
+    it('should accept FINALIZED status', async () => {
+      const report = createMockReport({ status: 'FINALIZED' });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(true);
+      expect(result.errors.filter((e) => e.type === 'not_approved')).toHaveLength(0);
+    });
+
+    it('should return missing_observation for applicable clause without observations', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: null,
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_observation',
+          entityId: 'cr-1',
+        })
+      );
+    });
+
+    it('should return missing_observation for applicable clause with empty observations', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: '   ',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_observation',
+        })
+      );
+    });
+
+    it('should not check observations for NA clauses', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'NA',
+              observations: null,
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.errors.filter((e) => e.type === 'missing_observation')).toHaveLength(0);
+    });
+
+    it('should return missing_caption for photo without caption', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [
+              {
+                id: 'photo-1',
+                reportNumber: 1,
+                caption: null,
+              },
+            ],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_caption',
+          entityId: 'photo-1',
+        })
+      );
+    });
+
+    it('should return missing_caption for photo with empty caption', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [
+              {
+                id: 'photo-1',
+                reportNumber: 1,
+                caption: '',
+              },
+            ],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_caption',
+        })
+      );
+    });
+
+    it('should return missing_document for required document', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [
+              {
+                id: 'doc-1',
+                description: 'PS1 Certificate',
+                status: 'REQUIRED',
+              },
+            ],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_document',
+          entityId: 'doc-1',
+        })
+      );
+    });
+
+    it('should not flag RECEIVED documents', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [
+              {
+                id: 'doc-1',
+                description: 'PS1 Certificate',
+                status: 'RECEIVED',
+              },
+            ],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.errors.filter((e) => e.type === 'missing_document')).toHaveLength(0);
+    });
+
+    it('should return warning for no applicable clauses', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'NA',
+              observations: null,
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContain('No applicable clauses found in clause reviews');
+    });
+
+    it('should return warning for empty clause reviews', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: 'John Smith',
+          clauseReviews: [],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toContain('No applicable clauses found in clause reviews');
+    });
+
+    it('should return missing_inspector when inspector name is null', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: null,
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_inspector',
+        })
+      );
+    });
+
+    it('should return missing_inspector when inspector name is empty', async () => {
+      const report = createMockReport({
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: '  ',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: 'Complete',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [],
+            documents: [],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_inspector',
+          field: 'inspectorName',
+        })
+      );
+    });
+
+    it('should return multiple errors at once (no short-circuit)', async () => {
+      const report = createMockReport({
+        status: 'DRAFT',
+        siteInspection: {
+          id: 'inspection-1',
+          inspectorName: '',
+          clauseReviews: [
+            {
+              id: 'cr-1',
+              clauseId: 'B1',
+              applicability: 'APPLICABLE',
+              observations: null,
+            },
+            {
+              id: 'cr-2',
+              clauseId: 'B2',
+              applicability: 'APPLICABLE',
+              observations: '',
+            },
+          ],
+          project: {
+            id: 'project-1',
+            photos: [
+              {
+                id: 'photo-1',
+                reportNumber: 1,
+                caption: null,
+              },
+              {
+                id: 'photo-2',
+                reportNumber: 2,
+                caption: '',
+              },
+            ],
+            documents: [
+              {
+                id: 'doc-1',
+                description: 'PS1',
+                status: 'REQUIRED',
+              },
+              {
+                id: 'doc-2',
+                description: 'PS2',
+                status: 'REQUIRED',
+              },
+            ],
+          },
+        },
+      });
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      // Should have: 1 not_approved + 1 missing_inspector + 2 missing_observation + 2 missing_caption + 2 missing_document
+      expect(result.errors.length).toBeGreaterThanOrEqual(8);
+      expect(result.errors.filter((e) => e.type === 'not_approved')).toHaveLength(1);
+      expect(result.errors.filter((e) => e.type === 'missing_inspector')).toHaveLength(1);
+      expect(result.errors.filter((e) => e.type === 'missing_observation')).toHaveLength(2);
+      expect(result.errors.filter((e) => e.type === 'missing_caption')).toHaveLength(2);
+      expect(result.errors.filter((e) => e.type === 'missing_document')).toHaveLength(2);
+    });
+
+    it('should handle report with no site inspection', async () => {
+      const report = {
+        id: 'report-1',
+        status: 'APPROVED',
+        siteInspection: null,
+      };
+      vi.mocked(prisma.report.findUnique).mockResolvedValue(report as never);
+
+      const result = await service.validate('report-1');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'missing_inspector',
+          message: 'Report has no linked site inspection',
+        })
+      );
+    });
+  });
+});

--- a/api/src/openapi/generator.ts
+++ b/api/src/openapi/generator.ts
@@ -1,7 +1,8 @@
 import { OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
+import type { OpenAPIObject } from 'openapi3-ts/oas31';
 import { registry } from './registry.js';
 
-export function generateOpenAPISpec() {
+export function generateOpenAPISpec(): OpenAPIObject {
   const generator = new OpenApiGeneratorV31(registry.definitions);
 
   const spec = generator.generateDocument({

--- a/api/src/routes/report-management.ts
+++ b/api/src/routes/report-management.ts
@@ -10,10 +10,12 @@ import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { PrismaReportManagementRepository } from '../repositories/prisma/report.js';
 import { ReportManagementService, ReportNotFoundError, InvalidStatusTransitionError } from '../services/report-management.js';
+import { ReportValidationService, ReportNotFoundError as ValidationReportNotFoundError } from '../services/report-validation.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaReportManagementRepository(prisma);
 const service = new ReportManagementService(repository);
+const validationService = new ReportValidationService(prisma);
 
 export const reportManagementRouter: RouterType = Router();
 
@@ -64,6 +66,21 @@ reportManagementRouter.get('/', async (req: Request, res: Response, next: NextFu
     });
     res.json(reports);
   } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/reports/:id/validate - Validate report for generation readiness
+reportManagementRouter.get('/:id/validate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const result = await validationService.validate(id);
+    res.json(result);
+  } catch (error) {
+    if (error instanceof ValidationReportNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
     next(error);
   }
 });

--- a/api/src/services/report-validation.ts
+++ b/api/src/services/report-validation.ts
@@ -1,0 +1,145 @@
+/**
+ * Report Validation Service — Issue #195
+ *
+ * Validates report data completeness before PDF generation.
+ * Checks all validation rules and returns all errors at once (no short-circuit).
+ */
+
+import type { PrismaClient } from '@prisma/client';
+
+export interface ValidationError {
+  type:
+    | 'missing_observation'
+    | 'missing_caption'
+    | 'missing_document'
+    | 'not_approved'
+    | 'no_applicable_clauses'
+    | 'missing_inspector';
+  field?: string;
+  entityId?: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: string[];
+}
+
+export class ReportNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Report not found: ${id}`);
+    this.name = 'ReportNotFoundError';
+  }
+}
+
+export class ReportValidationService {
+  constructor(private prisma: PrismaClient) {}
+
+  async validate(reportId: string): Promise<ValidationResult> {
+    const errors: ValidationError[] = [];
+    const warnings: string[] = [];
+
+    // Fetch report with related data
+    const report = await this.prisma.report.findUnique({
+      where: { id: reportId },
+      include: {
+        siteInspection: {
+          include: {
+            project: {
+              include: {
+                photos: true,
+                documents: true,
+              },
+            },
+            clauseReviews: true,
+          },
+        },
+      },
+    });
+
+    if (!report) {
+      throw new ReportNotFoundError(reportId);
+    }
+
+    // Rule 1: Report status must be APPROVED or FINALIZED
+    if (report.status !== 'APPROVED' && report.status !== 'FINALIZED') {
+      errors.push({
+        type: 'not_approved',
+        field: 'status',
+        message: `Report must be APPROVED or FINALIZED for generation, current status: ${report.status}`,
+      });
+    }
+
+    const siteInspection = report.siteInspection;
+    if (!siteInspection) {
+      // If no site inspection linked, we can't validate further
+      errors.push({
+        type: 'missing_inspector',
+        message: 'Report has no linked site inspection',
+      });
+      return { valid: false, errors, warnings };
+    }
+
+    // Rule 6: SiteInspection must have an inspector
+    if (!siteInspection.inspectorName || siteInspection.inspectorName.trim() === '') {
+      errors.push({
+        type: 'missing_inspector',
+        field: 'inspectorName',
+        message: 'Site inspection must have an inspector name',
+      });
+    }
+
+    // Rule 2: All applicable clause reviews must have observations
+    const applicableClauseReviews = siteInspection.clauseReviews.filter(
+      (cr) => cr.applicability === 'APPLICABLE'
+    );
+
+    for (const clauseReview of applicableClauseReviews) {
+      if (!clauseReview.observations || clauseReview.observations.trim() === '') {
+        errors.push({
+          type: 'missing_observation',
+          field: 'observations',
+          entityId: clauseReview.id,
+          message: `Clause review ${clauseReview.clauseId} is missing observations`,
+        });
+      }
+    }
+
+    // Rule 5: At least one applicable clause (warning, not blocking)
+    if (applicableClauseReviews.length === 0) {
+      warnings.push('No applicable clauses found in clause reviews');
+    }
+
+    const project = siteInspection.project;
+
+    // Rule 3: All project photos must have captions
+    for (const photo of project.photos) {
+      if (!photo.caption || photo.caption.trim() === '') {
+        errors.push({
+          type: 'missing_caption',
+          field: 'caption',
+          entityId: photo.id,
+          message: `Photo ${photo.reportNumber} is missing a caption`,
+        });
+      }
+    }
+
+    // Rule 4: All required documents must be received
+    const requiredDocuments = project.documents.filter((doc) => doc.status === 'REQUIRED');
+    for (const doc of requiredDocuments) {
+      errors.push({
+        type: 'missing_document',
+        field: 'status',
+        entityId: doc.id,
+        message: `Required document "${doc.description}" has not been received`,
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Validates report data completeness before PDF generation.

### Changes
- **New:** `api/src/services/report-validation.ts` — validates status, clause observations, photo captions, required documents, inspector name
- **Modified:** `api/src/routes/report-management.ts` — added `GET /api/reports/:id/validate` endpoint
- **New:** `api/src/__tests__/report-validation.test.ts` — 18 tests
- **Fixed:** pre-existing TS error in `openapi/generator.ts`

### Validation Rules
1. Report must be APPROVED or FINALIZED (blocking)
2. All applicable clauses must have observations (blocking)
3. All photos must have captions (blocking)
4. All required documents must be received (blocking)
5. At least one applicable clause (warning only)
6. Inspector name required (blocking)

Returns all errors at once — no short-circuit.

Closes #195