### PR TITLE
[Alex] fix(api): add Personnel company FK and Credential membershipFull (#487, #488)

### DIFF
--- a/api/prisma/migrations/20260225080000_add_personnel_company_fk_and_membership_full/migration.sql
+++ b/api/prisma/migrations/20260225080000_add_personnel_company_fk_and_membership_full/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: Add companyId FK to Personnel (#487)
+ALTER TABLE "Personnel" ADD COLUMN "companyId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Personnel_companyId_idx" ON "Personnel"("companyId");
+
+-- AddForeignKey
+ALTER TABLE "Personnel" ADD CONSTRAINT "Personnel_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AlterTable: Add membershipFull to Credential (#488)
+ALTER TABLE "Credential" ADD COLUMN "membershipFull" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -266,6 +266,10 @@ model Personnel {
   mobile    String?
   role      PersonnelRole
   active    Boolean       @default(true)
+  
+  companyId String?
+  company   Company?      @relation(fields: [companyId], references: [id])
+  
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
 
@@ -274,6 +278,7 @@ model Personnel {
   @@index([role])
   @@index([active])
   @@index([email])
+  @@index([companyId])
 }
 
 enum CredentialType {
@@ -290,6 +295,7 @@ model Credential {
   personnel         Personnel      @relation(fields: [personnelId], references: [id], onDelete: Cascade)
   credentialType    CredentialType
   membershipCode    String?        // "MNZIBS", "MEngNZ"
+  membershipFull    String?        // "Member of NZ Institute of Building Surveyors"
   registrationTitle String?        // "Registered Building Surveyor"
   licenseNumber     String?        // LBP or other license
   qualifications    String[]       @default([])  // ["BE (Hons)", "MBA"]
@@ -882,6 +888,8 @@ model Company {
   
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
+  
+  personnel   Personnel[]
   
   @@index([name])
 }

--- a/api/src/__tests__/credential.test.ts
+++ b/api/src/__tests__/credential.test.ts
@@ -32,6 +32,7 @@ const mockPersonnel: Personnel = {
   mobile: null,
   role: 'BUILDING_SURVEYOR',
   active: true,
+  companyId: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -41,6 +42,7 @@ const mockCredential: Credential = {
   personnelId: 'personnel-1',
   credentialType: 'NZIBS',
   membershipCode: 'MNZIBS',
+  membershipFull: null,
   registrationTitle: null,
   licenseNumber: null,
   qualifications: ['BE (Hons)'],

--- a/api/src/__tests__/personnel.test.ts
+++ b/api/src/__tests__/personnel.test.ts
@@ -21,6 +21,7 @@ function createMockPersonnel(overrides: Partial<Personnel> = {}): Personnel {
     mobile: null,
     role: 'INSPECTOR' as PersonnelRole,
     active: true,
+    companyId: null,
     createdAt: new Date('2026-01-01'),
     updatedAt: new Date('2026-01-01'),
     ...overrides,

--- a/api/src/repositories/interfaces/personnel.ts
+++ b/api/src/repositories/interfaces/personnel.ts
@@ -6,6 +6,7 @@ export interface CreatePersonnelInput {
   phone?: string;
   mobile?: string;
   role: PersonnelRole;
+  companyId?: string;
 }
 
 export interface UpdatePersonnelInput {
@@ -15,6 +16,7 @@ export interface UpdatePersonnelInput {
   mobile?: string;
   role?: PersonnelRole;
   active?: boolean;
+  companyId?: string | null;
 }
 
 export interface PersonnelSearchParams {

--- a/api/src/repositories/prisma/personnel.ts
+++ b/api/src/repositories/prisma/personnel.ts
@@ -18,6 +18,7 @@ export class PrismaPersonnelRepository implements IPersonnelRepository {
   async findById(id: string): Promise<Personnel | null> {
     return this.prisma.personnel.findUnique({
       where: { id },
+      include: { credentials: true, company: true },
     });
   }
 
@@ -36,6 +37,7 @@ export class PrismaPersonnelRepository implements IPersonnelRepository {
 
     return this.prisma.personnel.findMany({
       where,
+      include: { credentials: true, company: true },
       orderBy: { name: 'asc' },
     });
   }

--- a/api/src/routes/personnel.ts
+++ b/api/src/routes/personnel.ts
@@ -26,6 +26,7 @@ const CreatePersonnelSchema = z.object({
   phone: z.string().optional(),
   mobile: z.string().optional(),
   role: PersonnelRoleEnum,
+  companyId: z.string().uuid().optional(),
 });
 
 const UpdatePersonnelSchema = z.object({
@@ -35,6 +36,7 @@ const UpdatePersonnelSchema = z.object({
   mobile: z.string().optional(),
   role: PersonnelRoleEnum.optional(),
   active: z.boolean().optional(),
+  companyId: z.string().uuid().nullable().optional(),
 });
 
 // POST /api/personnel - Create personnel


### PR DESCRIPTION
## Summary
Fixes two schema bugs found during requirement acceptance review.

### #487 — Personnel missing Company FK
- Added `companyId` (optional) FK to Company on Personnel model
- Updated repository queries to include `credentials` and `company`
- Updated Zod schemas and interface to accept `companyId`

### #488 — Credential missing membershipFull field
- Added `membershipFull` (optional) field to Credential model
- e.g. "Member of NZ Institute of Building Surveyors"

### Migration
`20260225080000_add_personnel_company_fk_and_membership_full`

### Tests
All 31 personnel tests pass.

Fixes #487, fixes #488