### PR TITLE
[Sam] feat(web): make app mobile-friendly with responsive design

### DIFF
--- a/docs/design/ui/mobile-responsive.spec.yaml
+++ b/docs/design/ui/mobile-responsive.spec.yaml
@@ -1,0 +1,110 @@
+# Mobile Responsive Design — Issue #529
+# Make web app work well on mobile devices
+
+metadata:
+  issue: 529
+  created: "2026-02-28"
+  author: "Sam"
+
+# =============================================================================
+# BREAKPOINTS (from tokens.yaml)
+# =============================================================================
+breakpoints:
+  mobile: "< 640px"   # Default/base styles
+  sm: "640px"         # Small tablets
+  md: "768px"         # Tablets
+  lg: "1024px"        # Laptops
+
+# =============================================================================
+# HEADER / NAVIGATION
+# =============================================================================
+header:
+  current-issue: "Nav links hidden on mobile, no way to navigate"
+  
+  mobile-design:
+    layout: "Logo left, hamburger button right"
+    hamburger:
+      icon: "3 horizontal lines"
+      position: "right side of header"
+      visible: "md:hidden (below 768px)"
+    
+    menu:
+      type: "slide-down panel or drawer"
+      content:
+        - "Inspections link"
+        - "Profile link (user email)"
+        - "Sign Out button"
+      style: "full-width, stacked vertically"
+  
+  desktop-design:
+    hamburger: "hidden (md:hidden)"
+    nav: "visible inline (hidden md:flex)"
+
+# =============================================================================
+# PAGES
+# =============================================================================
+pages:
+  login-register:
+    status: "Already mobile-friendly (centered card, full-width inputs)"
+    changes: "None needed"
+  
+  profile:
+    status: "max-w-2xl works on mobile"
+    changes: "None needed"
+  
+  inspections-list:
+    current: "May have table or card layout"
+    mobile:
+      - "Cards stack vertically"
+      - "Full-width on mobile"
+      - "Adequate touch targets (min 44px)"
+  
+  inspection-detail:
+    current: "Multiple sections with forms"
+    mobile:
+      - "Sections stack vertically"
+      - "Forms use full width"
+      - "Photo grids adapt (2 cols on mobile vs 3-4 on desktop)"
+  
+  projects:
+    current: "List/table view"
+    mobile:
+      - "Cards or stacked rows"
+      - "Horizontal scroll for tables if needed"
+
+# =============================================================================
+# COMPONENT PATTERNS
+# =============================================================================
+patterns:
+  container:
+    desktop: "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
+    mobile: "px-4 (16px padding)"
+  
+  forms:
+    inputs: "w-full (already full-width)"
+    buttons: "w-full on mobile, auto on desktop"
+    spacing: "space-y-4"
+  
+  cards:
+    mobile: "full-width, stack vertically"
+    desktop: "grid layout"
+  
+  tables:
+    approach: "horizontal scroll wrapper"
+    wrapper: "overflow-x-auto"
+    min-width: "min-w-[600px] on table"
+
+# =============================================================================
+# IMPLEMENTATION
+# =============================================================================
+implementation:
+  priority:
+    1: "Header with mobile menu"
+    2: "Check all pages render without horizontal scroll"
+    3: "Fix any overflow issues"
+  
+  files:
+    - "web/components/app-header.tsx"  # Add mobile menu
+    - "web/app/layout.tsx"             # Check container
+    - "web/app/inspections/page.tsx"   # Check list layout
+    - "web/app/projects/page.tsx"      # Check list layout

--- a/docs/design/ui/mobile-responsive.spec.yaml
+++ b/docs/design/ui/mobile-responsive.spec.yaml
@@ -108,3 +108,23 @@ implementation:
     - "web/app/layout.tsx"             # Check container
     - "web/app/inspections/page.tsx"   # Check list layout
     - "web/app/projects/page.tsx"      # Check list layout
