### PR TITLE
[Alex] fix(api): allow inspector lookup without phoneVerified flag

### DIFF
--- a/api/src/routes/inspectors.ts
+++ b/api/src/routes/inspectors.ts
@@ -57,11 +57,11 @@ inspectorsRouter.get('/by-phone/:phone', async (req: Request, res: Response) => 
     // Normalize for lookup
     const normalizedPhone = normalizePhoneNumber(phone);
 
-    // Find user by phone number (must be verified)
+    // Find user by phone number
     const user = await prisma.user.findFirst({
       where: {
         phoneNumber: normalizedPhone,
-        phoneVerified: true,
+        // phoneVerified check removed - profile phone is sufficient (#519)
       },
       select: {
         id: true,


### PR DESCRIPTION
## Summary
Fixes #519 — WhatsApp shows 'Inspector not found' after saving phone number on profile.

## Root Cause
Inspector lookup required `phoneVerified: true`:
```typescript
const user = await prisma.user.findFirst({
  where: {
    phoneNumber: normalizedPhone,
    phoneVerified: true,  // ← Blocks users who saved phone on profile
  },
});
```

But profile save sets `phoneVerified: false` (requiring separate WhatsApp verification flow).

## Fix
Remove `phoneVerified` requirement — profile phone number is sufficient for inspector lookup.

## Testing
1. Save phone number on profile
2. Send WhatsApp message
3. Should now match user instead of returning 'Inspector not found'