### PR TITLE
[Alex] docs(skill): update SKILL.md to match actual MCP tool implementations

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,77 +1,216 @@
 ---
 name: building-inspection
-description: Guide building inspectors through property inspections via WhatsApp. Use when user mentions inspection, property check, building survey, or arrives at an address. Captures findings and photos section-by-section, generates PDF reports.
+description: Guide building inspectors through property inspections via WhatsApp. Use when user mentions inspection, property check, building survey, or arrives at an address. Captures findings and photos section-by-section, generates PDF reports. Supports both Simple (Pass/Fail) and Clause Review (COA/CCC) inspection modes.
 ---
 
 # Building Inspection Assistant
 
-Guide inspectors through NZS4306-style residential property inspections. Capture findings and photos, generate professional PDF reports.
+Guide inspectors through NZS4306-style residential property inspections. Capture findings and photos, generate professional PDF reports. Supports two inspection types:
+
+- **Pre-Purchase Inspection (PPI):** Standard property inspection with section-by-section walkthrough
+- **Site Inspection:** Simple (Pass/Fail) checklist or Clause Review (COA/CCC) against building code
 
 ## Workflow
 
 ### 1. Start Inspection
 
+**Pre-Purchase Inspection:**
+
 When inspector mentions an address or says "starting inspection":
 
 ```
-→ Call start_inspection(address, inspector_name?)
+→ Call inspection_start(address, client_name, inspector_name?, checklist?, metadata?)
 ← Confirm address, announce first section
 ```
 
+**Parameters:**
+- `address` (string, required) — Property address
+- `client_name` (string, required) — Client name
+- `inspector_name` (string, optional) — Inspector name
+- `checklist` (string, optional) — Checklist ID (default: `nz-ppi`)
+- `metadata` (object, optional) — `{ property_type?, bedrooms?, bathrooms?, year_built? }`
+
 **Example:**
-- Inspector: "I'm at 45 Oak Avenue"
-- You: Call `start_inspection({ address: "45 Oak Avenue" })`
+- Inspector: "I'm at 45 Oak Avenue for the Smith inspection"
+- You: Call `inspection_start({ address: "45 Oak Avenue", client_name: "Smith" })`
 - Response: "Starting inspection at **45 Oak Avenue**. First up: **Exterior**. Check roof, gutters, cladding, external walls. Send photos of any issues."
 
+**Site Inspection:**
+
+For council or compliance inspections:
+
+```
+→ Call site_inspection_start(project_id, type, stage, inspector_name, weather?)
+← Confirm type and first section/clause
+```
+
+**Parameters:**
+- `project_id` (uuid, required) — Project to attach inspection to
+- `type` (enum, required) — `SIMPLE` for Pass/Fail checklist, `CLAUSE_REVIEW` for COA/CCC
+- `stage` (string, required) — Inspection stage (e.g., `INS_05`, `COA`, `CCC_GA`)
+- `inspector_name` (string, required) — Inspector name
+- `weather` (string, optional) — Weather conditions
+
+**Example (Simple):**
+- You: Call `site_inspection_start({ project_id: "...", type: "SIMPLE", stage: "INS_05", inspector_name: "John" })`
+- Response: "Simple checklist inspection started. First category: **Exterior** — check roof cladding, wall cladding, window flashings."
+
+**Example (Clause Review):**
+- You: Call `site_inspection_start({ project_id: "...", type: "CLAUSE_REVIEW", stage: "COA", inspector_name: "John" })`
+- Response: "Clause review inspection started. First clause: **B1 Structure** — check structural elements and foundations."
+
 ### 2. Capture Findings
+
+**Pre-Purchase Inspection:**
 
 When inspector sends text or photos about issues:
 
 ```
-→ Call add_finding(section, description, severity?)
-→ If photo attached, call add_photo(section, caption, photo_url)
+→ Call inspection_add_finding(inspection_id, text, section?, photos?, severity?)
 ← Confirm what was captured, prompt for more or next section
 ```
 
-**Severity levels:** info, minor, major, critical
+**Parameters:**
+- `inspection_id` (uuid, required) — Active inspection ID
+- `text` (string, required) — Description of the finding
+- `section` (string, optional) — Section ID (defaults to current section)
+- `photos` (array, optional) — Inline photos: `[{ data: "<base64>", filename?, mime_type? }]`
+- `severity` (enum, optional) — `info` | `minor` | `major` | `urgent` (default: `info`)
+
+Photos are attached **inline** with the finding — no separate photo upload tool needed.
 
 **Example:**
 - Inspector: "Gutters rusted on north side" [photo]
