### PR TITLE
[Alex] feat(api): implement image compression for reports (#224)

### DIFF
--- a/api/src/__tests__/image-compressor.test.ts
+++ b/api/src/__tests__/image-compressor.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Image Compressor Tests — Issue #224
+ */
+
+import { describe, it, expect } from 'vitest';
+import sharp from 'sharp';
+import {
+  compressImage,
+  compressImageFromFile,
+  compressImageBatch,
+  generatePlaceholder,
+} from '../services/image-compressor.js';
+
+// Helper: create a test image buffer
+async function createTestImage(
+  width: number,
+  height: number,
+  format: 'jpeg' | 'png' = 'jpeg',
+): Promise<Buffer> {
+  const base = sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
+  });
+  return format === 'png' ? base.png().toBuffer() : base.jpeg({ quality: 100 }).toBuffer();
+}
+
+describe('image-compressor', () => {
+  describe('compressImage', () => {
+    it('resizes images exceeding max dimensions', async () => {
+      const input = await createTestImage(2400, 1800);
+      const result = await compressImage(input);
+
+      expect(result.width).toBeLessThanOrEqual(1200);
+      expect(result.height).toBeLessThanOrEqual(900);
+      expect(result.format).toBe('jpeg');
+      expect(result.isPlaceholder).toBe(false);
+    });
+
+    it('does not enlarge small images', async () => {
+      const input = await createTestImage(400, 300);
+      const result = await compressImage(input);
+
+      expect(result.width).toBeLessThanOrEqual(400);
+      expect(result.height).toBeLessThanOrEqual(300);
+    });
+
+    it('maintains aspect ratio', async () => {
+      const input = await createTestImage(2400, 1200); // 2:1 ratio
+      const result = await compressImage(input);
+
+      const ratio = result.width / result.height;
+      expect(ratio).toBeCloseTo(2, 0);
+    });
+
+    it('outputs progressive JPEG', async () => {
+      const input = await createTestImage(800, 600);
+      const result = await compressImage(input);
+      const metadata = await sharp(result.buffer).metadata();
+
+      expect(metadata.format).toBe('jpeg');
+      expect(metadata.isProgressive).toBe(true);
+    });
+
+    it('handles PNG input', async () => {
+      const input = await createTestImage(800, 600, 'png');
+      const result = await compressImage(input);
+
+      expect(result.format).toBe('jpeg');
+      expect(result.width).toBeLessThanOrEqual(800);
+    });
+
+    it('respects custom max dimensions', async () => {
+      const input = await createTestImage(2000, 2000);
+      const result = await compressImage(input, { maxWidth: 600, maxHeight: 600 });
+
+      expect(result.width).toBeLessThanOrEqual(600);
+      expect(result.height).toBeLessThanOrEqual(600);
+    });
+
+    it('output size is reported correctly', async () => {
+      const input = await createTestImage(800, 600);
+      const result = await compressImage(input);
+
+      expect(result.size).toBe(result.buffer.length);
+      expect(result.size).toBeGreaterThan(0);
+    });
+  });
+
+  describe('generatePlaceholder', () => {
+    it('generates a valid JPEG image', async () => {
+      const buffer = await generatePlaceholder();
+      const metadata = await sharp(buffer).metadata();
+
+      expect(metadata.format).toBe('jpeg');
+      expect(metadata.width).toBe(400);
+      expect(metadata.height).toBe(300);
+    });
+
+    it('accepts custom dimensions', async () => {
+      const buffer = await generatePlaceholder(800, 600);
+      const metadata = await sharp(buffer).metadata();
+
+      expect(metadata.width).toBe(800);
+      expect(metadata.height).toBe(600);
+    });
+  });
+
+  describe('compressImageFromFile', () => {
+    it('returns placeholder for missing file', async () => {
+      const { result, warning } = await compressImageFromFile('/nonexistent/image.jpg');
+
+      expect(result.isPlaceholder).toBe(true);
+      expect(result.format).toBe('jpeg');
+      expect(warning).toContain('Missing image');
+      expect(warning).toContain('/nonexistent/image.jpg');
+    });
+  });
+
+  describe('compressImageBatch', () => {
+    it('handles batch of missing files with warnings', async () => {
+      const paths = ['/missing/a.jpg', '/missing/b.jpg'];
+      const { results, warnings } = await compressImageBatch(paths);
+
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.isPlaceholder)).toBe(true);
+      expect(warnings).toHaveLength(2);
+    });
+
+    it('returns empty results for empty input', async () => {
+      const { results, warnings } = await compressImageBatch([]);
+
+      expect(results).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/api/src/services/image-compressor.ts
+++ b/api/src/services/image-compressor.ts
@@ -1,0 +1,184 @@
+/**
+ * Image Compressor Service — Issue #224
+ *
+ * Resizes and compresses images for report generation.
+ * - Max dimensions: 1200x900
+ * - Max file size: 1MB
+ * - Output: progressive JPEG at 80% quality
+ * - Handles missing images with a placeholder
+ */
+
+import sharp from 'sharp';
+import { readFile, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface CompressOptions {
+  maxWidth?: number;
+  maxHeight?: number;
+  quality?: number;
+  maxSizeBytes?: number;
+}
+
+export interface CompressResult {
+  buffer: Buffer;
+  width: number;
+  height: number;
+  size: number;
+  format: string;
+  isPlaceholder: boolean;
+}
+
+export interface BatchResult {
+  results: CompressResult[];
+  warnings: string[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ──────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_WIDTH = 1200;
+const DEFAULT_MAX_HEIGHT = 900;
+const DEFAULT_QUALITY = 80;
+const DEFAULT_MAX_SIZE_BYTES = 1_048_576; // 1MB
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Placeholder
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Generate a simple grey placeholder image with "Image Not Available" text.
+ */
+export async function generatePlaceholder(
+  width: number = 400,
+  height: number = 300,
+): Promise<Buffer> {
+  // Create a grey image with SVG text overlay
+  const svg = `
+    <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="100%" height="100%" fill="#E0E0E0"/>
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+            font-family="Arial, sans-serif" font-size="18" fill="#888888">
+        Image Not Available
+      </text>
+    </svg>`;
+
+  return sharp(Buffer.from(svg))
+    .jpeg({ quality: 80, progressive: true })
+    .toBuffer();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Core compression
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compress an image buffer to progressive JPEG within size and dimension constraints.
+ *
+ * If the output exceeds maxSizeBytes after initial compression, quality is
+ * iteratively reduced (down to 40%) until the constraint is met.
+ */
+export async function compressImage(
+  input: Buffer,
+  options: CompressOptions = {},
+): Promise<CompressResult> {
+  const maxWidth = options.maxWidth ?? DEFAULT_MAX_WIDTH;
+  const maxHeight = options.maxHeight ?? DEFAULT_MAX_HEIGHT;
+  let quality = options.quality ?? DEFAULT_QUALITY;
+  const maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
+
+  let pipeline = sharp(input)
+    .resize(maxWidth, maxHeight, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality, progressive: true });
+
+  let buffer = await pipeline.toBuffer();
+
+  // Iteratively reduce quality if over size limit
+  while (buffer.length > maxSizeBytes && quality > 40) {
+    quality -= 10;
+    pipeline = sharp(input)
+      .resize(maxWidth, maxHeight, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality, progressive: true });
+    buffer = await pipeline.toBuffer();
+  }
+
+  const metadata = await sharp(buffer).metadata();
+
+  return {
+    buffer,
+    width: metadata.width ?? 0,
+    height: metadata.height ?? 0,
+    size: buffer.length,
+    format: 'jpeg',
+    isPlaceholder: false,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// File-based compression
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compress an image from a file path. Returns a placeholder if the file is missing.
+ */
+export async function compressImageFromFile(
+  filePath: string,
+  options: CompressOptions = {},
+): Promise<{ result: CompressResult; warning?: string }> {
+  try {
+    await access(filePath, constants.R_OK);
+    const input = await readFile(filePath);
+    const result = await compressImage(input, options);
+    return { result };
+  } catch {
+    const placeholder = await generatePlaceholder();
+    const metadata = await sharp(placeholder).metadata();
+    return {
+      result: {
+        buffer: placeholder,
+        width: metadata.width ?? 400,
+        height: metadata.height ?? 300,
+        size: placeholder.length,
+        format: 'jpeg',
+        isPlaceholder: true,
+      },
+      warning: `Missing image: ${filePath} — replaced with placeholder`,
+    };
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Batch processing
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Process multiple images in sequence.
+ * Missing images produce warnings and placeholders instead of errors.
+ */
+export async function compressImageBatch(
+  filePaths: string[],
+  options: CompressOptions = {},
+): Promise<BatchResult> {
+  const results: CompressResult[] = [];
+  const warnings: string[] = [];
+
+  for (const filePath of filePaths) {
+    const { result, warning } = await compressImageFromFile(filePath, options);
+    results.push(result);
+    if (warning) {
+      warnings.push(warning);
+    }
+  }
+
+  return { results, warnings };
+}


### PR DESCRIPTION
## Summary
Image compression pipeline for report generation using Sharp.

### Changes
- **New:** `api/src/services/image-compressor.ts`
  - `compressImage()` — resize to 1200x900 max, progressive JPEG at 80% quality
  - Iterative quality reduction (down to 40%) if output exceeds 1MB
  - `generatePlaceholder()` — grey placeholder with 'Image Not Available' text
  - `compressImageFromFile()` — file-based with automatic placeholder on missing
  - `compressImageBatch()` — batch processing with warnings collection
- **New:** `api/src/__tests__/image-compressor.test.ts` — 12 tests

### Behaviour
- JPEG and PNG input supported, always outputs progressive JPEG
- Small images not enlarged (`withoutEnlargement: true`)
- Aspect ratio preserved
- Missing images → placeholder + warning (never throws)

### Tests
All 12 tests pass.

Closes #224