### PR TITLE
[Alex] feat(api): implement credential string formatting (#201)

### DIFF
--- a/api/src/__tests__/credential-formatter.test.ts
+++ b/api/src/__tests__/credential-formatter.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Credential Formatter Tests — Issue #201
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatCredentials, sortByPriority, type CredentialInput } from '../services/credential-formatter.js';
+
+describe('credential-formatter', () => {
+  describe('sortByPriority', () => {
+    it('sorts NZIBS before ENG_NZ before LBP before ACADEMIC before OTHER', () => {
+      const creds: CredentialInput[] = [
+        { credentialType: 'OTHER', registrationTitle: null, membershipCode: null, qualifications: [] },
+        { credentialType: 'NZIBS', registrationTitle: null, membershipCode: null, qualifications: [] },
+        { credentialType: 'ACADEMIC', registrationTitle: null, membershipCode: null, qualifications: [] },
+        { credentialType: 'LBP', registrationTitle: null, membershipCode: null, qualifications: [] },
+        { credentialType: 'ENG_NZ', registrationTitle: null, membershipCode: null, qualifications: [] },
+      ];
+
+      const sorted = sortByPriority(creds);
+      expect(sorted.map(c => c.credentialType)).toEqual([
+        'NZIBS', 'ENG_NZ', 'LBP', 'ACADEMIC', 'OTHER',
+      ]);
+    });
+
+    it('does not mutate the original array', () => {
+      const creds: CredentialInput[] = [
+        { credentialType: 'OTHER', registrationTitle: null, membershipCode: null, qualifications: [] },
+        { credentialType: 'NZIBS', registrationTitle: null, membershipCode: null, qualifications: [] },
+      ];
+
+      sortByPriority(creds);
+      expect(creds[0].credentialType).toBe('OTHER');
+    });
+  });
+
+  describe('formatCredentials', () => {
+    it('formats Ian Fong example correctly', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'NZIBS',
+          registrationTitle: 'Registered Building Surveyor',
+          membershipCode: 'MNZIBS',
+          qualifications: ['Dip. Building Surveying'],
+        },
+        {
+          credentialType: 'ACADEMIC',
+          registrationTitle: null,
+          membershipCode: null,
+          qualifications: ['BE (Hons)', 'MBA'],
+        },
+      ];
+
+      expect(formatCredentials(creds)).toBe(
+        'Registered Building Surveyor, MNZIBS, Dip. Building Surveying, BE (Hons), MBA',
+      );
+    });
+
+    it('formats Jake Li example correctly', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'NZIBS',
+          registrationTitle: 'Building Surveyor',
+          membershipCode: null,
+          qualifications: [],
+        },
+        {
+          credentialType: 'ACADEMIC',
+          registrationTitle: null,
+          membershipCode: null,
+          qualifications: ['MCon. Mgt.', 'M.Engin. (Safety)', 'BSc. (Materials)'],
+        },
+      ];
+
+      expect(formatCredentials(creds)).toBe(
+        'Building Surveyor, MCon. Mgt., M.Engin. (Safety), BSc. (Materials)',
+      );
+    });
+
+    it('returns empty string for empty array', () => {
+      expect(formatCredentials([])).toBe('');
+    });
+
+    it('returns empty string for null/undefined-like input', () => {
+      expect(formatCredentials(null as unknown as CredentialInput[])).toBe('');
+      expect(formatCredentials(undefined as unknown as CredentialInput[])).toBe('');
+    });
+
+    it('returns empty string when all fields are empty', () => {
+      const creds: CredentialInput[] = [
+        { credentialType: 'NZIBS', registrationTitle: null, membershipCode: null, qualifications: [] },
+      ];
+
+      expect(formatCredentials(creds)).toBe('');
+    });
+
+    it('orders registration titles before membership codes before qualifications', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'NZIBS',
+          registrationTitle: 'Registered Building Surveyor',
+          membershipCode: 'MNZIBS',
+          qualifications: ['BE (Hons)'],
+        },
+      ];
+
+      const result = formatCredentials(creds);
+      const parts = result.split(', ');
+      expect(parts[0]).toBe('Registered Building Surveyor');
+      expect(parts[1]).toBe('MNZIBS');
+      expect(parts[2]).toBe('BE (Hons)');
+    });
+
+    it('handles credentials with only qualifications', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'ACADEMIC',
+          registrationTitle: null,
+          membershipCode: null,
+          qualifications: ['PhD', 'MSc'],
+        },
+      ];
+
+      expect(formatCredentials(creds)).toBe('PhD, MSc');
+    });
+
+    it('handles credentials with only membership code', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'ENG_NZ',
+          registrationTitle: null,
+          membershipCode: 'MEngNZ',
+          qualifications: [],
+        },
+      ];
+
+      expect(formatCredentials(creds)).toBe('MEngNZ');
+    });
+
+    it('sorts mixed credential types by priority', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'ACADEMIC',
+          registrationTitle: null,
+          membershipCode: null,
+          qualifications: ['MBA'],
+        },
+        {
+          credentialType: 'NZIBS',
+          registrationTitle: 'Registered Building Surveyor',
+          membershipCode: 'MNZIBS',
+          qualifications: [],
+        },
+      ];
+
+      const result = formatCredentials(creds);
+      // Registration title from NZIBS should come first
+      expect(result).toBe('Registered Building Surveyor, MNZIBS, MBA');
+    });
+
+    it('skips empty qualification strings', () => {
+      const creds: CredentialInput[] = [
+        {
+          credentialType: 'ACADEMIC',
+          registrationTitle: null,
+          membershipCode: null,
+          qualifications: ['BE', '', 'MBA'],
+        },
+      ];
+
+      expect(formatCredentials(creds)).toBe('BE, MBA');
+    });
+  });
+});

