### PR TITLE
[Sam] feat(web): allow saving phone without WhatsApp verification

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -685,6 +685,7 @@ function setTokenCookie(res: Response, token: string): void {
 // ============================================
 
 const UpdateProfileSchema = z.object({
+  phoneNumber: z.string().regex(/^\+?[1-9]\d{9,14}$/, "Invalid phone number format").optional().nullable(),
   name: z.string().min(1, 'Name is required').max(100, 'Name too long').optional(),
   email: z.string().email('Invalid email format').optional(),
   company: z.string().max(100, 'Company name too long').optional().nullable(),
@@ -768,7 +769,13 @@ authRouter.patch('/profile', async (req: Request, res: Response) => {
       return;
     }
 
-    const { name, email, company } = parsed.data;
+    const { name, email, company, phoneNumber } = parsed.data;
+
+    // Get current user to check for changes
+    const currentUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { phoneNumber: true },
+    });
 
     // Check if email is being changed and if it's already taken
     if (email) {
@@ -782,10 +789,35 @@ authRouter.patch('/profile', async (req: Request, res: Response) => {
       }
     }
 
-    const updateData: { name?: string; email?: string; company?: string | null } = {};
+    // Check if phone number is being changed and if it's already taken
+    if (phoneNumber) {
+      const existingUser = await prisma.user.findUnique({
+        where: { phoneNumber },
+      });
+
+      if (existingUser && existingUser.id !== userId) {
+        res.status(409).json({ error: 'Phone number already in use' });
+        return;
+      }
+    }
+
+    const updateData: { 
+      name?: string; 
+      email?: string; 
+      company?: string | null;
+      phoneNumber?: string | null;
+      phoneVerified?: boolean;
+    } = {};
     if (name !== undefined) updateData.name = name;
     if (email !== undefined) updateData.email = email.toLowerCase();
     if (company !== undefined) updateData.company = company;
+    if (phoneNumber !== undefined) {
+      updateData.phoneNumber = phoneNumber;
+      // Clear verification if phone number changed
+      if (phoneNumber !== currentUser?.phoneNumber) {
+        updateData.phoneVerified = false;
+      }
+    }
 
     const user = await prisma.user.update({
       where: { id: userId },

--- a/docs/design/ui/profile-phone.spec.yaml
+++ b/docs/design/ui/profile-phone.spec.yaml
@@ -1,0 +1,92 @@
+# Profile Phone Field Update — Issue #517
+# Allow saving phone without verification, separate verify action
+
+metadata:
+  issue: 517
+  parent: 515
+  route: /profile
+  created: "2026-02-28"
+  author: "Sam"
+
+# =============================================================================
+# CHANGE SUMMARY
+# =============================================================================
+summary: |
+  Modify profile page to:
+  1. Move phone number into the main account form (saveable without verification)
+  2. Add inline "Verify" button beside phone field
+  3. Show verification status indicator
+
+# =============================================================================
+# PHONE FIELD (IN ACCOUNT FORM)
+# =============================================================================
+phone-field:
+  layout: "flex gap-2 items-start"
+  
+  input:
+    container: "flex-1"
+    label: "Phone Number"
+    type: tel
+    placeholder: "+64 21 123 4567"
+    helper: "Include country code. Optional — enables WhatsApp inspections when verified."
+    style: "block w-full h-11 px-3 border border-gray-200 rounded-lg ..."
+  
+  verify-button:
+    container: "flex-shrink-0 pt-7"  # Align with input (below label)
+    states:
+      unverified:
+        text: "Verify"
+        style: "h-11 px-4 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 ..."
+        disabled: "when phone is empty or changed from saved value"
+      
+      pending:
+        text: "Verifying..."
+        style: "h-11 px-4 bg-gray-100 text-gray-500 ..."
+        disabled: true
+      
+      verified:
+        text: "Verified"
+        style: "h-11 px-4 bg-green-50 text-green-700 text-sm font-medium rounded-lg border border-green-200 cursor-default"
+        icon: "checkmark"
+
+# =============================================================================
+# VERIFICATION FLOW (INLINE)
+# =============================================================================
+verification-flow:
+  trigger: "Click Verify button"
+  display: "Inline expansion below phone field"
+  
+  container: "mt-3 p-4 bg-gray-50 rounded-lg border border-gray-200"
+  instruction: "Enter the 6-digit code sent to your WhatsApp"
+    
+  code-input:
+    type: text
+    maxLength: 6
+    style: "w-32 h-11 px-3 text-center tracking-widest ..."
+    placeholder: "000000"
+  
+  actions:
+    confirm: "Confirm"
+    cancel: "Cancel"
+    resend: "Resend code"
+
+# =============================================================================
+# API CHANGES
+# =============================================================================
+api:
+  profile-patch:
+    endpoint: "PATCH /api/auth/profile"
+    change: "Add phoneNumber to updateable fields (saves without verification)"
+    fields: [name, email, company, phoneNumber]
+    note: "Changing phone number clears phoneVerified flag"
+  
+  existing-reuse:
+    - "POST /api/auth/link-whatsapp → sends verification code"
+    - "POST /api/auth/verify-whatsapp → verifies code, sets phoneVerified=true"
+
+# =============================================================================
+# REMOVE FROM CURRENT UI
+# =============================================================================
+remove:
+  - "Separate WhatsApp Integration section"
+  - "Unlink WhatsApp button"

--- a/test/e2e/profile.spec.ts
+++ b/test/e2e/profile.spec.ts
@@ -16,6 +16,7 @@ test.describe('Profile Page', () => {
     await expect(page.locator('#email')).toBeVisible();
     await expect(page.locator('#name')).toBeVisible();
     await expect(page.locator('#company')).toBeVisible();
+    await expect(page.locator('#phone')).toBeVisible();
   });
 
   test('should load and display user profile data', async ({ authenticatedPage: page }) => {
@@ -33,10 +34,19 @@ test.describe('Profile Page', () => {
     await expect(page.getByText('Profile updated successfully')).toBeVisible();
   });
 
-  test('should show WhatsApp integration section', async ({ authenticatedPage: page }) => {
+  test('should show phone field with verify button', async ({ authenticatedPage: page }) => {
     await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: 'WhatsApp Integration' })).toBeVisible();
+    await expect(page.locator('#phone')).toBeVisible();
     await expect(page.getByPlaceholder('+64 21 123 4567')).toBeVisible();
+    // Verify button should exist (may be disabled if phone not saved)
+    await expect(page.getByRole('button', { name: /Verify/ })).toBeVisible();
+  });
+
+  test('should save phone number without verification', async ({ authenticatedPage: page }) => {
+    await page.goto('/profile');
+    await page.locator('#phone').fill('+64211234567');
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect(page.getByText('Profile updated successfully')).toBeVisible();
   });
 
   test('should require auth — redirect to login if not authenticated', async ({ page }) => {

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -27,7 +27,6 @@ export default function ProfilePage(): React.ReactElement {
 function ProfileContent(): React.ReactElement {
   const { data: session } = useSession();
   
-  
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -38,15 +37,20 @@ function ProfileContent(): React.ReactElement {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [company, setCompany] = useState('');
-  
-  // WhatsApp linking state
   const [phoneNumber, setPhoneNumber] = useState('');
+  
+  // Verification state
   const [verificationCode, setVerificationCode] = useState('');
-  const [linkingPhone, setLinkingPhone] = useState(false);
+  const [sendingCode, setSendingCode] = useState(false);
   const [verifyingCode, setVerifyingCode] = useState(false);
   const [showVerification, setShowVerification] = useState(false);
 
   const token = (session as { apiToken?: string } | null)?.apiToken;
+
+  // Check if phone has changed from saved value
+  const phoneChanged = phoneNumber !== (profile?.phoneNumber || '');
+  const phoneSaved = profile?.phoneNumber === phoneNumber && phoneNumber !== '';
+  const phoneVerified = profile?.phoneVerified && phoneSaved;
 
   // Fetch profile on mount
   useEffect(() => {
@@ -96,6 +100,7 @@ function ProfileContent(): React.ReactElement {
           name: name || undefined,
           email,
           company: company || null,
+          phoneNumber: phoneNumber || null,
         }),
       });
 
@@ -114,9 +119,9 @@ function ProfileContent(): React.ReactElement {
     }
   };
 
-  const handleLinkWhatsApp = async (): Promise<void> => {
+  const handleSendVerificationCode = async (): Promise<void> => {
     setError(null);
-    setLinkingPhone(true);
+    setSendingCode(true);
 
     try {
       const res = await fetch(`${API_URL}/api/auth/link-whatsapp`, {
@@ -136,13 +141,13 @@ function ProfileContent(): React.ReactElement {
       setShowVerification(true);
       setSuccess('Verification code sent to your WhatsApp');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to link WhatsApp');
+      setError(err instanceof Error ? err.message : 'Failed to send code');
     } finally {
-      setLinkingPhone(false);
+      setSendingCode(false);
     }
   };
 
-  const handleVerifyWhatsApp = async (): Promise<void> => {
+  const handleVerifyCode = async (): Promise<void> => {
     setError(null);
     setVerifyingCode(true);
 
@@ -169,38 +174,11 @@ function ProfileContent(): React.ReactElement {
       setProfile(data.user);
       setShowVerification(false);
       setVerificationCode('');
-      setSuccess('WhatsApp number verified successfully');
+      setSuccess('Phone number verified successfully');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Verification failed');
     } finally {
       setVerifyingCode(false);
-    }
-  };
-
-  const handleUnlinkWhatsApp = async (): Promise<void> => {
-    setError(null);
-
-    try {
-      const res = await fetch(`${API_URL}/api/auth/unlink-whatsapp`, {
-        method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to unlink WhatsApp');
-      }
-
-      // Refresh profile
-      const profileRes = await fetch(`${API_URL}/api/auth/profile`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = await profileRes.json();
-      setProfile(data.user);
-      setPhoneNumber('');
-      setSuccess('WhatsApp number unlinked');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to unlink WhatsApp');
     }
   };
 
@@ -224,7 +202,7 @@ function ProfileContent(): React.ReactElement {
 
       {/* Alerts */}
       {error && (
-        <div className="mb-6 p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg">
+        <div className="mb-6 p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg" role="alert">
           {error}
         </div>
       )}
@@ -235,7 +213,7 @@ function ProfileContent(): React.ReactElement {
       )}
 
       {/* Profile Form */}
-      <form onSubmit={handleSubmit} className="bg-white shadow-sm rounded-xl p-6 mb-6">
+      <form onSubmit={handleSubmit} className="bg-white shadow-sm rounded-xl p-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Account Details</h2>
         
         <div className="space-y-4">
@@ -284,6 +262,84 @@ function ProfileContent(): React.ReactElement {
               placeholder="Your company (optional)"
             />
           </div>
+
+          {/* Phone Number with Verify Button */}
+          <div>
+            <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">
+              Phone Number
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="phone"
+                type="tel"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                disabled={saving}
+                className="flex-1 h-11 px-3 border border-gray-200 rounded-lg text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50"
+                placeholder="+64 21 123 4567"
+              />
+              {phoneVerified ? (
+                <span className="flex items-center gap-1.5 h-11 px-4 bg-green-50 text-green-700 text-sm font-medium rounded-lg border border-green-200">
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                  Verified
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleSendVerificationCode}
+                  disabled={!phoneSaved || sendingCode || phoneNumber.length < 10}
+                  className="h-11 px-4 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {sendingCode ? 'Sending...' : 'Verify'}
+                </button>
+              )}
+            </div>
+            <p className="mt-1.5 text-xs text-gray-500">
+              {phoneChanged && phoneNumber
+                ? 'Save profile to enable verification'
+                : 'Include country code (e.g., +64 for NZ). Enables WhatsApp inspections when verified.'}
+            </p>
+            
+            {/* Inline Verification */}
+            {showVerification && (
+              <div className="mt-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
+                <p className="text-sm text-gray-600 mb-3">
+                  Enter the 6-digit code sent to your WhatsApp
+                </p>
+                <div className="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    value={verificationCode}
+                    onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                    disabled={verifyingCode}
+                    maxLength={6}
+                    className="w-32 h-11 px-3 border border-gray-200 rounded-lg text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50 text-center tracking-widest"
+                    placeholder="000000"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleVerifyCode}
+                    disabled={verifyingCode || verificationCode.length !== 6}
+                    className="h-11 px-4 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {verifyingCode ? 'Verifying...' : 'Confirm'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowVerification(false);
+                      setVerificationCode('');
+                    }}
+                    className="h-11 px-3 text-gray-600 text-sm hover:text-gray-900"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <button
@@ -294,91 +350,6 @@ function ProfileContent(): React.ReactElement {
           {saving ? 'Saving...' : 'Save Changes'}
         </button>
       </form>
-
-      {/* WhatsApp Integration */}
-      <div className="bg-white shadow-sm rounded-xl p-6">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">WhatsApp Integration</h2>
-        <p className="text-sm text-gray-600 mb-4">
-          Link your phone number to enable WhatsApp-based inspections
-        </p>
-
-        {profile?.phoneVerified ? (
-          <div className="space-y-4">
-            <div className="flex items-center gap-2 text-green-600">
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-              </svg>
-              <span className="text-sm font-medium">
-                Connected: {profile.phoneNumber}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={handleUnlinkWhatsApp}
-              className="text-sm text-red-600 hover:text-red-700 font-medium"
-            >
-              Unlink WhatsApp
-            </button>
-          </div>
-        ) : showVerification ? (
-          <div className="space-y-4">
-            <p className="text-sm text-gray-600">
-              Enter the 6-digit code sent to {phoneNumber}
-            </p>
-            <input
-              type="text"
-              value={verificationCode}
-              onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-              disabled={verifyingCode}
-              maxLength={6}
-              className="block w-full h-11 px-3 border border-gray-200 rounded-lg text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50 text-center tracking-widest"
-              placeholder="000000"
-            />
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={handleVerifyWhatsApp}
-                disabled={verifyingCode || verificationCode.length !== 6}
-                className="flex-1 h-11 px-4 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {verifyingCode ? 'Verifying...' : 'Verify'}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowVerification(false);
-                  setVerificationCode('');
-                }}
-                className="h-11 px-4 border border-gray-200 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <input
-              type="tel"
-              value={phoneNumber}
-              onChange={(e) => setPhoneNumber(e.target.value)}
-              disabled={linkingPhone}
-              className="block w-full h-11 px-3 border border-gray-200 rounded-lg text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50"
-              placeholder="+64 21 123 4567"
-            />
-            <p className="text-xs text-gray-500">
-              Include country code (e.g., +64 for NZ, +1 for US)
-            </p>
-            <button
-              type="button"
-              onClick={handleLinkWhatsApp}
-              disabled={linkingPhone || !phoneNumber || phoneNumber.length < 10}
-              className="w-full h-11 px-4 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {linkingPhone ? 'Sending code...' : 'Link WhatsApp'}
-            </button>
-          </div>
-        )}
-      </div>
 
       {/* Account Info */}
       <div className="mt-6 text-sm text-gray-500">


### PR DESCRIPTION
## Summary
Allow users to save their phone number on the profile page without requiring WhatsApp verification. Verification becomes an optional action.

## Changes
- **Profile form**: Phone number is now part of the main form
- **Verify button**: Inline button beside phone field
- **Status indicator**: Shows "Verified" badge when phone is verified
- **API**: PATCH `/api/auth/profile` now accepts `phoneNumber`
- **Verification reset**: Changing phone number clears verification status
- **E2E tests**: Updated to reflect new UI

## UX Flow
```
┌─────────────────────────────────────────────┐
│ Phone Number                                │
│ ┌──────────────────────┐  ┌──────────────┐  │
│ │ +64 21 xxx xxxx      │  │ Verify       │  │
│ └──────────────────────┘  └──────────────┘  │
│                                             │
│            [Save Profile]                   │
└─────────────────────────────────────────────┘
```

## Issue
Closes #517

## Design
`docs/design/ui/profile-phone.spec.yaml`

## Testing
- [x] Web typecheck passes
- [x] Lint passes (no errors)
- [x] E2E tests updated