### PR TITLE
[Alex] feat(api): implement credential expiry alerts (#202)

### DIFF
--- a/api/src/__tests__/credential-expiry.test.ts
+++ b/api/src/__tests__/credential-expiry.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Credential Expiry Alert Tests — Issue #202
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getAlertLevel, daysUntilDate } from '../services/credential-expiry.js';
+
+describe('credential-expiry', () => {
+  describe('getAlertLevel', () => {
+    it('returns EXPIRED for 0 or negative days', () => {
+      expect(getAlertLevel(0)).toBe('EXPIRED');
+      expect(getAlertLevel(-5)).toBe('EXPIRED');
+      expect(getAlertLevel(-100)).toBe('EXPIRED');
+    });
+
+    it('returns URGENT for 1-30 days', () => {
+      expect(getAlertLevel(1)).toBe('URGENT');
+      expect(getAlertLevel(15)).toBe('URGENT');
+      expect(getAlertLevel(30)).toBe('URGENT');
+    });
+
+    it('returns WARNING for 31-60 days', () => {
+      expect(getAlertLevel(31)).toBe('WARNING');
+      expect(getAlertLevel(45)).toBe('WARNING');
+      expect(getAlertLevel(60)).toBe('WARNING');
+    });
+
+    it('returns INFO for 61+ days', () => {
+      expect(getAlertLevel(61)).toBe('INFO');
+      expect(getAlertLevel(90)).toBe('INFO');
+      expect(getAlertLevel(365)).toBe('INFO');
+    });
+  });
+
+  describe('daysUntilDate', () => {
+    it('returns positive days for future date', () => {
+      const now = new Date('2026-02-25T00:00:00Z');
+      const expiry = new Date('2026-03-27T00:00:00Z');
+      expect(daysUntilDate(expiry, now)).toBe(30);
+    });
+
+    it('returns 0 for same day', () => {
+      const now = new Date('2026-02-25T00:00:00Z');
+      const expiry = new Date('2026-02-25T00:00:00Z');
+      expect(daysUntilDate(expiry, now)).toBe(0);
+    });
+
+    it('returns negative days for past date', () => {
+      const now = new Date('2026-02-25T00:00:00Z');
+      const expiry = new Date('2026-02-15T00:00:00Z');
+      expect(daysUntilDate(expiry, now)).toBe(-10);
+    });
+
+    it('floors partial days', () => {
+      const now = new Date('2026-02-25T12:00:00Z');
+      const expiry = new Date('2026-02-26T06:00:00Z');
+      // 18 hours = 0 full days
+      expect(daysUntilDate(expiry, now)).toBe(0);
+    });
+  });
+});

