### PR TITLE
[Alex] fix(api): serve finding photos without auth for img tags

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import { authRouter } from './routes/auth.js';
 import { inspectionsRouter } from './routes/inspections.js';
 import { findingsRouter } from './routes/findings.js';
 import { photosRouter } from './routes/photos.js';
+import { photosPublicRouter } from './routes/photos-public.js';
 import { reportsRouter } from './routes/reports.js';
 import { reportManagementRouter } from './routes/report-management.js';
 import { navigationRouter } from './routes/navigation.js';
@@ -79,6 +80,7 @@ app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 app.use('/health', healthRouter);
 app.use('/api', openApiRouter);  // OpenAPI docs (no auth required)
 app.use('/api/auth', authRouter);
+app.use('/api/photos', photosPublicRouter);  // Public photo serving (no auth) - #524
 
 // Service routes (JWT or API key auth)
 app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -19,3 +19,4 @@ export * from './report-generation.js';
 export * from './personnel.js';
 export * from './credentials.js';
 export * from './interaction-logs.js';
+export * from './photos-public.js';

--- a/api/src/routes/photos-public.ts
+++ b/api/src/routes/photos-public.ts
@@ -1,0 +1,50 @@
+/**
+ * Public Photos Route
+ * Issue #524 - Photos must be accessible without auth for <img> tags
+ * 
+ * This route serves photo files without authentication.
+ * Photos are identified by UUID which provides security through obscurity.
+ * Supports both R2 storage (production) and local disk (development).
+ */
+
+import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import { PhotoService, PhotoNotFoundError } from '../services/photo.js';
+
+const prisma = new PrismaClient();
+const repository = new PrismaInspectionRepository(prisma);
+const service = new PhotoService(repository);
+
+export const photosPublicRouter: RouterType = Router();
+
+// GET /api/photos/:id - Serve photo file (public, no auth)
+photosPublicRouter.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const photo = await service.findById(id);
+
+    // Get file buffer (from R2 or local disk)
+    let fileBuffer: Buffer;
+    try {
+      fileBuffer = await service.getFileBuffer(id);
+    } catch (err) {
+      console.error(`[PhotosPublic] Failed to get file buffer for ${id}:`, err);
+      res.status(404).json({ error: 'Photo file not found' });
+      return;
+    }
+
+    // Set cache headers (photos are immutable)
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('Content-Type', photo.mimeType);
+    res.setHeader('Content-Disposition', `inline; filename="${photo.filename}"`);
+    
+    res.send(fileBuffer);
+  } catch (error) {
+    if (error instanceof PhotoNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});

--- a/api/src/routes/photos.ts
+++ b/api/src/routes/photos.ts
@@ -1,5 +1,4 @@
 import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
-import * as fs from 'node:fs/promises';
 import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
@@ -58,35 +57,6 @@ photosRouter.post(
     }
   }
 );
