### PR TITLE
[Alex] feat(api): implement signature block generation (#203)

### DIFF
--- a/api/src/__tests__/signature-block.test.ts
+++ b/api/src/__tests__/signature-block.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Signature Block Generator Tests — Issue #203
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateSignatureBlock, type GenerateSignatureBlockInput } from '../services/signature-block.js';
+
+describe('signature-block', () => {
+  const baseAuthor: GenerateSignatureBlockInput['author'] = {
+    id: 'auth-1',
+    name: 'Ian Fong',
+    credentials: [
+      {
+        credentialType: 'NZIBS',
+        registrationTitle: 'Registered Building Surveyor',
+        membershipCode: 'MNZIBS',
+        qualifications: ['Dip. Building Surveying'],
+      },
+      {
+        credentialType: 'ACADEMIC',
+        registrationTitle: null,
+        membershipCode: null,
+        qualifications: ['BE (Hons)', 'MBA'],
+      },
+    ],
+  };
+
+  const baseReviewer: GenerateSignatureBlockInput['author'] = {
+    id: 'rev-1',
+    name: 'Jake Li',
+    credentials: [
+      {
+        credentialType: 'NZIBS',
+        registrationTitle: 'Building Surveyor',
+        membershipCode: null,
+        qualifications: [],
+      },
+      {
+        credentialType: 'ACADEMIC',
+        registrationTitle: null,
+        membershipCode: null,
+        qualifications: ['MCon. Mgt.'],
+      },
+    ],
+  };
+
+  it('generates author block with name, credentials, and company', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      companyName: 'Apex Inspection Services',
+    });
+
+    expect(result.author.name).toBe('Ian Fong');
+    expect(result.author.credentials).toBe(
+      'Registered Building Surveyor, MNZIBS, Dip. Building Surveying, BE (Hons), MBA',
+    );
+    expect(result.author.company).toBe('Apex Inspection Services');
+    expect(result.author.signatureLine).toBe('_________________________');
+  });
+
+  it('generates reviewer block when provided', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      reviewer: baseReviewer,
+      companyName: 'Apex Inspection Services',
+    });
+
+    expect(result.reviewer).not.toBeNull();
+    expect(result.reviewer!.name).toBe('Jake Li');
+    expect(result.reviewer!.credentials).toBe('Building Surveyor, MCon. Mgt.');
+    expect(result.reviewer!.company).toBe('Apex Inspection Services');
+  });
+
+  it('sets reviewer to null when not provided', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      companyName: 'Apex Inspection Services',
+    });
+
+    expect(result.reviewer).toBeNull();
+  });
+
+  it('sets reviewer to null when explicitly null', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      reviewer: null,
+      companyName: 'Apex Inspection Services',
+    });
+
+    expect(result.reviewer).toBeNull();
+  });
+
+  it('handles author with no credentials', () => {
+    const result = generateSignatureBlock({
+      author: { id: 'a', name: 'John Doe', credentials: [] },
+      companyName: 'Test Co',
+    });
+
+    expect(result.author.name).toBe('John Doe');
+    expect(result.author.credentials).toBe('');
+    expect(result.author.company).toBe('Test Co');
+  });
+
+  it('handles empty company name', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      companyName: '',
+    });
+
+    expect(result.author.company).toBe('');
+  });
+
+  it('includes signature line on both author and reviewer', () => {
+    const result = generateSignatureBlock({
+      author: baseAuthor,
+      reviewer: baseReviewer,
+      companyName: 'Test',
+    });
+
+    expect(result.author.signatureLine).toBeTruthy();
+    expect(result.reviewer!.signatureLine).toBeTruthy();
+  });
+});

--- a/api/src/routes/report-management.ts
+++ b/api/src/routes/report-management.ts
@@ -11,6 +11,7 @@ import { PrismaClient } from '@prisma/client';
 import { PrismaReportManagementRepository } from '../repositories/prisma/report.js';
 import { ReportManagementService, ReportNotFoundError, InvalidStatusTransitionError } from '../services/report-management.js';
 import { ReportValidationService, ReportNotFoundError as ValidationReportNotFoundError } from '../services/report-validation.js';