--- a/api/src/routes/personnel.ts
+++ b/api/src/routes/personnel.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPersonnelRepository } from '../repositories/prisma/personnel.js';
 import { PersonnelService, PersonnelNotFoundError, PersonnelEmailConflictError } from '../services/personnel.js';
+import { formatCredentials } from '../services/credential-formatter.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaPersonnelRepository(prisma);
@@ -127,6 +128,31 @@ personnelRouter.delete('/:id', async (req: Request, res: Response, next: NextFun
       res.status(404).json({ error: error.message });
       return;
     }
+    next(error);
+  }
+});
+
+// GET /api/personnel/:id/credentials-string - Formatted credential string (#201)
+personnelRouter.get('/:id/credentials-string', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const personnel = await prisma.personnel.findUnique({
+      where: { id: req.params.id as string },
+      include: { credentials: true },
+    });
+
+    if (!personnel) {
+      res.status(404).json({ error: `Personnel not found: ${req.params.id}` });
+      return;
+    }
+
+    const credentialsString = formatCredentials(personnel.credentials);
+
+    res.json({
+      personnelId: personnel.id,
+      name: personnel.name,
+      credentialsString,
+    });
+  } catch (error) {
     next(error);
   }
 });

--- a/api/src/services/credential-formatter.ts
+++ b/api/src/services/credential-formatter.ts
@@ -1,0 +1,92 @@
+/**
+ * Credential String Formatter — Issue #201
+ *
+ * Formats personnel credentials into a single display string.
+ * Order: Registration title, Memberships, Qualifications
+ * Priority: NZIBS > ENG_NZ > LBP > ACADEMIC > OTHER
+ */
+
+import type { CredentialType } from '@prisma/client';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface CredentialInput {
+  credentialType: CredentialType;
+  registrationTitle: string | null;
+  membershipCode: string | null;
+  qualifications: string[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Priority ordering
+// ──────────────────────────────────────────────────────────────────────────────
+
+const CREDENTIAL_PRIORITY: Record<CredentialType, number> = {
+  NZIBS: 0,
+  ENG_NZ: 1,
+  LBP: 2,
+  ACADEMIC: 3,
+  OTHER: 4,
+};
+
+/**
+ * Sort credentials by priority (NZIBS first, OTHER last).
+ */
+export function sortByPriority(credentials: CredentialInput[]): CredentialInput[] {
+  return [...credentials].sort(
+    (a, b) => CREDENTIAL_PRIORITY[a.credentialType] - CREDENTIAL_PRIORITY[b.credentialType],
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Formatter
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Format a list of credentials into a display string.
+ *
+ * Output order:
+ * 1. Registration titles (sorted by priority)
+ * 2. Membership codes (sorted by priority)
+ * 3. Qualifications (sorted by priority, flattened)
+ *
+ * Example: "Registered Building Surveyor, MNZIBS, BE (Hons), MBA"
+ *
+ * Returns empty string if no credentials or all fields are empty.
+ */
+export function formatCredentials(credentials: CredentialInput[]): string {
+  if (!credentials || credentials.length === 0) {
+    return '';
+  }
+
+  const sorted = sortByPriority(credentials);
+
+  const parts: string[] = [];
+
+  // 1. Registration titles
+  for (const cred of sorted) {
+    if (cred.registrationTitle) {
+      parts.push(cred.registrationTitle);
+    }
+  }
+
+  // 2. Membership codes
+  for (const cred of sorted) {
+    if (cred.membershipCode) {
+      parts.push(cred.membershipCode);
+    }
+  }
+
+  // 3. Qualifications
+  for (const cred of sorted) {
+    for (const qual of cred.qualifications) {
+      if (qual) {
+        parts.push(qual);
+      }
+    }
+  }
+
+  return parts.join(', ');
+}


### PR DESCRIPTION
## Summary
Implements credential string formatting for personnel report signature blocks.

### Changes
- **New:** `api/src/services/credential-formatter.ts` — `formatCredentials()` utility with priority-based sorting
- **Modified:** `api/src/routes/personnel.ts` — added `GET /api/personnel/:id/credentials-string` endpoint
- **New:** `api/src/__tests__/credential-formatter.test.ts` — 12 tests

### Output Format
Registration titles → Membership codes → Qualifications, sorted by type priority (NZIBS > ENG_NZ > LBP > ACADEMIC > OTHER).

**Examples from AC:**
- Ian Fong: `Registered Building Surveyor, MNZIBS, Dip. Building Surveying, BE (Hons), MBA`
- Jake Li: `Building Surveyor, MCon. Mgt., M.Engin. (Safety), BSc. (Materials)`
- No credentials: empty string

### Tests
All 12 tests pass.

Closes #201