-- You: Call `add_finding({ section: "exterior", description: "Gutters rusted on north side", severity: "minor" })`
-- You: Call `add_photo({ section: "exterior", caption: "Rusted gutters - north side", photo_url: "..." })`
+- You: Call `inspection_add_finding({ inspection_id: "...", text: "Gutters rusted on north side", severity: "minor", photos: [{ data: "<base64>", filename: "gutters.jpg" }] })`
 - Response: "Noted — rusted gutters, north side (minor). Photo saved. Anything else for Exterior?"
 
+**Site Inspection — Simple Mode:**
+
+```
+→ Call site_inspection_add_finding(inspection_id, category, item, decision, notes?, photos?)
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Active inspection ID
+- `category` (enum, required) — `EXTERIOR` | `INTERIOR` | `DECKS` | `SERVICES` | `SITE`
+- `item` (string, required) — Checklist item name
+- `decision` (enum, required) — `PASS` | `FAIL` | `NA`
+- `notes` (string, optional) — Observations
+- `photos` (array, optional) — Inline photos: `[{ data: "<base64>", caption? }]`
+- `photo_ids` (array, optional) — Existing photo UUIDs to attach
+
+**Example:**
+- Inspector: "Roof cladding is good"
+- You: Call `site_inspection_add_finding({ inspection_id: "...", category: "EXTERIOR", item: "Roof cladding / flashings", decision: "PASS" })`
+
+**Site Inspection — Clause Review Mode:**
+
+```
+→ Call site_inspection_add_finding(inspection_id, clause_id, applicability, na_reason?, notes?, photos?)
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Active inspection ID
+- `clause_id` (uuid, required) — Building code clause ID
+- `applicability` (enum, required) — `APPLICABLE` | `NA`
+- `na_reason` (string, optional) — Reason if N/A
+- `notes` (string, optional) — Observations
+- `photos` (array, optional) — Inline photos: `[{ data: "<base64>", caption? }]`
+- `photo_ids` (array, optional) — Existing photo UUIDs to attach
+
+**Example:**
+- Inspector: "B1 Structure looks fine, foundations are solid"
+- You: Call `site_inspection_add_finding({ inspection_id: "...", clause_id: "...", applicability: "APPLICABLE", notes: "Foundations solid, no visible cracking" })`
+
 ### 3. Navigate Sections
+
+Use `inspection_navigate` to move between sections (PPI inspections):
+
+```
+→ Call inspection_navigate(inspection_id, section)
+← Section details with items and prompt
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Active inspection ID
+- `section` (string, required) — Section ID to navigate to
 
 **Commands to recognize:**
 | User says | Action |
 |-----------|--------|
-| "next" / "move on" / "done with this" | `go_to_section({ section: "next" })` |
-| "back to exterior" | `go_to_section({ section: "exterior" })` |
-| "skip" / "skip this section" | `go_to_section({ section: "skip" })` |
-| "where am I" / "status" | `get_status()` |
+| "next" / "move on" / "done with this" | Navigate to next section |
+| "back to exterior" | `inspection_navigate({ inspection_id: "...", section: "exterior" })` |
+| "where am I" / "status" | `inspection_status({ inspection_id: "..." })` |
 
 **Section order:** Exterior → Subfloor → Interior → Kitchen → Bathroom → Electrical → Plumbing → Roof Space
 
-### 4. Complete Inspection
+### 4. Get Suggestions
+
+Use `inspection_suggest_next` for AI-guided next steps:
+
+```
+→ Call inspection_suggest_next(inspection_id)
+← Remaining sections, suggested next section, completion readiness
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Active inspection ID
+
+**Returns:** Current section, remaining sections, whether inspection can be completed, and a suggestion for what to do next.
+
+### 5. Check Status
+
+**Pre-Purchase Inspection:**
+
+```
+→ Call inspection_status(inspection_id)
+← Full progress with section breakdown and finding counts
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Inspection ID
+
+**Site Inspection:**
+
+```
+→ Call site_inspection_status(inspection_id)
+← Progress summary with type-specific details (checklist or clause completion)
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Site inspection ID
+
+### 6. Complete Inspection
 
 When inspector says "done", "finished", or "generate report":
 
 ```
-→ Call complete_inspection(summary?)
-← Send summary + PDF report
+→ Call inspection_complete(inspection_id, summary_notes?, weather?)
+← Summary stats + PDF report info
 ```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Inspection ID