+import { generateSignatureBlock } from '../services/signature-block.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaReportManagementRepository(prisma);
@@ -184,6 +185,69 @@ reportManagementRouter.post('/:id/approve', async (req: Request, res: Response, 
       res.status(400).json({ error: error.message });
       return;
     }
+    next(error);
+  }
+});
+
+// GET /api/reports/:id/signature-block - Generate signature block (#203)
+reportManagementRouter.get('/:id/signature-block', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+
+    const report = await prisma.report.findUnique({
+      where: { id },
+    });
+    if (!report) {
+      res.status(404).json({ error: `Report not found: ${id}` });
+      return;
+    }
+
+    // Fetch author with credentials
+    if (!report.preparedById) {
+      res.status(400).json({ error: 'Report has no author (preparedById)' });
+      return;
+    }
+
+    const author = await prisma.personnel.findUnique({
+      where: { id: report.preparedById },
+      include: { credentials: true },
+    });
+    if (!author) {
+      res.status(404).json({ error: `Author personnel not found: ${report.preparedById}` });
+      return;
+    }
+
+    // Fetch reviewer with credentials (optional)
+    let reviewer = null;
+    if (report.reviewedById) {
+      reviewer = await prisma.personnel.findUnique({
+        where: { id: report.reviewedById },
+        include: { credentials: true },
+      });
+    }
+
+    // Get company name (first company record or fallback)
+    const company = await prisma.company.findFirst();
+    const companyName = company?.name ?? '';
+
+    const signatureBlock = generateSignatureBlock({
+      author: {
+        id: author.id,
+        name: author.name,
+        credentials: author.credentials,
+      },
+      reviewer: reviewer
+        ? {
+            id: reviewer.id,
+            name: reviewer.name,
+            credentials: reviewer.credentials,
+          }
+        : null,
+      companyName,
+    });
+
+    res.json(signatureBlock);
+  } catch (error) {
     next(error);
   }
 });

--- a/api/src/services/signature-block.ts
+++ b/api/src/services/signature-block.ts
@@ -1,0 +1,73 @@
+/**
+ * Signature Block Generator — Issue #203
+ *
+ * Generates signature block data for report Section 7 (Declaration & Signatures).
+ * Uses formatCredentials() from #201 for credential strings.
+ */
+
+import type { CredentialInput } from './credential-formatter.js';
+import { formatCredentials } from './credential-formatter.js';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface PersonnelWithCredentials {
+  id: string;
+  name: string;
+  credentials: CredentialInput[];
+}
+
+export interface SignatureEntry {
+  name: string;
+  credentials: string;
+  company: string;
+  signatureLine: string;
+}
+
+export interface SignatureBlock {
+  author: SignatureEntry;
+  reviewer: SignatureEntry | null;
+}
+
+export interface GenerateSignatureBlockInput {
+  author: PersonnelWithCredentials;
+  reviewer?: PersonnelWithCredentials | null;
+  companyName: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Generator
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a single signature entry from personnel data.
+ */
+function buildEntry(
+  personnel: PersonnelWithCredentials,
+  companyName: string,
+): SignatureEntry {
+  return {
+    name: personnel.name,
+    credentials: formatCredentials(personnel.credentials),
+    company: companyName,
+    signatureLine: '_________________________',
+  };
+}
+
+/**
+ * Generate a signature block for a report.
+ *
+ * Always includes the author. Reviewer is optional.
+ * Credential strings are formatted per #201 priority ordering.
+ */
+export function generateSignatureBlock(
+  input: GenerateSignatureBlockInput,
+): SignatureBlock {
+  return {
+    author: buildEntry(input.author, input.companyName),
+    reviewer: input.reviewer
+      ? buildEntry(input.reviewer, input.companyName)
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary
Generates signature block data for report Section 7 (Declaration & Signatures).

### Changes
- **New:** `api/src/services/signature-block.ts` — `generateSignatureBlock()` using `formatCredentials()` from #201
- **Modified:** `api/src/routes/report-management.ts` — added `GET /api/reports/:id/signature-block`
- **New:** `api/src/__tests__/signature-block.test.ts` — 7 tests

### Output
```json
{
  "author": { "name": "Ian Fong", "credentials": "Registered Building Surveyor, MNZIBS, ...", "company": "Apex", "signatureLine": "_________________________" },
  "reviewer": { ... } | null
}
```

### Tests
All 7 tests pass.

Closes #203