### PR TITLE
[Alex] feat(api): implement Form 9 data export (#196)

### DIFF
--- a/api/src/__tests__/form9-export.test.ts
+++ b/api/src/__tests__/form9-export.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Form 9 Export Tests — Issue #196
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Form9ExportService, ReportNotFoundError, InspectionNotLinkedError } from '../services/form9-export.js';
+
+// Mock data factory
+function createMockReport(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'report-1',
+    siteInspection: {
+      id: 'insp-1',
+      date: new Date('2026-02-20'),
+      inspectorName: 'John Smith',
+      weather: 'Fine, 22°C',
+      methodology: 'Visual inspection with moisture testing',
+      areasNotAccessed: 'Subfloor (no access hatch)',
+      outcome: 'PASS',
+      project: {
+        jobNumber: 'INS-2026-001',
+        activity: 'COA Assessment',
+        reportType: 'COA',
+        property: {
+          streetAddress: '123 Main St, Auckland',
+          lotDp: 'Lot 1 DP 12345',
+          councilPropertyId: 'AKL-99999',
+          territorialAuthority: 'AKL',
+        },
+        client: {
+          name: 'Test Client Ltd',
+          address: '456 Client Ave, Auckland',
+          phone: '09-123-4567',
+          email: 'client@test.com',
+          contactPerson: 'Jane Doe',
+        },
+        documents: [
+          {
+            documentType: 'PS1',
+            filename: 'ps1-plumbing.pdf',
+            description: 'Producer Statement - Plumbing',
+            status: 'RECEIVED',
+            referenceNumber: 'PS1-001',
+          },
+          {
+            documentType: 'COC',
+            filename: 'coc-electrical.pdf',
+            description: 'Certificate of Compliance - Electrical',
+            status: 'RECEIVED',
+            referenceNumber: 'COC-001',
+          },
+        ],
+      },
+      clauseReviews: [
+        {
+          applicability: 'APPLICABLE',
+          observations: 'Compliant with B1 requirements',
+          clause: { code: 'B1', title: 'Structure' },
+        },
+        {
+          applicability: 'APPLICABLE',
+          observations: 'Fire safety measures in place',
+          clause: { code: 'C1', title: 'Outbreak of Fire' },
+        },
+        {
+          applicability: 'NA',
+          observations: null,
+          clause: { code: 'G12', title: 'Water Supplies' },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function createMockPrisma(report: unknown) {
+  return {
+    report: {
+      findUnique: vi.fn().mockResolvedValue(report),
+      update: vi.fn().mockResolvedValue(report),
+    },
+  } as unknown as Parameters<typeof Form9ExportService.prototype['extract']> extends never[]
+    ? never
+    : ConstructorParameters<typeof Form9ExportService>[0];
+}
+
+describe('Form9ExportService', () => {
+  let service: Form9ExportService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    const report = createMockReport();
+    mockPrisma = createMockPrisma(report);
+    service = new Form9ExportService(mockPrisma);
+  });
+
+  describe('extract', () => {
+    it('throws ReportNotFoundError when report does not exist', async () => {
+      mockPrisma = createMockPrisma(null);
+      service = new Form9ExportService(mockPrisma);
+
+      await expect(service.extract('nonexistent')).rejects.toThrow(ReportNotFoundError);
+    });
+
+    it('throws InspectionNotLinkedError when no site inspection linked', async () => {
+      mockPrisma = createMockPrisma({ id: 'report-1', siteInspection: null });
+      service = new Form9ExportService(mockPrisma);
+
+      await expect(service.extract('report-1')).rejects.toThrow(InspectionNotLinkedError);
+    });
+
+    it('extracts Part A (applicant details) from client', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partA).toEqual({
+        applicantName: 'Test Client Ltd',
+        applicantAddress: '456 Client Ave, Auckland',
+        applicantPhone: '09-123-4567',
+        applicantEmail: 'client@test.com',
+        contactPerson: 'Jane Doe',
+      });
+    });
+
+    it('extracts Part B (building work) from project/property', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partB).toEqual({
+        propertyAddress: '123 Main St, Auckland',
+        lotDp: 'Lot 1 DP 12345',
+        councilPropertyId: 'AKL-99999',
+        territorialAuthority: 'AKL',
+        jobNumber: 'INS-2026-001',
+        activity: 'COA Assessment',
+        reportType: 'COA',
+      });
+    });
+
+    it('extracts Part C (clauses) separating applicable and N/A', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partC.compliantClauses).toHaveLength(2);
+      expect(result.partC.compliantClauses[0]).toEqual({
+        code: 'B1',
+        title: 'Structure',
+        observations: 'Compliant with B1 requirements',
+      });
+      expect(result.partC.nonApplicableClauses).toHaveLength(1);
+      expect(result.partC.nonApplicableClauses[0].code).toBe('G12');
+    });
+
+    it('extracts Part D (limitations) from areas not accessed', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partD.limitations).toContain(
+        'Areas not accessed: Subfloor (no access hatch)',
+      );
+    });
+
+    it('returns empty limitations when no areas not accessed', async () => {
+      const report = createMockReport();
+      (report.siteInspection as Record<string, unknown>).areasNotAccessed = null;
+      mockPrisma = createMockPrisma(report);
+      service = new Form9ExportService(mockPrisma);
+
+      const result = await service.extract('report-1');
+      expect(result.partD.limitations).toHaveLength(0);
+    });
+
+    it('extracts Part E (documents) from project documents', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partE.documents).toHaveLength(2);
+      expect(result.partE.documents[0]).toEqual({
+        type: 'PS1',
+        filename: 'ps1-plumbing.pdf',
+        description: 'Producer Statement - Plumbing',
+        status: 'RECEIVED',
+        referenceNumber: 'PS1-001',
+      });
+    });
+
+    it('extracts Part F (inspection details)', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.partF.inspectorName).toBe('John Smith');
+      expect(result.partF.weather).toBe('Fine, 22°C');
+      expect(result.partF.methodology).toBe('Visual inspection with moisture testing');
+      expect(result.partF.outcome).toBe('PASS');
+      expect(result.partF.inspectionDate).toContain('2026-02-20');
+    });
+
+    it('includes exportedAt timestamp', async () => {
+      const result = await service.extract('report-1');
+
+      expect(result.exportedAt).toBeDefined();
+      expect(new Date(result.exportedAt).getTime()).not.toBeNaN();
+    });
+
+    it('caches form9Data on the report', async () => {
+      await service.extract('report-1');
+
+      expect(mockPrisma.report.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'report-1' },
+          data: { form9Data: expect.objectContaining({ partA: expect.any(Object) }) },
+        }),
+      );
+    });
+  });
+});

