### PR TITLE
[Alex] chore(ci): skip CI/CD for docs-only changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "skill/**"
   workflow_dispatch:  # Allow manual triggers
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "skill/**"
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "skill/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Skip CI/CD pipeline for documentation-only changes.

## Changes
Added `paths-ignore` to both CI and CD workflows:
- `docs/**` — documentation folder
- `*.md` — root level markdown files  
- `skill/**` — skill documentation

## Behavior
| Change Type | CI | CD |
|-------------|----|----|
| Docs only | ⏭️ Skip | ⏭️ Skip |
| Code only | ✅ Run | ✅ Run |
| Mixed (docs + code) | ✅ Run | ✅ Run |

Closes #510