--- a/api/src/routes/credentials.ts
+++ b/api/src/routes/credentials.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import { z } from 'zod';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, type CredentialType } from '@prisma/client';
 import { PrismaCredentialRepository } from '../repositories/prisma/credential.js';
 import {
   CredentialService,
@@ -8,7 +8,7 @@ import {
   PersonnelNotFoundError,
   InvalidLBPLicenseError,
 } from '../services/credential.js';
-import { CredentialExpiryService } from '../services/credential-expiry.js';
+import { CredentialExpiryService, type AlertLevel } from '../services/credential-expiry.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaCredentialRepository(prisma);
@@ -60,8 +60,8 @@ credentialsRouter.get(
       const results = await expiryService.findExpiring({
         days,
         personnelId,
-        credentialType: credentialType as Parameters<typeof expiryService.findExpiring>[0]['credentialType'],
-        alertLevel: alertLevel as Parameters<typeof expiryService.findExpiring>[0]['alertLevel'],
+        credentialType: credentialType as CredentialType | undefined,
+        alertLevel: alertLevel as AlertLevel | undefined,
       });
 
       res.json({

--- a/api/src/routes/credentials.ts
+++ b/api/src/routes/credentials.ts
@@ -8,10 +8,12 @@ import {
   PersonnelNotFoundError,
   InvalidLBPLicenseError,
 } from '../services/credential.js';
+import { CredentialExpiryService } from '../services/credential-expiry.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaCredentialRepository(prisma);
 const service = new CredentialService(repository, prisma);
+const expiryService = new CredentialExpiryService(prisma);
 
 export const credentialsRouter = Router();
 
@@ -39,6 +41,53 @@ const UpdateCredentialSchema = z.object({
   expiryDate: z.string().datetime().nullable().optional(),
   verified: z.boolean().optional(),
 });
+
+// GET /api/credentials/expiring - List expiring credentials (#202)
+credentialsRouter.get(
+  '/credentials/expiring',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const days = req.query.days ? parseInt(req.query.days as string, 10) : undefined;
+      const personnelId = req.query.personnelId as string | undefined;
+      const credentialType = req.query.credentialType as string | undefined;
+      const alertLevel = req.query.alertLevel as string | undefined;
+
+      if (days !== undefined && (isNaN(days) || days < 1)) {
+        res.status(400).json({ error: 'days must be a positive integer' });
+        return;
+      }
+
+      const results = await expiryService.findExpiring({
+        days,
+        personnelId,
+        credentialType: credentialType as Parameters<typeof expiryService.findExpiring>[0]['credentialType'],
+        alertLevel: alertLevel as Parameters<typeof expiryService.findExpiring>[0]['alertLevel'],
+      });
+
+      res.json({
+        count: results.length,
+        thresholdDays: days ?? 90,
+        credentials: results,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/credentials/expiring/summary - Summary counts by alert level (#202)
+credentialsRouter.get(
+  '/credentials/expiring/summary',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const days = req.query.days ? parseInt(req.query.days as string, 10) : undefined;
+      const summary = await expiryService.getSummary(days);
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 // POST /api/personnel/:personnelId/credentials - Create credential
 credentialsRouter.post(

--- a/api/src/services/credential-expiry.ts
+++ b/api/src/services/credential-expiry.ts
@@ -1,0 +1,151 @@
+/**
+ * Credential Expiry Alert Service — Issue #202
+ *
+ * Detects credentials expiring within a configurable threshold
+ * and categorises them by urgency level.
+ */
+
+import type { PrismaClient, Credential, Personnel, CredentialType } from '@prisma/client';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type AlertLevel = 'INFO' | 'WARNING' | 'URGENT' | 'EXPIRED';
+
+export interface ExpiringCredential {
+  credentialId: string;
+  credentialType: CredentialType;
+  registrationTitle: string | null;
+  licenseNumber: string | null;
+  expiryDate: Date;
+  daysUntilExpiry: number;
+  alertLevel: AlertLevel;
+  personnel: {
+    id: string;
+    name: string;
+    email: string;
+    phone: string | null;
+    mobile: string | null;
+    role: string;
+  };
+}
+
+export interface ExpiryQueryParams {
+  days?: number;
+  personnelId?: string;
+  credentialType?: CredentialType;
+  alertLevel?: AlertLevel;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Determine alert level based on days until expiry.
+ */
+export function getAlertLevel(daysUntilExpiry: number): AlertLevel {
+  if (daysUntilExpiry <= 0) return 'EXPIRED';
+  if (daysUntilExpiry <= 30) return 'URGENT';
+  if (daysUntilExpiry <= 60) return 'WARNING';
+  return 'INFO';
+}
+
+/**
+ * Calculate days between now and expiry date.
+ */
+export function daysUntilDate(expiryDate: Date, now: Date = new Date()): number {
+  const diff = expiryDate.getTime() - now.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Service
+// ──────────────────────────────────────────────────────────────────────────────
+
+export class CredentialExpiryService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Find all credentials expiring within the given number of days.
+   * Returns results ordered by expiry date (soonest first).
+   * Only includes active personnel.
+   */
+  async findExpiring(params: ExpiryQueryParams = {}): Promise<ExpiringCredential[]> {
+    const days = params.days ?? 90;
+    const now = new Date();
+    const threshold = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+
+    const where: Record<string, unknown> = {
+      expiryDate: { lte: threshold },
+      personnel: { active: true },
+    };
+
+    if (params.personnelId) {
+      where.personnelId = params.personnelId;
+    }
+    if (params.credentialType) {
+      where.credentialType = params.credentialType;
+    }
+
+    const credentials = await this.prisma.credential.findMany({
+      where,
+      include: {
+        personnel: true,
+      },
+      orderBy: { expiryDate: 'asc' },
+    });
+
+    const results: ExpiringCredential[] = credentials
+      .filter((c): c is Credential & { personnel: Personnel; expiryDate: Date } => c.expiryDate !== null)
+      .map((c) => {
+        const daysLeft = daysUntilDate(c.expiryDate, now);
+        const alertLevel = getAlertLevel(daysLeft);
+
+        return {
+          credentialId: c.id,
+          credentialType: c.credentialType,
+          registrationTitle: c.registrationTitle,
+          licenseNumber: c.licenseNumber,
+          expiryDate: c.expiryDate,
+          daysUntilExpiry: daysLeft,
+          alertLevel,
+          personnel: {
+            id: c.personnel.id,
+            name: c.personnel.name,
+            email: c.personnel.email,
+            phone: c.personnel.phone,
+            mobile: c.personnel.mobile,
+            role: c.personnel.role,
+          },
+        };
+      });
+
+    // Filter by alert level if specified
+    if (params.alertLevel) {
+      return results.filter((r) => r.alertLevel === params.alertLevel);
+    }
+
+    return results;
+  }
+
+  /**
+   * Get summary counts by alert level.
+   */
+  async getSummary(days?: number): Promise<Record<AlertLevel, number>> {
+    const results = await this.findExpiring({ days });
+    const summary: Record<AlertLevel, number> = {
+      INFO: 0,
+      WARNING: 0,
+      URGENT: 0,
+      EXPIRED: 0,
+    };
+
+    for (const r of results) {
+      summary[r.alertLevel]++;
+    }
+
+    return summary;
+  }
+}


### PR DESCRIPTION
## Summary
Implements credential expiry detection and alerting for personnel certifications.

### Changes
- **New:** `api/src/services/credential-expiry.ts` — service with alert level categorisation
- **Modified:** `api/src/routes/credentials.ts` — added expiring credentials endpoints
- **New:** `api/src/__tests__/credential-expiry.test.ts` — 8 tests

### Alert Levels
| Level | Threshold |
|-------|-----------|
| INFO | 61-90 days |
| WARNING | 31-60 days |
| URGENT | 1-30 days |
| EXPIRED | ≤ 0 days |

### Endpoints
- `GET /api/credentials/expiring?days=90&personnelId=&credentialType=&alertLevel=`
- `GET /api/credentials/expiring/summary`

### Features
- Only active personnel included
- Ordered by expiry date (soonest first)
- Filter by personnel, credential type, alert level
- Summary endpoint with counts per level

Closes #202