--- a/api/src/routes/report-management.ts
+++ b/api/src/routes/report-management.ts
@@ -12,6 +12,7 @@ import { PrismaReportManagementRepository } from '../repositories/prisma/report.
 import { ReportManagementService, ReportNotFoundError, InvalidStatusTransitionError } from '../services/report-management.js';
 import { ReportValidationService, ReportNotFoundError as ValidationReportNotFoundError } from '../services/report-validation.js';
 import { generateSignatureBlock } from '../services/signature-block.js';
+import { Form9ExportService, ReportNotFoundError as Form9ReportNotFoundError, InspectionNotLinkedError } from '../services/form9-export.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaReportManagementRepository(prisma);
@@ -248,6 +249,27 @@ reportManagementRouter.get('/:id/signature-block', async (req: Request, res: Res
 
     res.json(signatureBlock);
   } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/reports/:id/form9 - Export Form 9 data (#196)
+const form9Service = new Form9ExportService(prisma);
+
+reportManagementRouter.get('/:id/form9', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const form9Data = await form9Service.extract(id);
+    res.json(form9Data);
+  } catch (error) {
+    if (error instanceof Form9ReportNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    if (error instanceof InspectionNotLinkedError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
     next(error);
   }
 });

--- a/api/src/services/form9-export.ts
+++ b/api/src/services/form9-export.ts
@@ -1,0 +1,234 @@
+/**
+ * Form 9 Data Export Service — Issue #196
+ *
+ * Extracts Form 9 data from report/inspection/project data
+ * for council submission (Certificate of Acceptance application).
+ *
+ * Form 9 Sections:
+ * - Part A: Applicant details (from client)
+ * - Part B: Building work details (from project/property)
+ * - Part C: Clauses claimed compliant (from clause reviews)
+ * - Part D: Limitations (from inspection)
+ * - Part E: Supporting documents (from project documents)
+ * - Part F: Inspection details (from site inspection)
+ */
+
+import type { PrismaClient } from '@prisma/client';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface Form9Data {
+  partA: Form9PartA;
+  partB: Form9PartB;
+  partC: Form9PartC;
+  partD: Form9PartD;
+  partE: Form9PartE;
+  partF: Form9PartF;
+  exportedAt: string;
+}
+
+export interface Form9PartA {
+  applicantName: string;
+  applicantAddress: string | null;
+  applicantPhone: string | null;
+  applicantEmail: string | null;
+  contactPerson: string | null;
+}
+
+export interface Form9PartB {
+  propertyAddress: string;
+  lotDp: string | null;
+  councilPropertyId: string | null;
+  territorialAuthority: string;
+  jobNumber: string;
+  activity: string;
+  reportType: string;
+}
+
+export interface Form9PartC {
+  compliantClauses: Form9ClauseEntry[];
+  nonApplicableClauses: Form9ClauseEntry[];
+}
+
+export interface Form9ClauseEntry {
+  code: string;
+  title: string;
+  observations: string | null;
+}
+
+export interface Form9PartD {
+  limitations: string[];
+}
+
+export interface Form9PartE {
+  documents: Form9DocumentEntry[];
+}
+
+export interface Form9DocumentEntry {
+  type: string;
+  filename: string;
+  description: string;
+  status: string;
+  referenceNumber: string | null;
+}
+
+export interface Form9PartF {
+  inspectionDate: string | null;
+  inspectorName: string;
+  weather: string | null;
+  methodology: string | null;
+  areasNotAccessed: string | null;
+  outcome: string | null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Errors
+// ──────────────────────────────────────────────────────────────────────────────
+
+export class ReportNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Report not found: ${id}`);
+    this.name = 'ReportNotFoundError';
+  }
+}
+
+export class InspectionNotLinkedError extends Error {
+  constructor(reportId: string) {
+    super(`Report ${reportId} has no linked site inspection`);
+    this.name = 'InspectionNotLinkedError';
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Service
+// ──────────────────────────────────────────────────────────────────────────────
+
+export class Form9ExportService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Extract Form 9 data for a report.
+   * Pulls data from the report's linked site inspection, project, property,
+   * client, clause reviews, and documents.
+   */
+  async extract(reportId: string): Promise<Form9Data> {
+    const report = await this.prisma.report.findUnique({
+      where: { id: reportId },
+      include: {
+        siteInspection: {
+          include: {
+            project: {
+              include: {
+                property: true,
+                client: true,
+                documents: true,
+              },
+            },
+            clauseReviews: {
+              include: { clause: true },
+              orderBy: { sortOrder: 'asc' },
+            },
+          },
+        },
+      },
+    });
+
+    if (!report) throw new ReportNotFoundError(reportId);
+    if (!report.siteInspection) throw new InspectionNotLinkedError(reportId);
+
+    const inspection = report.siteInspection;
+    const project = inspection.project;
+    const property = project.property;
+    const client = project.client;
+
+    // Part A: Applicant details
+    const partA: Form9PartA = {
+      applicantName: client.name,
+      applicantAddress: client.address,
+      applicantPhone: client.phone,
+      applicantEmail: client.email,
+      contactPerson: client.contactPerson,
+    };
+
+    // Part B: Building work
+    const partB: Form9PartB = {
+      propertyAddress: property.streetAddress,
+      lotDp: property.lotDp,
+      councilPropertyId: property.councilPropertyId,
+      territorialAuthority: property.territorialAuthority,
+      jobNumber: project.jobNumber,
+      activity: project.activity,
+      reportType: project.reportType,
+    };
+
+    // Part C: Clauses
+    const compliantClauses: Form9ClauseEntry[] = [];
+    const nonApplicableClauses: Form9ClauseEntry[] = [];
+
+    for (const review of inspection.clauseReviews) {
+      const entry: Form9ClauseEntry = {
+        code: review.clause.code,
+        title: review.clause.title,
+        observations: review.observations,
+      };
+
+      if (review.applicability === 'APPLICABLE') {
+        compliantClauses.push(entry);
+      } else {
+        nonApplicableClauses.push(entry);
+      }
+    }
+
+    const partC: Form9PartC = { compliantClauses, nonApplicableClauses };
+
+    // Part D: Limitations
+    const limitations: string[] = [];
+    if (inspection.areasNotAccessed) {
+      limitations.push(`Areas not accessed: ${inspection.areasNotAccessed}`);
+    }
+    // Could extend with more limitation sources in future
+
+    const partD: Form9PartD = { limitations };
+
+    // Part E: Documents
+    const partE: Form9PartE = {
+      documents: project.documents.map((doc) => ({
+        type: doc.documentType,
+        filename: doc.filename,
+        description: doc.description,
+        status: doc.status,
+        referenceNumber: doc.referenceNumber,
+      })),
+    };
+
+    // Part F: Inspection details
+    const partF: Form9PartF = {
+      inspectionDate: inspection.date.toISOString(),
+      inspectorName: inspection.inspectorName,
+      weather: inspection.weather,
+      methodology: inspection.methodology,
+      areasNotAccessed: inspection.areasNotAccessed,
+      outcome: inspection.outcome,
+    };
+
+    const form9Data: Form9Data = {
+      partA,
+      partB,
+      partC,
+      partD,
+      partE,
+      partF,
+      exportedAt: new Date().toISOString(),
+    };
+
+    // Also store on the report for caching
+    await this.prisma.report.update({
+      where: { id: reportId },
+      data: { form9Data: form9Data as unknown as Record<string, unknown> },
+    });
+
+    return form9Data;
+  }
+}

--- a/api/src/services/form9-export.ts
+++ b/api/src/services/form9-export.ts
@@ -226,7 +226,7 @@ export class Form9ExportService {
     // Also store on the report for caching
     await this.prisma.report.update({
       where: { id: reportId },
-      data: { form9Data: form9Data as unknown as Record<string, unknown> },
+      data: { form9Data: JSON.parse(JSON.stringify(form9Data)) },
     });
 
     return form9Data;


### PR DESCRIPTION
## Summary
Implements Form 9 data extraction for council COA submissions.

### Changes
- **New:** `api/src/services/form9-export.ts` — extracts all 6 Form 9 parts from report/inspection/project data
- **Modified:** `api/src/routes/report-management.ts` — added `GET /api/reports/:id/form9` endpoint
- **New:** `api/src/__tests__/form9-export.test.ts` — 11 tests

### Form 9 Parts
| Part | Source | Data |
|------|--------|------|
| A | Client | Applicant name, address, phone, email, contact |
| B | Project/Property | Address, lot/DP, council ID, TA, job number |
| C | ClauseReviews | Compliant vs N/A clauses with observations |
| D | Inspection | Limitations (areas not accessed) |
| E | Documents | Supporting documents with status |
| F | Inspection | Date, inspector, weather, methodology, outcome |

Also caches extracted data on `report.form9Data` for subsequent requests.

### Tests
All 11 tests pass.

Closes #196