### PR TITLE
[Alex] feat(api): add CCC Gap Analysis report templates (#221)

### DIFF
--- a/api/prisma/seed-templates.ts
+++ b/api/prisma/seed-templates.ts
@@ -58,6 +58,73 @@ This report assesses whether the building meets the minimum requirements for saf
     variables: ['Company Name', 'Address'],
   },
 
+  // ── CCC Gap Analysis Section Templates (#221) ──────────────────────────
+  {
+    name: 'Executive Summary - CCC Gap Analysis',
+    type: 'SECTION',
+    reportType: 'CCC_GAP',
+    content: `This CCC Gap Analysis report has been prepared for [Client Name] in respect of the building at [Address].
+
+The inspection identified the following key findings:
+
+**Defects Identified:**
+[Defect List]
+
+**Breached Building Code Clauses:**
+[Breached Clauses]
+
+**Remediation Summary:**
+[Remediation Summary]
+
+**Estimated Remediation Cost (excl. GST):**
+[Cost Estimate]`,
+    variables: ['Client Name', 'Address', 'Defect List', 'Breached Clauses', 'Remediation Summary', 'Cost Estimate'],
+  },
+  {
+    name: 'Defect Schedule - CCC Gap Analysis',
+    type: 'SECTION',
+    reportType: 'CCC_GAP',
+    content: `The following defect schedule details all items identified during the inspection that require remediation prior to achieving a Code Compliance Certificate.
+
+| # | Location | Element | Description | Clause | Priority | Remedial Action |
+|---|----------|---------|-------------|--------|----------|-----------------|
+[Defect List]
+
+Total defects identified: [Defect Count]`,
+    variables: ['Defect List', 'Defect Count'],
+  },
+  {
+    name: 'Moisture Reading Summary - CCC Gap Analysis',
+    type: 'SECTION',
+    reportType: 'CCC_GAP',
+    content: `Non-invasive moisture testing was carried out at locations identified as high-risk for moisture ingress. The following table summarises the readings obtained.
+
+[Moisture Summary]
+
+**Interpretation:**
+- Acceptable: < 18% — within normal range
+- Marginal: 18–25% — monitoring recommended
+- Unacceptable: > 25% — further investigation required
+
+Any unacceptable readings have been cross-referenced to the Defect Schedule above.`,
+    variables: ['Moisture Summary'],
+  },
+  {
+    name: 'Cost Estimate Summary - CCC Gap Analysis',
+    type: 'SECTION',
+    reportType: 'CCC_GAP',
+    content: `The following cost estimate provides an indicative budget for the remediation works identified in this report. Costs are estimates only and should be confirmed by obtaining competitive quotations from suitably qualified contractors.
+
+[Cost Estimate]
+
+**Notes:**
+- All costs are exclusive of GST
+- A contingency allowance has been included
+- Actual costs may vary depending on site conditions and contractor availability
+- Costs do not include professional fees, consenting fees, or council charges`,
+    variables: ['Cost Estimate'],
+  },
+
   // ── Methodology Templates ─────────────────────────────────────────────
   {
     name: 'Methodology - Standard',

--- a/api/src/__tests__/seed-templates.test.ts
+++ b/api/src/__tests__/seed-templates.test.ts
@@ -31,6 +31,72 @@ The works subject to this Certificate of Acceptance application are described in
 This report identifies outstanding items and inspections required to achieve a Code Compliance Certificate from [Territorial Authority].`,
     variables: ['Company Name', 'Address', 'Territorial Authority'],
   },
+  // CCC Gap Analysis templates (#221)
+  {
+    name: 'Executive Summary - CCC Gap Analysis',
+    type: 'SECTION' as const,
+    reportType: 'CCC_GAP' as const,
+    content: `This CCC Gap Analysis report has been prepared for [Client Name] in respect of the building at [Address].
+
+The inspection identified the following key findings:
+
+**Defects Identified:**
+[Defect List]
+
+**Breached Building Code Clauses:**
+[Breached Clauses]
+
+**Remediation Summary:**
+[Remediation Summary]
+
+**Estimated Remediation Cost (excl. GST):**
+[Cost Estimate]`,
+    variables: ['Client Name', 'Address', 'Defect List', 'Breached Clauses', 'Remediation Summary', 'Cost Estimate'],
+  },
+  {
+    name: 'Defect Schedule - CCC Gap Analysis',
+    type: 'SECTION' as const,
+    reportType: 'CCC_GAP' as const,
+    content: `The following defect schedule details all items identified during the inspection that require remediation prior to achieving a Code Compliance Certificate.
+
+| # | Location | Element | Description | Clause | Priority | Remedial Action |
+|---|----------|---------|-------------|--------|----------|-----------------|
+[Defect List]
+
+Total defects identified: [Defect Count]`,
+    variables: ['Defect List', 'Defect Count'],
+  },
+  {
+    name: 'Moisture Reading Summary - CCC Gap Analysis',
+    type: 'SECTION' as const,
+    reportType: 'CCC_GAP' as const,
+    content: `Non-invasive moisture testing was carried out at locations identified as high-risk for moisture ingress. The following table summarises the readings obtained.
+
+[Moisture Summary]
+
+**Interpretation:**
+- Acceptable: < 18% — within normal range
+- Marginal: 18–25% — monitoring recommended
+- Unacceptable: > 25% — further investigation required
+
+Any unacceptable readings have been cross-referenced to the Defect Schedule above.`,
+    variables: ['Moisture Summary'],
+  },
+  {
+    name: 'Cost Estimate Summary - CCC Gap Analysis',
+    type: 'SECTION' as const,
+    reportType: 'CCC_GAP' as const,
+    content: `The following cost estimate provides an indicative budget for the remediation works identified in this report. Costs are estimates only and should be confirmed by obtaining competitive quotations from suitably qualified contractors.
+
+[Cost Estimate]
+
+**Notes:**
+- All costs are exclusive of GST
+- A contingency allowance has been included
+- Actual costs may vary depending on site conditions and contractor availability
+- Costs do not include professional fees, consenting fees, or council charges`,
+    variables: ['Cost Estimate'],
+  },
   {
     name: 'Methodology - Standard',
     type: 'METHODOLOGY' as const,
@@ -127,5 +193,18 @@ describe('Default Report Templates (seed data)', () => {
   it('has at least one boilerplate template', () => {
     const boilerplates = DEFAULT_TEMPLATES.filter((t) => t.type === 'BOILERPLATE');
     expect(boilerplates.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('has CCC Gap Analysis section templates (#221)', () => {
+    const cccTemplates = DEFAULT_TEMPLATES.filter(
+      (t) => t.reportType === 'CCC_GAP' && t.type === 'SECTION',
+    );
+    const names = cccTemplates.map((t) => t.name);
+
+    expect(names).toContain('Introduction - CCC Gap Analysis');
+    expect(names).toContain('Executive Summary - CCC Gap Analysis');
+    expect(names).toContain('Defect Schedule - CCC Gap Analysis');
+    expect(names).toContain('Moisture Reading Summary - CCC Gap Analysis');
+    expect(names).toContain('Cost Estimate Summary - CCC Gap Analysis');
   });
 });


### PR DESCRIPTION
## Summary
Adds CCC Gap Analysis specific report templates for the template system.

### New Templates (CCC_GAP / SECTION)
1. **Executive Summary** — defect list, breached clauses, remediation summary, cost estimate
2. **Defect Schedule** — table format with location, element, clause, priority, remedial action
3. **Moisture Reading Summary** — readings table with interpretation guide
4. **Cost Estimate Summary** — budget breakdown with standard notes/caveats

### Changes
- **Modified:** `api/prisma/seed-templates.ts` — added 4 CCC_GAP section templates
- **Modified:** `api/src/__tests__/seed-templates.test.ts` — added templates + CCC_GAP coverage test

### Tests
All 9 seed template tests pass.

Closes #221