+
+# =============================================================================
+# DESKTOP IMPROVEMENTS (added)
+# =============================================================================
+desktop:
+  issue: "Tables/content too narrow, not using screen width"
+  
+  solution:
+    layout: "Remove max-w-7xl from main, let pages control width"
+    list-pages:
+      inspections: "full-width table with side padding"
+      projects: "full-width table with side padding"
+    form-pages:
+      profile: "keep max-w-2xl for readability"
+      inspection-detail: "use available width"
+  
+  implementation:
+    - "layout.tsx: remove max-w-7xl, use w-full with padding"
+    - "list pages: tables expand to available width"
+    - "form pages: maintain readable max-width"

--- a/docs/developer/design/tokens.yaml
+++ b/docs/developer/design/tokens.yaml
@@ -266,6 +266,10 @@ breakpoints:
 
   # Layout constraints
   layout:
+    # Page types determine their own max-width
+    # List pages (tables): full width, no max-w
+    # Form/content pages: max-w-2xl to max-w-4xl for readability
+    # Layout provides padding only, not width constraints
     max-width: "1280px"  # max-w-7xl
     content-max: "768px" # max-w-3xl (prose content)
 
@@ -327,7 +331,13 @@ guidelines:
     - "Card title: text-lg font-medium"
 
   layout:
-    - "Page max-width: max-w-7xl mx-auto"
+    # Page types determine their own max-width
+    # List pages (tables): full width, no max-w
+    # Form/content pages: max-w-2xl to max-w-4xl for readability
+    # Layout provides padding only, not width constraints
+    - "List pages (tables): full width, use available space"
+    - "Form/content pages: max-w-2xl to max-w-4xl mx-auto"
+    - "Layout provides padding (px-4 sm:px-6 lg:px-8), pages control width"
     - "Page padding: px-6 py-8"
     - "Mobile-first responsive design"
 

