### PR TITLE
[Alex] fix(api): add CCC Gap Analysis Handlebars templates (#489)

### DIFF
--- a/api/templates/ccc/appendices/photos.hbs
+++ b/api/templates/ccc/appendices/photos.hbs
@@ -1,0 +1,21 @@
+<section class="appendix" id="appendix-photos">
+  <h2>Appendix: Inspection Photographs</h2>
+
+  {{#if photos}}
+  <div class="photo-grid">
+    {{#each photos}}
+    <figure class="photo-item">
+      <img src="{{path}}" alt="{{caption}}" />
+      <figcaption>
+        <strong>Photo {{photoNumber}}:</strong> {{caption}}
+        {{#if location}}
+        <span class="photo-location">({{location}})</span>
+        {{/if}}
+      </figcaption>
+    </figure>
+    {{/each}}
+  </div>
+  {{else}}
+  <p>No photographs included.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/base.hbs
+++ b/api/templates/ccc/base.hbs
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{project.jobNumber}} — CCC Gap Analysis Report</title>
+  <style>{{{css}}}</style>
+</head>
+<body>
+  {{> header}}
+
+  {{#if tableOfContents}}
+  <nav class="table-of-contents">
+    <h2>Table of Contents</h2>
+    {{{tableOfContents}}}
+  </nav>
+  {{/if}}
+
+  <main class="report-content">
+    {{{sections}}}
+  </main>
+
+  {{#if appendixContent}}
+  <div class="appendices">
+    {{{appendixContent}}}
+  </div>
+  {{/if}}
+
+  {{> footer}}
+</body>
+</html>

--- a/api/templates/ccc/cover.hbs
+++ b/api/templates/ccc/cover.hbs
@@ -1,0 +1,46 @@
+{{!-- Cover Page Template — Issue #489 --}}
+<div class="cover-page">
+  <div class="cover-content">
+    <div class="cover-header">
+      {{#if company.logoPath}}
+        <img src="{{company.logoPath}}" alt="{{company.name}}" class="cover-logo" />
+      {{else}}
+        <div class="cover-logo-placeholder">{{project.company}}</div>
+      {{/if}}
+    </div>
+
+    <div class="cover-title">
+      <h1>CCC Gap Analysis Report</h1>
+    </div>
+
+    <div class="cover-details">
+      <div class="cover-address">{{project.address}}</div>
+      <div class="cover-client">
+        <span class="label">Client:</span> {{project.client}}
+      </div>
+      <div class="cover-job-number">
+        <span class="label">Job Number:</span> {{project.jobNumber}}
+      </div>
+      <div class="cover-date">
+        <span class="label">Date:</span> {{formatDate generatedAt}}
+      </div>
+    </div>
+
+    <div class="cover-footer">
+      <div class="cover-prepared-by">
+        <span class="label">Prepared by:</span> {{personnel.author.name}}
+        {{#if personnel.author.credentials}}
+          <span class="credentials">({{personnel.author.credentials}})</span>
+        {{/if}}
+      </div>
+      {{#if personnel.reviewer}}
+        <div class="cover-reviewed-by">
+          <span class="label">Reviewed by:</span> {{personnel.reviewer.name}}
+          {{#if personnel.reviewer.credentials}}
+            <span class="credentials">({{personnel.reviewer.credentials}})</span>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/api/templates/ccc/sections/01-executive-summary.hbs
+++ b/api/templates/ccc/sections/01-executive-summary.hbs
@@ -1,0 +1,40 @@
+<section class="report-section" id="section-1">
+  <h2>1. Executive Summary</h2>
+
+  <table class="summary-table">
+    <tr><th>Job Number</th><td>{{project.jobNumber}}</td></tr>
+    <tr><th>Activity</th><td>{{project.activity}}</td></tr>
+    <tr><th>Address</th><td>{{project.address}}</td></tr>
+    <tr><th>Client</th><td>{{project.client}}</td></tr>
+    <tr><th>Inspection Date</th><td>{{formatDate inspection.date}}</td></tr>
+    <tr><th>Weather</th><td>{{inspection.weather}}</td></tr>
+  </table>
+
+  <h3>Personnel</h3>
+  <table class="personnel-table">
+    <tr>
+      <th>Prepared By</th>
+      <td>{{personnel.author.name}} — {{personnel.author.credentials}}</td>
+    </tr>
+    {{#if personnel.reviewer}}
+    <tr>
+      <th>Reviewed By</th>
+      <td>{{personnel.reviewer.name}} — {{personnel.reviewer.credentials}}</td>
+    </tr>
+    {{/if}}
+  </table>
+
+  {{#if personnel.inspectors}}
+  <h3>Inspection Team</h3>
+  <ul>
+    {{#each personnel.inspectors}}
+    <li>{{name}} — {{role}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if defects}}
+  <h3>Summary of Findings</h3>
+  <p>This inspection identified <strong>{{defects.length}}</strong> defect(s) requiring attention.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/02-introduction.hbs
+++ b/api/templates/ccc/sections/02-introduction.hbs
@@ -1,0 +1,18 @@
+<section class="report-section" id="section-2">
+  <h2>2. Introduction</h2>
+
+  <p>This CCC Gap Analysis Report has been prepared to identify outstanding items and defects
+  that must be addressed prior to the issuance of a Code Compliance Certificate (CCC) for the
+  building work at <strong>{{project.address}}</strong>.</p>
+
+  <p>The purpose of this report is to document the current state of the building work, identify
+  any defects or non-compliances, and provide recommendations for remedial action to achieve
+  compliance with the New Zealand Building Code.</p>
+
+  <p>The inspection was carried out on <strong>{{formatDate inspection.date}}</strong>
+  by <strong>{{personnel.author.name}}</strong> ({{personnel.author.credentials}}).</p>
+
+  {{#if inspection.weather}}
+  <p>Weather conditions at the time of inspection: <strong>{{inspection.weather}}</strong>.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/03-general-information.hbs
+++ b/api/templates/ccc/sections/03-general-information.hbs
@@ -1,0 +1,41 @@
+<section class="report-section" id="section-3">
+  <h2>3. General Information</h2>
+
+  <h3>Property Details</h3>
+  <table class="property-table">
+    <tr><th>Legal Description</th><td>{{property.lotDp}}</td></tr>
+    <tr><th>Council Property ID</th><td>{{property.councilPropertyId}}</td></tr>
+    {{#if property.construction}}
+    <tr><th>Construction Type</th><td>{{property.construction}}</td></tr>
+    {{/if}}
+    {{#if property.yearBuilt}}
+    <tr><th>Year Built</th><td>{{property.yearBuilt}}</td></tr>
+    {{/if}}
+  </table>
+
+  {{#if buildingHistory}}
+  <h3>Building History</h3>
+  <table class="history-table">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reference</th>
+        <th>Year</th>
+        <th>Status</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each buildingHistory}}
+      <tr>
+        <td>{{type}}</td>
+        <td>{{reference}}</td>
+        <td>{{year}}</td>
+        <td>{{status}}</td>
+        <td>{{description}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/04-defect-schedule.hbs
+++ b/api/templates/ccc/sections/04-defect-schedule.hbs
@@ -1,0 +1,42 @@
+<section class="report-section" id="section-4">
+  <h2>4. Defect Schedule</h2>
+
+  {{#if defects}}
+  <p>The following defects were identified during the inspection:</p>
+
+  {{#each defects}}
+  <div class="defect-item">
+    <h3>Defect {{defectNumber}}</h3>
+    <table class="defect-table">
+      <tr><th>Location</th><td>{{location}}</td></tr>
+      <tr><th>Element</th><td>{{element}}</td></tr>
+      <tr><th>Description</th><td>{{description}}</td></tr>
+      {{#if cause}}
+      <tr><th>Probable Cause</th><td>{{cause}}</td></tr>
+      {{/if}}
+      <tr><th>Remedial Action</th><td>{{remedialAction}}</td></tr>
+      <tr><th>Priority</th><td class="priority-{{lowercase priority}}">{{priority}}</td></tr>
+    </table>
+
+    {{#if photos}}
+    <div class="defect-photos">
+      <h4>Supporting Photographs</h4>
+      <div class="photo-grid">
+        {{#each photos}}
+        <figure class="photo-item">
+          <img src="{{path}}" alt="{{caption}}" />
+          <figcaption>
+            <strong>Photo {{photoNumber}}:</strong> {{caption}}
+          </figcaption>
+        </figure>
+        {{/each}}
+      </div>
+    </div>
+    {{/if}}
+  </div>
+  {{/each}}
+
+  {{else}}
+  <p>No defects were identified during the inspection.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/05-moisture-readings.hbs
+++ b/api/templates/ccc/sections/05-moisture-readings.hbs
@@ -1,0 +1,44 @@
+<section class="report-section" id="section-5">
+  <h2>5. Moisture Readings</h2>
+
+  {{#if moistureReadings}}
+  <p>The following moisture readings were recorded during the inspection:</p>
+
+  <table class="moisture-table">
+    <thead>
+      <tr>
+        <th>Location</th>
+        <th>Substrate</th>
+        <th>Reading (%)</th>
+        <th>Depth (mm)</th>
+        <th>Result</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each moistureReadings}}
+      <tr class="moisture-{{lowercase result}}">
+        <td>{{location}}</td>
+        <td>{{substrate}}</td>
+        <td>{{reading}}</td>
+        <td>{{depth}}</td>
+        <td class="result-{{lowercase result}}">{{result}}</td>
+        <td>{{notes}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  <div class="moisture-legend">
+    <h4>Result Legend</h4>
+    <ul>
+      <li><span class="legend-acceptable">ACCEPTABLE</span> — Moisture levels within normal range</li>
+      <li><span class="legend-marginal">MARGINAL</span> — Elevated moisture levels requiring monitoring</li>
+      <li><span class="legend-unacceptable">UNACCEPTABLE</span> — Moisture levels exceeding acceptable limits</li>
+    </ul>
+  </div>
+
+  {{else}}
+  <p>No moisture readings were taken during this inspection.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/06-cost-estimate.hbs
+++ b/api/templates/ccc/sections/06-cost-estimate.hbs
@@ -1,0 +1,58 @@
+<section class="report-section" id="section-6">
+  <h2>6. Cost Estimate</h2>
+
+  {{#if costEstimate}}
+  <p>The following cost estimate has been prepared for the remedial works required:</p>
+
+  {{#if costEstimate.lineItems}}
+  <table class="cost-table">
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Description</th>
+        <th>Qty</th>
+        <th>Unit</th>
+        <th>Rate ($)</th>
+        <th>Amount ($)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each costEstimate.lineItems}}
+      <tr>
+        <td>{{category}}</td>
+        <td>{{description}}</td>
+        <td>{{quantity}}</td>
+        <td>{{unit}}</td>
+        <td class="currency">{{formatCurrency rate}}</td>
+        <td class="currency">{{formatCurrency amount}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+    <tfoot>
+      <tr class="subtotal-row">
+        <td colspan="5">Subtotal</td>
+        <td class="currency">{{formatCurrency costEstimate.subtotal}}</td>
+      </tr>
+      {{#if costEstimate.contingencyRate}}
+      <tr class="contingency-row">
+        <td colspan="5">Contingency ({{costEstimate.contingencyRate}}%)</td>
+        <td class="currency">{{formatCurrency costEstimate.contingencyAmount}}</td>
+      </tr>
+      {{/if}}
+      <tr class="total-row">
+        <td colspan="5"><strong>Total (excl. GST)</strong></td>
+        <td class="currency"><strong>{{formatCurrency costEstimate.totalExGst}}</strong></td>
+      </tr>
+    </tfoot>
+  </table>
+  {{/if}}
+
+  {{#if costEstimate.notes}}
+  <h3>Notes</h3>
+  <p>{{costEstimate.notes}}</p>
+  {{/if}}
+
+  {{else}}
+  <p>No cost estimate has been prepared for this report.</p>
+  {{/if}}
+</section>

--- a/api/templates/ccc/sections/07-signatures.hbs
+++ b/api/templates/ccc/sections/07-signatures.hbs
@@ -1,0 +1,27 @@
+<section class="report-section signatures" id="section-7">
+  <h2>7. Declaration &amp; Signatures</h2>
+
+  <p>I/we declare that this report has been prepared in accordance with recognised inspection
+  practices and that the observations and conclusions contained herein are accurate to the
+  best of our knowledge.</p>
+
+  <div class="signature-blocks">
+    <div class="signature-block">
+      <h3>Prepared By</h3>
+      <div class="signature-line"></div>
+      <p class="sig-name">{{personnel.author.name}}</p>
+      <p class="sig-credentials">{{personnel.author.credentials}}</p>
+      <p class="sig-date">Date: {{formatDate generatedAt}}</p>
+    </div>
+
+    {{#if personnel.reviewer}}
+    <div class="signature-block">
+      <h3>Reviewed By</h3>
+      <div class="signature-line"></div>
+      <p class="sig-name">{{personnel.reviewer.name}}</p>
+      <p class="sig-credentials">{{personnel.reviewer.credentials}}</p>
+      <p class="sig-date">Date: {{formatDate generatedAt}}</p>
+    </div>
+    {{/if}}
+  </div>
+</section>

--- a/api/templates/ccc/styles/report.css
+++ b/api/templates/ccc/styles/report.css
@@ -1,0 +1,387 @@
+/* CCC Gap Analysis Report — Print-Optimized Styles */
+
+/* ─── Page Setup ─── */
+@page {
+  size: A4;
+  margin: 25mm 20mm;
+}
+
+@media print {
+  body { margin: 0; }
+  .report-section { page-break-inside: avoid; }
+  .appendix { page-break-before: always; }
+  .signatures { page-break-before: always; }
+  .photo-item { page-break-inside: avoid; }
+  .defect-item { page-break-inside: avoid; }
+}
+
+/* ─── Base ─── */
+body {
+  font-family: 'Arial', 'Helvetica Neue', sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #1a1a1a;
+  max-width: 210mm;
+  margin: 0 auto;
+}
+
+h1 { font-size: 20pt; margin-bottom: 4mm; color: #003366; }
+h2 { font-size: 14pt; margin-top: 8mm; margin-bottom: 4mm; color: #003366; border-bottom: 1px solid #003366; padding-bottom: 2mm; }
+h3 { font-size: 12pt; margin-top: 6mm; margin-bottom: 3mm; color: #333; }
+h4 { font-size: 11pt; margin-top: 4mm; margin-bottom: 2mm; color: #333; }
+
+p { margin: 3mm 0; }
+
+/* ─── Header / Footer ─── */
+.report-header {
+  border-bottom: 2px solid #003366;
+  padding-bottom: 4mm;
+  margin-bottom: 8mm;
+}
+
+.report-header h1 { margin: 0; }
+.job-number { font-size: 12pt; color: #666; margin: 1mm 0; }
+.report-date { font-size: 10pt; color: #666; }
+
+.report-footer {
+  margin-top: 10mm;
+  padding-top: 4mm;
+  border-top: 1px solid #ccc;
+  font-size: 9pt;
+  color: #666;
+  text-align: center;
+}
+
+.confidential { font-weight: bold; text-transform: uppercase; letter-spacing: 0.5mm; }
+
+/* ─── Tables ─── */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 4mm 0;
+  font-size: 10pt;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 2mm 3mm;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #f0f4f8;
+  font-weight: bold;
+  color: #003366;
+}
+
+.summary-table th { width: 35%; }
+.property-table th { width: 35%; }
+.personnel-table th { width: 25%; }
+.history-table th { background: #003366; color: white; }
+
+/* ─── Defect Schedule ─── */
+.defect-item {
+  margin: 6mm 0;
+  padding: 4mm;
+  border: 1px solid #ddd;
+  border-radius: 2mm;
+  background: #fafafa;
+}
+
+.defect-item h3 {
+  margin-top: 0;
+  color: #003366;
+  border-bottom: 1px solid #003366;
+  padding-bottom: 2mm;
+}
+
+.defect-table th { width: 25%; }
+.defect-table td { width: 75%; }
+
+.defect-photos {
+  margin-top: 4mm;
+}
+
+.defect-photos h4 {
+  margin-bottom: 2mm;
+}
+
+/* Priority Styling */
+.priority-high { color: #c0392b; font-weight: bold; }
+.priority-medium { color: #e67e22; font-weight: bold; }
+.priority-low { color: #27ae60; }
+
+/* ─── Moisture Readings Table ─── */
+.moisture-table th { background: #003366; color: white; font-size: 9pt; }
+.moisture-table td { text-align: center; }
+.moisture-table td:first-child { text-align: left; }
+
+/* Result Color Coding */
+.result-acceptable { background: #d4edda; color: #155724; font-weight: bold; }
+.result-marginal { background: #fff3cd; color: #856404; font-weight: bold; }
+.result-unacceptable { background: #f8d7da; color: #721c24; font-weight: bold; }
+
+.moisture-acceptable { background: #f8fff8; }
+.moisture-marginal { background: #fffef8; }
+.moisture-unacceptable { background: #fff8f8; }
+
+.moisture-legend {
+  margin-top: 4mm;
+  padding: 3mm;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  font-size: 9pt;
+}
+
+.moisture-legend h4 {
+  margin: 0 0 2mm 0;
+  font-size: 10pt;
+}
+
+.moisture-legend ul {
+  margin: 0;
+  padding-left: 5mm;
+}
+
+.moisture-legend li { margin: 1mm 0; }
+
+.legend-acceptable {
+  display: inline-block;
+  padding: 1mm 2mm;
+  background: #d4edda;
+  color: #155724;
+  font-weight: bold;
+  font-size: 8pt;
+}
+
+.legend-marginal {
+  display: inline-block;
+  padding: 1mm 2mm;
+  background: #fff3cd;
+  color: #856404;
+  font-weight: bold;
+  font-size: 8pt;
+}
+
+.legend-unacceptable {
+  display: inline-block;
+  padding: 1mm 2mm;
+  background: #f8d7da;
+  color: #721c24;
+  font-weight: bold;
+  font-size: 8pt;
+}
+
+/* ─── Cost Estimate Table ─── */
+.cost-table th { background: #003366; color: white; font-size: 9pt; }
+.cost-table .currency { text-align: right; font-family: 'Courier New', monospace; }
+
+.cost-table tfoot td {
+  background: #f0f4f8;
+  font-weight: bold;
+}
+
+.subtotal-row td { border-top: 2px solid #003366; }
+.contingency-row td { font-style: italic; }
+.total-row td {
+  background: #003366;
+  color: white;
+  font-size: 11pt;
+}
+
+/* ─── Signatures ─── */
+.signature-blocks {
+  display: flex;
+  gap: 20mm;
+  margin-top: 10mm;
+}
+
+.signature-block {
+  flex: 1;
+}
+
+.signature-line {
+  border-bottom: 1px solid #333;
+  height: 15mm;
+  margin-bottom: 2mm;
+}
+
+.sig-name { font-weight: bold; margin: 1mm 0; }
+.sig-credentials { font-size: 10pt; color: #666; margin: 1mm 0; }
+.sig-date { font-size: 10pt; color: #666; margin: 1mm 0; }
+
+/* ─── Photo Grid ─── */
+.photo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6mm;
+  margin: 4mm 0;
+}
+
+.photo-item {
+  border: 1px solid #ddd;
+  padding: 2mm;
+}
+
+.photo-item img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.photo-item figcaption {
+  font-size: 9pt;
+  padding: 2mm 0;
+  text-align: center;
+}
+
+.photo-location { color: #666; font-style: italic; }
+
+/* ─── Cover Page ─── */
+.cover-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 20mm;
+}
+
+.cover-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15mm;
+  max-width: 160mm;
+}
+
+.cover-header {
+  margin-bottom: 10mm;
+}
+
+.cover-logo {
+  max-width: 80mm;
+  max-height: 30mm;
+  object-fit: contain;
+}
+
+.cover-logo-placeholder {
+  font-size: 18pt;
+  font-weight: bold;
+  color: #003366;
+  padding: 10mm 20mm;
+  border: 2px solid #003366;
+}
+
+.cover-title h1 {
+  font-size: 24pt;
+  color: #003366;
+  margin: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.cover-details {
+  margin: 10mm 0;
+}
+
+.cover-address {
+  font-size: 16pt;
+  font-weight: bold;
+  margin-bottom: 8mm;
+  color: #1a1a1a;
+}
+
+.cover-client,
+.cover-job-number,
+.cover-date {
+  font-size: 12pt;
+  margin: 3mm 0;
+  color: #333;
+}
+
+.cover-details .label,
+.cover-footer .label {
+  font-weight: bold;
+  color: #003366;
+}
+
+.cover-footer {
+  margin-top: 20mm;
+  padding-top: 10mm;
+  border-top: 1px solid #ccc;
+}
+
+.cover-prepared-by,
+.cover-reviewed-by {
+  font-size: 11pt;
+  margin: 3mm 0;
+}
+
+.cover-footer .credentials {
+  font-size: 10pt;
+  color: #666;
+}
+
+/* ─── Table of Contents ─── */
+.table-of-contents {
+  margin: 8mm 0;
+  padding: 6mm;
+}
+
+.table-of-contents h2 {
+  font-size: 14pt;
+  color: #003366;
+  margin-bottom: 6mm;
+  border-bottom: 1px solid #003366;
+  padding-bottom: 2mm;
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-entry {
+  display: flex;
+  align-items: baseline;
+  padding: 2mm 0;
+  border-bottom: 1px dotted #ccc;
+}
+
+.toc-number {
+  font-weight: bold;
+  color: #003366;
+  min-width: 8mm;
+}
+
+.toc-title {
+  flex: 1;
+}
+
+.toc-link {
+  display: flex;
+  align-items: baseline;
+  width: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.toc-link:hover {
+  color: #003366;
+  text-decoration: underline;
+}
+
+/* ─── Print: Cover & TOC Pages ─── */
+@media print {
+  .cover-page {
+    page-break-after: always;
+  }
+
+  .table-of-contents {
+    page-break-after: always;
+  }
+}


### PR DESCRIPTION
## Summary
Creates the full set of CCC Gap Analysis .hbs rendering templates, analogous to the existing COA templates.

### Files Created
```
api/templates/ccc/
  base.hbs
  cover.hbs
  sections/
    01-executive-summary.hbs
    02-introduction.hbs
    03-general-information.hbs   (property + building history)
    04-defect-schedule.hbs       (defect table with photos)
    05-moisture-readings.hbs     (color-coded results table)
    06-cost-estimate.hbs         (line items + contingency + total)
    07-signatures.hbs
  appendices/
    photos.hbs
  styles/
    report.css
```

### Data Context
Templates consume: project, property, personnel, inspection, defects[], moistureReadings[], costEstimate, buildingHistory[], photos[]

Fixes #489