-
-// GET /api/photos/:id - Get photo (serve file)
-photosRouter.get('/photos/:id', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const id = req.params.id as string;
-    const photo = await service.findById(id);
-
-    // Check if file exists
-    try {
-      await fs.access(photo.path);
-    } catch {
-      res.status(404).json({ error: 'Photo file not found on disk' });
-      return;
-    }
-
-    // Serve the file
-    res.setHeader('Content-Type', photo.mimeType);
-    res.setHeader('Content-Disposition', `inline; filename="${photo.filename}"`);
-    
-    const fileBuffer = await fs.readFile(photo.path);
-    res.send(fileBuffer);
-  } catch (error) {
-    if (error instanceof PhotoNotFoundError) {
-      res.status(404).json({ error: error.message });
-      return;
-    }
-    next(error);
-  }
-});
 
 // GET /api/photos/:id/metadata - Get photo metadata
 photosRouter.get('/photos/:id/metadata', async (req: Request, res: Response, next: NextFunction) => {

--- a/api/src/services/photo.ts
+++ b/api/src/services/photo.ts
@@ -1,9 +1,17 @@
+/**
+ * Photo Service
+ * Issue #524 - Updated to use R2 storage in production
+ * 
+ * Stores finding photos in Cloudflare R2 (production) or local disk (development).
+ */
+
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import type { Photo } from '@prisma/client';
 import type { IInspectionRepository, CreatePhotoInput } from '../repositories/interfaces/inspection.js';
 import { FindingNotFoundError } from './finding.js';
+import { uploadToR2, downloadFromR2, deleteFromR2, isR2Configured } from './r2-storage.js';
 
 export { FindingNotFoundError };
 
@@ -29,9 +37,17 @@ export interface UploadPhotoInput {
 
 export class PhotoService {
   private photoDir: string;
+  private useR2: boolean;
 
   constructor(private repository: IInspectionRepository, photoDir?: string) {
     this.photoDir = photoDir || process.env.PHOTO_DIR || './uploads/photos';
+    this.useR2 = isR2Configured();
+    
+    if (this.useR2) {
+      console.log('[PhotoService] Using R2 storage');
+    } else {
+      console.log('[PhotoService] Using local storage (R2 not configured)');
+    }
   }
 
   async upload(input: UploadPhotoInput): Promise<Photo> {
@@ -57,7 +73,6 @@ export class PhotoService {
     // Validate base64
     let buffer: Buffer;
     try {
-      // Check if it's valid base64 by decoding it
       buffer = Buffer.from(base64Data, 'base64');
       if (buffer.length === 0 || !this.isValidBase64(base64Data)) {
         throw new InvalidBase64Error();
@@ -73,18 +88,27 @@ export class PhotoService {
     const ext = this.getExtensionFromMimeType(mimeType);
     const filename = `${crypto.randomUUID()}${ext}`;
 
-    // Ensure directory exists
-    await fs.mkdir(this.photoDir, { recursive: true });
+    let storagePath: string;
 
-    // Write file
-    const filePath = path.join(this.photoDir, filename);
-    await fs.writeFile(filePath, buffer);
+    if (this.useR2) {
+      // Upload to R2
+      const r2Key = `findings/${input.findingId}/${filename}`;
+      await uploadToR2(r2Key, buffer, mimeType);
+      storagePath = `r2://${r2Key}`;
+      console.log(`[PhotoService] Uploaded to R2: ${r2Key}`);
+    } else {
+      // Write to local disk (development fallback)
+      await fs.mkdir(this.photoDir, { recursive: true });
+      const filePath = path.join(this.photoDir, filename);
+      await fs.writeFile(filePath, buffer);
+      storagePath = filePath;
+    }
 
     // Create database record
     const photoInput: CreatePhotoInput = {
       findingId: input.findingId,
       filename,
-      path: filePath,
+      path: storagePath,
       mimeType,
     };
 
@@ -100,7 +124,6 @@ export class PhotoService {
   }
 
   async findByFinding(findingId: string): Promise<Photo[]> {
-    // Verify finding exists
     const finding = await this.repository.findFindingById(findingId);
     if (!finding) {
       throw new FindingNotFoundError(findingId);
@@ -108,19 +131,42 @@ export class PhotoService {
     return this.repository.findPhotosByFinding(findingId);
   }
 
+  /**
+   * Get photo file buffer (from R2 or local disk)
+   */
+  async getFileBuffer(id: string): Promise<Buffer> {
+    const photo = await this.findById(id);
+    
+    if (photo.path.startsWith('r2://')) {
+      // Download from R2
+      const r2Key = photo.path.replace('r2://', '');
+      return downloadFromR2(r2Key);
+    } else {
+      // Read from local disk
+      return fs.readFile(photo.path);
+    }
+  }
+
   async delete(id: string): Promise<void> {
-    // Get photo first to get file path
     const photo = await this.findById(id);
 
-    // Delete file from disk
-    try {
-      await fs.unlink(photo.path);
-    } catch (err) {
-      // Log but don't fail if file doesn't exist
-      console.warn(`Failed to delete photo file: ${photo.path}`, err);
+    if (photo.path.startsWith('r2://')) {
+      // Delete from R2
+      const r2Key = photo.path.replace('r2://', '');
+      try {
+        await deleteFromR2(r2Key);
+      } catch (err) {
+        console.warn(`Failed to delete from R2: ${r2Key}`, err);
+      }
+    } else {
+      // Delete from local disk
+      try {
+        await fs.unlink(photo.path);
+      } catch (err) {
+        console.warn(`Failed to delete photo file: ${photo.path}`, err);
+      }
     }
 
-    // Delete database record
     await this.repository.deletePhoto(id);
   }
 
@@ -141,12 +187,10 @@ export class PhotoService {
   }
 
   private isValidBase64(str: string): boolean {
-    // Valid base64 pattern: alphanumeric, +, /, and optional = padding
     const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
     if (!base64Regex.test(str)) {
       return false;
     }
-    // Length should be a multiple of 4 (accounting for padding)
     if (str.length % 4 !== 0) {
       return false;
     }

--- a/api/src/services/r2-storage.ts
+++ b/api/src/services/r2-storage.ts
@@ -100,6 +100,31 @@ export async function getPresignedUrl(key: string): Promise<string> {
 /**
  * Delete a file from R2
  */
+/**
+ * Download a file from R2
+ */
+export async function downloadFromR2(key: string): Promise<Buffer> {
+  const client = getR2Client();
+
+  const command = new GetObjectCommand({
+    Bucket: R2_BUCKET_NAME,
+    Key: key,
+  });
+
+  const response = await client.send(command);
+  
+  if (!response.Body) {
+    throw new Error(`No body in R2 response for key: ${key}`);
+  }
+
+  // Convert stream to buffer
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
 export async function deleteFromR2(key: string): Promise<void> {
   const client = getR2Client();
 


### PR DESCRIPTION
## Summary
Fixes #524 — finding photos display as broken images.

## Root Cause
**Two issues:**
1. Photos written to local disk (`./uploads/photos/`) which is ephemeral in Railway containers
2. `GET /api/photos/:id` required auth, but `<img>` tags don't send cookies cross-origin

R2 bucket was empty — photos never made it to persistent storage.

## Fix

### 1. R2 Storage for PhotoService
- `PhotoService.upload()` now writes to R2 in production
- Falls back to local disk when R2 not configured (dev)
- Path stored as `r2://findings/{findingId}/{uuid}.ext`
- Added `downloadFromR2()` to r2-storage service
- `PhotoService.getFileBuffer()` handles both R2 and local

### 2. Public Photo Endpoint
- `GET /api/photos/:id` is now public (no auth)
- Uses `PhotoService.getFileBuffer()` for storage-agnostic serving
- Added `Cache-Control: immutable` for browser caching
- Upload/delete still require auth

## Security
- Photos identified by UUID (hard to guess)
- Only read operations are public
- Mutations still require authentication

## Testing
1. Ensure R2 env vars are set in production
2. Add finding with photo via MCP
3. Photo should appear in R2 bucket
4. Photo should render in web UI

Fixes #524