--- a/web/app/inspections/page.tsx
+++ b/web/app/inspections/page.tsx
@@ -48,18 +48,18 @@ export default function InspectionsPage(): React.ReactElement {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Inspections</h1>
         <Link
           href="/inspections/new"
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
+          className="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
         >
           + New Inspection
         </Link>
       </div>
 
       {inspections.length === 0 ? (
-        <div className="bg-white shadow rounded-lg p-12 text-center">
+        <div className="bg-white shadow rounded-lg p-8 sm:p-12 text-center">
           <p className="text-gray-500 mb-4">No inspections yet</p>
           <Link
             href="/inspections/new"
@@ -69,59 +69,86 @@ export default function InspectionsPage(): React.ReactElement {
           </Link>
         </div>
       ) : (
-        <div className="bg-white shadow rounded-lg overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Address
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Client
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Created
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {inspections.map((inspection) => (
-                <tr key={inspection.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-medium text-gray-900">
-                      {inspection.address}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-500">
-                      {inspection.clientName}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <StatusBadge status={inspection.status} />
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {new Date(inspection.createdAt).toLocaleDateString()}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <Link
-                      href={`/inspections/${inspection.id}`}
-                      className="text-blue-600 hover:text-blue-900"
-                    >
-                      View
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          {/* Mobile: Card Layout */}
+          <div className="sm:hidden space-y-4">
+            {inspections.map((inspection) => (
+              <Link
+                key={inspection.id}
+                href={`/inspections/${inspection.id}`}
+                className="block bg-white shadow rounded-lg p-4 hover:shadow-md transition-shadow"
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="text-sm font-medium text-gray-900 line-clamp-2">
+                    {inspection.address}
+                  </div>
+                  <StatusBadge status={inspection.status} />
+                </div>
+                <div className="text-sm text-gray-500">{inspection.clientName}</div>
+                <div className="text-xs text-gray-400 mt-2">
+                  {new Date(inspection.createdAt).toLocaleDateString()}
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          {/* Desktop: Table Layout */}
+          <div className="hidden sm:block bg-white shadow rounded-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Address
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Client
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Created
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {inspections.map((inspection) => (
+                    <tr key={inspection.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">
+                          {inspection.address}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">
+                          {inspection.clientName}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <StatusBadge status={inspection.status} />
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {new Date(inspection.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <Link
+                          href={`/inspections/${inspection.id}`}
+                          className="text-blue-600 hover:text-blue-900"
+                        >
+                          View
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -33,11 +33,11 @@ export default function RootLayout({
         <AuthProvider>
           <div className="flex min-h-screen flex-col">
             <AppHeader />
-            <main className="mx-auto max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+            <main className="flex-1 w-full px-4 py-8 sm:px-6 lg:px-8">
               {children}
             </main>
             <footer className="border-t border-gray-200 bg-white py-4">
-              <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-right">
+              <div className="w-full px-4 sm:px-6 lg:px-8 text-right">
                 <VersionBadge />
               </div>
             </footer>

--- a/web/app/projects/project-list.tsx
+++ b/web/app/projects/project-list.tsx
@@ -190,75 +190,111 @@ export function ProjectList(): React.ReactElement {
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
-          <tr>
-            <th
-              scope="col"
-              className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
-              onClick={() => handleSort('jobNumber')}
-            >
-              Job # <SortIcon column="jobNumber" />
-            </th>
-            <th
-              scope="col"
-              className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
-              onClick={() => handleSort('address')}
-            >
-              Address <SortIcon column="address" />
-            </th>
-            <th
-              scope="col"
-              className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
-              onClick={() => handleSort('client')}
-            >
-              Client <SortIcon column="client" />
-            </th>
-            <th
-              scope="col"
-              className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
-              onClick={() => handleSort('status')}
-            >
-              Status <SortIcon column="status" />
-            </th>
-            <th
-              scope="col"
-              className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
-              onClick={() => handleSort('updatedAt')}
-            >
-              Last Updated <SortIcon column="updatedAt" />
-            </th>
-          </tr>
-        </thead>
-        <tbody className="bg-white divide-y divide-gray-200">
-          {projects.map((project) => (
-            <tr
-              key={project.id}
-              className="hover:bg-gray-50 cursor-pointer"
-              onClick={() => router.push(`/projects/${project.id}`)}
-            >
-              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                {project.jobNumber || '—'}
-              </td>
-              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-                {project.property?.address || '—'}
-              </td>
-              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-                {project.client?.name || '—'}
-              </td>
-              <td className="px-6 py-4 whitespace-nowrap">
-                <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[project.status] || 'bg-gray-100 text-gray-700'}`}>
-                  {STATUS_LABELS[project.status] || project.status}
-                </span>
-              </td>
-              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {new Date(project.updatedAt).toLocaleDateString()}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <>
+      {/* Mobile: Card Layout */}
+      <div className="sm:hidden space-y-4">
+        {projects.map((project) => (
+          <div
+            key={project.id}
+            className="bg-white border border-gray-200 rounded-xl shadow-sm p-4 cursor-pointer hover:shadow-md transition-shadow"
+            onClick={() => router.push(`/projects/${project.id}`)}
+          >
+            <div className="flex items-start justify-between gap-2 mb-2">
+              <div>
+                {project.jobNumber && (
+                  <div className="text-xs font-medium text-gray-500 mb-1">
+                    #{project.jobNumber}
+                  </div>
+                )}
+                <div className="text-sm font-medium text-gray-900 line-clamp-2">
+                  {project.property?.address || '—'}
+                </div>
+              </div>
+              <span className={`flex-shrink-0 inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[project.status] || 'bg-gray-100 text-gray-700'}`}>
+                {STATUS_LABELS[project.status] || project.status}
+              </span>
+            </div>
+            <div className="text-sm text-gray-500">{project.client?.name || '—'}</div>
+            <div className="text-xs text-gray-400 mt-2">
+              Updated {new Date(project.updatedAt).toLocaleDateString()}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop: Table Layout */}
+      <div className="hidden sm:block bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort('jobNumber')}
+                >
+                  Job # <SortIcon column="jobNumber" />
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort('address')}
+                >
+                  Address <SortIcon column="address" />
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort('client')}
+                >
+                  Client <SortIcon column="client" />
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort('status')}
+                >
+                  Status <SortIcon column="status" />
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-sm font-medium text-gray-500 cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort('updatedAt')}
+                >
+                  Last Updated <SortIcon column="updatedAt" />
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {projects.map((project) => (
+                <tr
+                  key={project.id}
+                  className="hover:bg-gray-50 cursor-pointer"
+                  onClick={() => router.push(`/projects/${project.id}`)}
+                >
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    {project.jobNumber || '—'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                    {project.property?.address || '—'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                    {project.client?.name || '—'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[project.status] || 'bg-gray-100 text-gray-700'}`}>
+                      {STATUS_LABELS[project.status] || project.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {new Date(project.updatedAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
   );
 }

--- a/web/components/app-header.tsx
+++ b/web/components/app-header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
@@ -9,6 +10,7 @@ export function AppHeader(): React.ReactElement | null {
   const { data: session, status } = useSession();
   const isAuthenticated = status === 'authenticated';
   const isLoading = status === 'loading';
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // Don't show header on login/register pages
   if (pathname === '/login' || pathname === '/register') {
@@ -28,25 +30,22 @@ export function AppHeader(): React.ReactElement | null {
     <header className="border-b border-gray-200 bg-white">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
-          <div className="flex items-center gap-8">
-            <Link href="/" className="flex items-center gap-2">
-              <span className="text-xl font-bold text-gray-900">
-                🔍 AI Inspection
-              </span>
-            </Link>
-            {isAuthenticated && (
-              <nav className="hidden md:flex items-center gap-6">
-                <Link
-                  href="/inspections"
-                  className="text-sm font-medium text-gray-600 hover:text-gray-900"
-                >
-                  Inspections
-                </Link>
-              </nav>
-            )}
-          </div>
+          {/* Logo */}
+          <Link href="/" className="flex items-center gap-2">
+            <span className="text-xl font-bold text-gray-900">
+              🔍 AI Inspection
+            </span>
+          </Link>
+
+          {/* Desktop Navigation */}
           {isAuthenticated && (
-            <div className="flex items-center gap-4">
+            <nav className="hidden md:flex items-center gap-6">
+              <Link
+                href="/inspections"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900"
+              >
+                Inspections
+              </Link>
               <Link
                 href="/profile"
                 className="text-sm text-gray-600 hover:text-gray-900"
@@ -59,9 +58,64 @@ export function AppHeader(): React.ReactElement | null {
               >
                 Sign Out
               </button>
-            </div>
+            </nav>
+          )}
+
+          {/* Mobile Menu Button */}
+          {isAuthenticated && (
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              className="md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+              aria-expanded={mobileMenuOpen}
+              aria-label="Toggle menu"
+            >
+              {mobileMenuOpen ? (
+                // X icon
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                // Hamburger icon
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
           )}
         </div>
+
+        {/* Mobile Menu */}
+        {isAuthenticated && mobileMenuOpen && (
+          <nav className="md:hidden border-t border-gray-200 py-3 space-y-1">
+            <Link
+              href="/inspections"
+              onClick={() => setMobileMenuOpen(false)}
+              className="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+            >
+              Inspections
+            </Link>
+            <Link
+              href="/profile"
+              onClick={() => setMobileMenuOpen(false)}
+              className="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+            >
+              Profile
+            </Link>
+            <div className="px-3 py-2 text-sm text-gray-500">
+              {session?.user?.email}
+            </div>
+            <button
+              onClick={() => {
+                setMobileMenuOpen(false);
+                handleLogout();
+              }}
+              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+            >
+              Sign Out
+            </button>
+          </nav>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
Make the web app responsive for both mobile and desktop.

## Changes

### Desktop
- Remove `max-w-7xl` constraint from layout
- Tables expand to use available screen width
- Form pages maintain readable max-widths

### Mobile - Header
- Add hamburger menu button (visible below md breakpoint)
- Slide-down mobile menu with navigation links

### Mobile - Lists
- **Inspections**: Card layout on mobile, full-width table on desktop
- **Projects**: Card layout on mobile, full-width table on desktop

## Acceptance Criteria
- [x] Desktop: content/tables expand to utilize available screen width
- [x] Desktop: layout uses space effectively
- [x] Mobile: all pages render correctly (320px - 768px)
- [x] Mobile: navigation is mobile-friendly (hamburger menu)
- [x] Mobile: forms usable on touch devices
- [x] Mobile: tables adapt to small screens (card layout)
- [x] No horizontal scrolling on mobile
- [x] Profile page works on both desktop and mobile

## Issue
Closes #529

## Design
`docs/design/ui/mobile-responsive.spec.yaml`