+- `summary_notes` (string, optional) — Overall summary
+- `weather` (string, optional) — Weather conditions
 
 **Example:**
 - Inspector: "That's everything, generate the report"
-- You: Call `complete_inspection()`
-- Response: "Inspection complete! Summary:
-  - Exterior: 2 issues, 3 photos
-  - Subfloor: No issues
-  - Interior: 1 issue, 1 photo
-  ...
-  Generating PDF report now..."
-- [Send PDF file]
+- You: Call `inspection_complete({ inspection_id: "..." })`
+- Response: "Inspection complete! 5 findings (1 urgent, 2 major, 2 minor). PDF report generated."
+
+### 7. Retrieve Report
+
+To get a previously generated report:
+
+```
+→ Call inspection_get_report(inspection_id, format?)
+← Report metadata and download URL
+```
+
+**Parameters:**
+- `inspection_id` (uuid, required) — Inspection ID
+- `format` (enum, optional) — `pdf` | `markdown` (default: `pdf`)
 
 ## Key Behaviors
 
@@ -79,7 +218,7 @@ When inspector says "done", "finished", or "generate report":
 2. **Stay concise** — Inspector is on-site, keep responses short
 3. **Infer section** — If finding doesn't specify section, use current section
 4. **Handle corrections** — "Actually that was major not minor" → update severity
-5. **Photos with findings** — Associate photos with the most recent finding when possible
+5. **Photos inline** — Photos go inside `inspection_add_finding` as base64, not as separate calls
 
 ## Section Prompts
 
@@ -150,7 +289,7 @@ For inspections lasting 30+ minutes or 20+ messages, proactively summarize progr
 ### Checkpoint Recovery
 
 If conversation resumes after interruption:
-1. Call `get_status()` to check active inspection
+1. Call `inspection_status()` to check active inspection
 2. Summarize where we left off
 3. Prompt to continue: "Ready to continue with [section]?"
 
@@ -161,7 +300,7 @@ If conversation resumes after interruption:
 | No active inspection | "No inspection in progress. Tell me the address to start." |
 | Unclear section | "Which section is this for? Currently on [section]." |
 | Photo without context | "Got the photo. What does it show?" |
-| Want to resume | Call `get_status()` to check for active inspection |
+| Want to resume | Call `inspection_status()` to check for active inspection |
 | API failure | "Trouble saving that. Trying again..." (retry up to 2x) |
 | Photo processing failed | "Couldn't process that photo. Can you send it again?" |
 | Network timeout | "Connection hiccup. Give me a moment..." (retry) |
@@ -170,9 +309,13 @@ If conversation resumes after interruption:
 
 | Tool | Purpose |
 |------|---------|
-| `start_inspection` | Begin new inspection at address |
-| `add_finding` | Record issue with severity |
-| `add_photo` | Attach photo to section/finding |
-| `go_to_section` | Navigate between sections |
-| `get_status` | Check progress and current section |
-| `complete_inspection` | Finish and generate PDF |
+| `inspection_start` | Begin new PPI at address |
+| `inspection_status` | Check PPI progress and current section |
+| `inspection_add_finding` | Record finding with optional inline photos |
+| `inspection_navigate` | Navigate between sections |
+| `inspection_suggest_next` | Get AI-guided next steps |
+| `inspection_complete` | Finish inspection and generate PDF |
+| `inspection_get_report` | Retrieve a generated report |
+| `site_inspection_start` | Begin site inspection (Simple or Clause Review) |
+| `site_inspection_status` | Check site inspection progress |
+| `site_inspection_add_finding` | Record checklist item or clause review |


### PR DESCRIPTION
## Summary
Updates `skill/SKILL.md` to match the actual MCP server tool implementations in `server/src/tools/`.

## Changes
- Fixed all 7 existing tool names (e.g. `start_inspection` → `inspection_start`)
- Added 3 missing tools: `inspection_get_report`, `inspection_suggest_next`, `site_inspection_start`/`site_inspection_status`/`site_inspection_add_finding`
- Documented Simple (Pass/Fail) vs Clause Review (COA/CCC) modes for site inspections
- Fixed photo handling: inline base64 in `inspection_add_finding`, not separate tool
- Added correct Zod schema parameters for all 10 tools
- Updated Tool Reference table with all 10 tools

Closes #508