### PR TITLE
[Sam] fix(api): add Cross-Origin-Resource-Policy header for photos

### DIFF
--- a/api/src/routes/photos-public.ts
+++ b/api/src/routes/photos-public.ts
@@ -36,6 +36,7 @@ photosPublicRouter.get('/:id', async (req: Request, res: Response, next: NextFun
 
     // Set cache headers (photos are immutable)
     res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
     res.setHeader('Content-Type', photo.mimeType);
     res.setHeader('Content-Disposition', `inline; filename="${photo.filename}"`);
     


### PR DESCRIPTION
## Summary
Fix broken photos in browser due to CORS blocking.

## Root Cause
**NOT** a `NEXT_PUBLIC_API_URL` issue — env var is set correctly.

The actual issue: `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`

Browser blocks cross-origin image embedding when the response lacks `Cross-Origin-Resource-Policy: cross-origin` header.

## Fix
Add header to photo serving endpoint:
```js
res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
```

## Issue
Fixes #533

## Testing
After deploy, photos should load in `<img>` tags without CORS errors.