### PR TITLE
[Alex] fix(data): mark test user phone as verified

### DIFF
--- a/api/prisma/migrations/20260228050000_verify_test_user_phone/migration.sql
+++ b/api/prisma/migrations/20260228050000_verify_test_user_phone/migration.sql
@@ -1,0 +1,5 @@
+-- Mark test user phone as verified (data fix for #519)
+UPDATE "User"
+SET "phoneVerified" = true
+WHERE email = 'test@example.com'
+  AND "phoneNumber" = '+64272880688';

--- a/api/src/routes/inspectors.ts
+++ b/api/src/routes/inspectors.ts
@@ -57,11 +57,11 @@ inspectorsRouter.get('/by-phone/:phone', async (req: Request, res: Response) => 
     // Normalize for lookup
     const normalizedPhone = normalizePhoneNumber(phone);
 
-    // Find user by phone number
+    // Find user by phone number (must be verified)
     const user = await prisma.user.findFirst({
       where: {
         phoneNumber: normalizedPhone,
-        // phoneVerified check removed - profile phone is sufficient (#519)
+        phoneVerified: true,
       },
       select: {
         id: true,

--- a/api/src/routes/inspectors.ts
+++ b/api/src/routes/inspectors.ts
@@ -57,11 +57,11 @@ inspectorsRouter.get('/by-phone/:phone', async (req: Request, res: Response) => 
     // Normalize for lookup
     const normalizedPhone = normalizePhoneNumber(phone);
 
-    // Find user by phone number (must be verified)
+    // Find user by phone number
     const user = await prisma.user.findFirst({
       where: {
         phoneNumber: normalizedPhone,
-        phoneVerified: true,
+        // phoneVerified check removed - profile phone is sufficient (#519)
       },
       select: {
         id: true,


### PR DESCRIPTION
## Summary
Data fix for #519 — sets `phoneVerified = true` for test@example.com (+64272880688).

## Context
User had verified their phone before profile management was added. When viewing profile, the phone showed as unverified despite being previously verified via WhatsApp flow.

## Migration
```sql
UPDATE "User"
SET "phoneVerified" = true
WHERE email = 'test@example.com'
  AND "phoneNumber" = '+64272880688';
```

Closes #519