### PR TITLE
[Alex] feat(api): implement personnel role validation for reports (#204)

### DIFF
--- a/api/src/__tests__/personnel-role-validation.test.ts
+++ b/api/src/__tests__/personnel-role-validation.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Personnel Role Validation Tests — Issue #204
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getRoleCapabilities,
+  canAuthor,
+  canReview,
+  validateAuthor,
+  validateReviewer,
+  validateAssignment,
+  getAuthorRoles,
+  getReviewerRoles,
+  type PersonnelValidationInput,
+} from '../services/personnel-role-validation.js';
+
+const rbs: PersonnelValidationInput = {
+  id: '1', name: 'Ian Fong', role: 'REGISTERED_BUILDING_SURVEYOR', active: true,
+};
+const bs: PersonnelValidationInput = {
+  id: '2', name: 'Jake Li', role: 'BUILDING_SURVEYOR', active: true,
+};
+const inspector: PersonnelValidationInput = {
+  id: '3', name: 'Joe Smith', role: 'INSPECTOR', active: true,
+};
+const admin: PersonnelValidationInput = {
+  id: '4', name: 'Admin User', role: 'ADMIN', active: true,
+};
+const inactive: PersonnelValidationInput = {
+  id: '5', name: 'Gone Person', role: 'REGISTERED_BUILDING_SURVEYOR', active: false,
+};
+
+describe('personnel-role-validation', () => {
+  describe('getRoleCapabilities', () => {
+    it('REGISTERED_BUILDING_SURVEYOR can author and review', () => {
+      expect(getRoleCapabilities('REGISTERED_BUILDING_SURVEYOR')).toEqual({ canAuthor: true, canReview: true });
+    });
+
+    it('BUILDING_SURVEYOR can author only', () => {
+      expect(getRoleCapabilities('BUILDING_SURVEYOR')).toEqual({ canAuthor: true, canReview: false });
+    });
+
+    it('INSPECTOR cannot author or review', () => {
+      expect(getRoleCapabilities('INSPECTOR')).toEqual({ canAuthor: false, canReview: false });
+    });
+
+    it('ADMIN cannot author or review', () => {
+      expect(getRoleCapabilities('ADMIN')).toEqual({ canAuthor: false, canReview: false });
+    });
+  });
+
+  describe('canAuthor / canReview', () => {
+    it('RBS can author', () => expect(canAuthor('REGISTERED_BUILDING_SURVEYOR')).toBe(true));
+    it('BS can author', () => expect(canAuthor('BUILDING_SURVEYOR')).toBe(true));
+    it('Inspector cannot author', () => expect(canAuthor('INSPECTOR')).toBe(false));
+    it('only RBS can review', () => {
+      expect(canReview('REGISTERED_BUILDING_SURVEYOR')).toBe(true);
+      expect(canReview('BUILDING_SURVEYOR')).toBe(false);
+      expect(canReview('INSPECTOR')).toBe(false);
+      expect(canReview('ADMIN')).toBe(false);
+    });
+  });
+
+  describe('validateAuthor', () => {
+    it('accepts RBS as author', () => {
+      expect(validateAuthor(rbs)).toEqual({ valid: true, errors: [], warnings: [] });
+    });
+
+    it('accepts BS as author', () => {
+      expect(validateAuthor(bs)).toEqual({ valid: true, errors: [], warnings: [] });
+    });
+
+    it('rejects INSPECTOR as author', () => {
+      const result = validateAuthor(inspector);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('authoring capability');
+    });
+
+    it('rejects inactive personnel', () => {
+      const result = validateAuthor(inactive);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('inactive');
+    });
+  });
+
+  describe('validateReviewer', () => {
+    it('accepts RBS as reviewer', () => {
+      expect(validateReviewer(rbs)).toEqual({ valid: true, errors: [], warnings: [] });
+    });
+
+    it('rejects BS as reviewer', () => {
+      const result = validateReviewer(bs);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('reviewing capability');
+    });
+
+    it('rejects inactive personnel', () => {
+      const result = validateReviewer(inactive);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('inactive'))).toBe(true);
+    });
+  });
+
+  describe('validateAssignment', () => {
+    it('accepts valid author + reviewer pair', () => {
+      const rbs2: PersonnelValidationInput = { id: '6', name: 'Second RBS', role: 'REGISTERED_BUILDING_SURVEYOR', active: true };
+      const result = validateAssignment(rbs, rbs2);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('warns when reviewer credentials < author credentials', () => {
+      // BS author, RBS reviewer — this is fine (no warning)
+      const result1 = validateAssignment(bs, rbs);
+      expect(result1.warnings.filter(w => w.includes('lower credentials'))).toHaveLength(0);
+
+      // Not possible to have lower reviewer since only RBS can review,
+      // but test the logic with a hypothetical
+    });
+
+    it('warns when author and reviewer are the same person', () => {
+      const result = validateAssignment(rbs, rbs);
+      expect(result.warnings.some(w => w.includes('same person'))).toBe(true);
+    });
+
+    it('collects errors from both author and reviewer', () => {
+      const result = validateAssignment(inspector, bs);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('getAuthorRoles / getReviewerRoles', () => {
+    it('returns RBS and BS as author roles', () => {
+      const roles = getAuthorRoles();
+      expect(roles).toContain('REGISTERED_BUILDING_SURVEYOR');
+      expect(roles).toContain('BUILDING_SURVEYOR');
+      expect(roles).not.toContain('INSPECTOR');
+      expect(roles).not.toContain('ADMIN');
+    });
+
+    it('returns only RBS as reviewer role', () => {
+      const roles = getReviewerRoles();
+      expect(roles).toEqual(['REGISTERED_BUILDING_SURVEYOR']);
+    });
+  });
+});

--- a/api/src/routes/personnel.ts
+++ b/api/src/routes/personnel.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from '@prisma/client';
 import { PrismaPersonnelRepository } from '../repositories/prisma/personnel.js';
 import { PersonnelService, PersonnelNotFoundError, PersonnelEmailConflictError } from '../services/personnel.js';
 import { formatCredentials } from '../services/credential-formatter.js';
+import { getAuthorRoles, getReviewerRoles } from '../services/personnel-role-validation.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaPersonnelRepository(prisma);
@@ -71,6 +72,36 @@ personnelRouter.get('/', async (req: Request, res: Response, next: NextFunction)
       name: name as string | undefined,
     });
     res.json(personnel);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/personnel/authors - List personnel eligible to author reports (#204)
+personnelRouter.get('/authors', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const roles = getAuthorRoles();
+    const authors = await prisma.personnel.findMany({
+      where: { role: { in: roles }, active: true },
+      include: { credentials: true },
+      orderBy: { name: 'asc' },
+    });
+    res.json(authors);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/personnel/reviewers - List personnel eligible to review reports (#204)
+personnelRouter.get('/reviewers', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const roles = getReviewerRoles();
+    const reviewers = await prisma.personnel.findMany({
+      where: { role: { in: roles }, active: true },
+      include: { credentials: true },
+      orderBy: { name: 'asc' },
+    });
+    res.json(reviewers);
   } catch (error) {
     next(error);
   }

--- a/api/src/services/personnel-role-validation.ts
+++ b/api/src/services/personnel-role-validation.ts
@@ -1,0 +1,159 @@
+/**
+ * Personnel Role Validation Service — Issue #204
+ *
+ * Validates personnel assignments for report authoring and reviewing.
+ * Only qualified personnel can be assigned based on their role.
+ */
+
+import type { PersonnelRole } from '@prisma/client';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface RoleCapabilities {
+  canAuthor: boolean;
+  canReview: boolean;
+}
+
+export interface PersonnelValidationInput {
+  id: string;
+  name: string;
+  role: PersonnelRole;
+  active: boolean;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Role Capabilities Matrix
+// ──────────────────────────────────────────────────────────────────────────────
+
+const ROLE_CAPABILITIES: Record<PersonnelRole, RoleCapabilities> = {
+  REGISTERED_BUILDING_SURVEYOR: { canAuthor: true, canReview: true },
+  BUILDING_SURVEYOR: { canAuthor: true, canReview: false },
+  INSPECTOR: { canAuthor: false, canReview: false },
+  ADMIN: { canAuthor: false, canReview: false },
+};
+
+/**
+ * Role hierarchy for credential comparison (higher = more qualified).
+ */
+const ROLE_RANK: Record<PersonnelRole, number> = {
+  REGISTERED_BUILDING_SURVEYOR: 3,
+  BUILDING_SURVEYOR: 2,
+  INSPECTOR: 1,
+  ADMIN: 0,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Validation Functions
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Get capabilities for a given role.
+ */
+export function getRoleCapabilities(role: PersonnelRole): RoleCapabilities {
+  return ROLE_CAPABILITIES[role];
+}
+
+/**
+ * Check if a personnel can author reports.
+ */
+export function canAuthor(role: PersonnelRole): boolean {
+  return ROLE_CAPABILITIES[role].canAuthor;
+}
+
+/**
+ * Check if a personnel can review reports.
+ */
+export function canReview(role: PersonnelRole): boolean {
+  return ROLE_CAPABILITIES[role].canReview;
+}
+
+/**
+ * Validate a personnel assignment as report author.
+ */
+export function validateAuthor(personnel: PersonnelValidationInput): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!personnel.active) {
+    errors.push(`${personnel.name} is inactive and cannot be assigned as author`);
+  }
+
+  if (!canAuthor(personnel.role)) {
+    errors.push(`${personnel.name} (${personnel.role}) does not have authoring capability`);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Validate a personnel assignment as report reviewer.
+ */
+export function validateReviewer(personnel: PersonnelValidationInput): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!personnel.active) {
+    errors.push(`${personnel.name} is inactive and cannot be assigned as reviewer`);
+  }
+
+  if (!canReview(personnel.role)) {
+    errors.push(`${personnel.name} (${personnel.role}) does not have reviewing capability`);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Validate an author + reviewer assignment pair.
+ * Warns if reviewer credentials are lower than author credentials.
+ */
+export function validateAssignment(
+  author: PersonnelValidationInput,
+  reviewer: PersonnelValidationInput,
+): ValidationResult {
+  const authorResult = validateAuthor(author);
+  const reviewerResult = validateReviewer(reviewer);
+
+  const errors = [...authorResult.errors, ...reviewerResult.errors];
+  const warnings = [...authorResult.warnings, ...reviewerResult.warnings];
+
+  // Warn if reviewer rank < author rank
+  if (ROLE_RANK[reviewer.role] < ROLE_RANK[author.role]) {
+    warnings.push(
+      `Reviewer ${reviewer.name} (${reviewer.role}) has lower credentials than author ${author.name} (${author.role})`,
+    );
+  }
+
+  // Warn if author and reviewer are the same person
+  if (author.id === reviewer.id) {
+    warnings.push('Author and reviewer are the same person');
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Get all roles that can author reports.
+ */
+export function getAuthorRoles(): PersonnelRole[] {
+  return (Object.keys(ROLE_CAPABILITIES) as PersonnelRole[]).filter(
+    (role) => ROLE_CAPABILITIES[role].canAuthor,
+  );
+}
+
+/**
+ * Get all roles that can review reports.
+ */
+export function getReviewerRoles(): PersonnelRole[] {
+  return (Object.keys(ROLE_CAPABILITIES) as PersonnelRole[]).filter(
+    (role) => ROLE_CAPABILITIES[role].canReview,
+  );
+}


### PR DESCRIPTION
## Summary
Implements role-based validation for report author/reviewer assignments.

### Role Capabilities Matrix
| Role | Can Author | Can Review |
|------|-----------|-----------|
| REGISTERED_BUILDING_SURVEYOR | ✅ | ✅ |
| BUILDING_SURVEYOR | ✅ | ❌ |
| INSPECTOR | ❌ | ❌ |
| ADMIN | ❌ | ❌ |

### Changes
- **New:** `api/src/services/personnel-role-validation.ts` — validation service with role capabilities matrix
- **Modified:** `api/src/routes/personnel.ts` — added `GET /api/personnel/authors` and `GET /api/personnel/reviewers`
- **New:** `api/src/__tests__/personnel-role-validation.test.ts` — 21 tests

### Validation Features
- Active status check (inactive personnel rejected)
- Role capability check for author/reviewer
- Warning when reviewer credentials < author credentials
- Warning when author and reviewer are the same person

### Tests
All 21 tests pass.

Closes #204