### PR TITLE
[Alex] fix(api): move interaction-logs route before generic /api handlers

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -82,6 +82,7 @@ app.use('/api/auth', authRouter);
 
 // Service routes (JWT or API key auth)
 app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);
+app.use('/api/interaction-logs', serviceAuthMiddleware, interactionLogsRouter);
 
 // Protected routes (auth required)
 app.use('/api/inspections', authMiddleware, inspectionsRouter);
@@ -114,7 +115,6 @@ app.use('/api', authMiddleware, reportTemplatesRouter);
 app.use('/api', authMiddleware, reviewCommentsRouter);
 app.use('/api/reports', authMiddleware, generatedReportsRouter);
 app.use('/api', authMiddleware, credentialsRouter);
-app.use('/api/interaction-logs', serviceAuthMiddleware, interactionLogsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {


### PR DESCRIPTION
## Summary
Fix for #512 — route was unreachable because Express matched `/api` prefix first.

## Problem
Casey found that `POST /api/interaction-logs` with API key auth returned 401 because:
1. `app.use('/api/interaction-logs', serviceAuthMiddleware, ...)` was registered after
2. `app.use('/api', authMiddleware, ...)` handlers
3. Express matched `/api` first → `authMiddleware` rejected with 401

## Fix
Move to Service routes section (before generic `/api` handlers):
```typescript
// Service routes (JWT or API key auth)
app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);
app.use('/api/interaction-logs', serviceAuthMiddleware, interactionLogsRouter);

// Protected routes (auth required)  
app.use('/api/inspections', authMiddleware, inspectionsRouter);
```

Fixes tested-fail from #512