### PR TITLE
[Alex] fix(api): add PPI report template

### DIFF
--- a/api/src/__tests__/template-engine.test.ts
+++ b/api/src/__tests__/template-engine.test.ts
@@ -4,7 +4,7 @@
  * Tests for the Handlebars template engine service.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   renderReport,
   renderSection,
@@ -240,6 +240,196 @@ describe('Template Engine', () => {
       const html = await renderSection('coa', '05-clause-review.hbs', data);
       // B2 has no photo refs — should show dash
       expect(html).toContain('—');
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PPI Test data
+// ──────────────────────────────────────────────────────────────────────────────
+
+function makePPIReportData() {
+  return {
+    generatedAt: new Date('2026-02-20T10:00:00Z'),
+    project: {
+      jobNumber: 'PPI-2026-001',
+      address: '45 Example Road, Auckland',
+      client: 'Home Buyer Ltd',
+      company: 'Apex Inspection Services',
+    },
+    personnel: {
+      author: {
+        name: 'John Smith',
+        credentials: 'BSCE, LBP #12345',
+      },
+      inspectors: [{ name: 'John Smith', role: 'Lead Inspector' }],
+    },
+    inspection: {
+      date: '2026-02-18T00:00:00Z',
+      weather: 'Overcast, 18°C',
+    },
+    property: {
+      type: 'Standalone dwelling',
+      yearBuilt: '1985',
+      bedrooms: '3',
+      bathrooms: '2',
+      garaging: 'Single garage',
+      cccStatus: 'Issued',
+    },
+    methodology: {
+      areasNotAccessed: 'Sub-floor space (access hatch blocked)',
+      documentsReviewed: ['LIM report', 'Title documents'],
+    },
+    findings: {
+      summary: 'Property is in fair condition with some maintenance required.',
+    },
+    siteGround: {
+      items: [
+        { name: 'Topography', condition: 'Good', observations: 'Level site', photoRefs: [] },
+        { name: 'Retaining walls', condition: 'Fair', observations: 'Minor cracking noted', photoRefs: ['1'], issue: true },
+      ],
+    },
+    exterior: {
+      items: [
+        { name: 'Roof', condition: 'Good', observations: 'Concrete tiles in good condition', photoRefs: ['2'] },
+        { name: 'Cladding', condition: 'Fair', observations: 'Weatherboard, some paint peeling', photoRefs: ['3'], issue: true },
+      ],
+    },
+    interior: {
+      living: {
+        items: [
+          { name: 'Walls', condition: 'Good', observations: 'No defects noted', photoRefs: [] },
+        ],
+      },
+      bathrooms: {
+        items: [
+          { name: 'Shower', condition: 'Fair', observations: 'Grout needs resealing', photoRefs: ['4'], issue: true },
+        ],
+        moistureReadings: [
+          { location: 'Bathroom 1 - shower wall', reading: '12', result: 'Acceptable' },
+          { location: 'Bathroom 2 - floor', reading: '22', result: 'Marginal' },
+        ],
+      },
+    },
+    services: {
+      items: [
+        { name: 'Switchboard', condition: 'Good', observations: 'Modern RCD protection fitted', photoRefs: [] },
+        { name: 'Hot water', condition: 'Good', observations: 'Electric cylinder, 10 years old', photoRefs: [] },
+      ],
+    },
+    conclusions: {
+      rating: 'Fair',
+      summary: 'The property is generally in fair condition for its age. Some maintenance and minor repairs are recommended.',
+      immediateAttention: ['Reseal shower grout in bathroom 1'],
+      maintenance: ['Repaint weatherboard cladding', 'Monitor retaining wall cracks'],
+      furtherInvestigation: ['Structural engineer assessment of retaining wall if cracks worsen'],
+    },
+    appendices: {
+      photos: [
+        { number: 1, caption: 'Retaining wall crack', location: 'Side boundary', base64: 'dGVzdA==' },
+        { number: 2, caption: 'Roof condition', location: 'Front elevation', base64: 'dGVzdA==' },
+        { number: 3, caption: 'Paint peeling', location: 'West wall', base64: 'dGVzdA==' },
+        { number: 4, caption: 'Shower grout', location: 'Bathroom 1', base64: 'dGVzdA==' },
+      ],
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PPI Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('PPI Templates', () => {
+  describe('listTemplates', () => {
+    it('lists PPI section and appendix templates', async () => {
+      const result = await listTemplates('ppi');
+
+      expect(result.sections).toContain('01-executive-summary.hbs');
+      expect(result.sections).toContain('05-interior.hbs');
+      expect(result.sections).toContain('08-signatures.hbs');
+      expect(result.sections).toHaveLength(8);
+
+      expect(result.appendices).toContain('photos.hbs');
+      expect(result.appendices).toHaveLength(1);
+    });
+  });
+
+  describe('renderSection', () => {
+    it('renders PPI executive summary with property details', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '01-executive-summary.hbs', data);
+
+      expect(html).toContain('Executive Summary');
+      expect(html).toContain('PPI-2026-001');
+      expect(html).toContain('45 Example Road, Auckland');
+      expect(html).toContain('Standalone dwelling');
+      expect(html).toContain('1985');
+    });
+
+    it('renders PPI interior with moisture readings', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '05-interior.hbs', data);
+
+      expect(html).toContain('Interior of Building');
+      expect(html).toContain('Bathrooms');
+      expect(html).toContain('Moisture Readings');
+      expect(html).toContain('Bathroom 1 - shower wall');
+      expect(html).toContain('Acceptable');
+      expect(html).toContain('Marginal');
+    });
+
+    it('renders PPI conclusions with recommendations', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '07-conclusions.hbs', data);
+
+      expect(html).toContain('Conclusions and Recommendations');
+      expect(html).toContain('Fair');
+      expect(html).toContain('Reseal shower grout');
+      expect(html).toContain('Repaint weatherboard');
+      expect(html).toContain('Structural engineer');
+    });
+  });
+
+  describe('renderReport', () => {
+    it('renders full PPI report with all sections', async () => {
+      const data = makePPIReportData();
+      const html = await renderReport({ reportType: 'ppi', data });
+
+      // Base layout
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('Pre-Purchase Inspection Report');
+
+      // Header
+      expect(html).toContain('PPI-2026-001');
+
+      // CSS included
+      expect(html).toContain('@page');
+      expect(html).toContain('font-family');
+
+      // All 8 sections present
+      expect(html).toContain('id="section-1"');
+      expect(html).toContain('id="section-2"');
+      expect(html).toContain('id="section-3"');
+      expect(html).toContain('id="section-4"');
+      expect(html).toContain('id="section-5"');
+      expect(html).toContain('id="section-6"');
+      expect(html).toContain('id="section-7"');
+      expect(html).toContain('id="section-8"');
+
+      // Appendix present
+      expect(html).toContain('id="appendix-a"');
+
+      // Footer
+      expect(html).toContain('CONFIDENTIAL');
+    });
+
+    it('includes photo data in appendix', async () => {
+      const data = makePPIReportData();
+      const html = await renderReport({ reportType: 'ppi', data });
+
+      expect(html).toContain('Photograph 1');
+      expect(html).toContain('Retaining wall crack');
+      expect(html).toContain('data:image/jpeg;base64,dGVzdA==');
     });
   });
 });

--- a/api/templates/ppi/appendices/photos.hbs
+++ b/api/templates/ppi/appendices/photos.hbs
@@ -1,0 +1,19 @@
+<section class="appendix" id="appendix-a">
+  <h2>Appendix A: Photographs</h2>
+
+  {{#if appendices.photos}}
+  <div class="photo-grid">
+    {{#each appendices.photos}}
+    <figure class="photo-item">
+      <img src="data:image/jpeg;base64,{{{base64}}}" alt="{{caption}}" />
+      <figcaption>
+        <strong>Photograph {{number}}</strong>: {{caption}}
+        {{#if location}}<span class="photo-location">({{location}})</span>{{/if}}
+      </figcaption>
+    </figure>
+    {{/each}}
+  </div>
+  {{else}}
+  <p>No photographs were taken during this inspection.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/base.hbs
+++ b/api/templates/ppi/base.hbs
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{project.jobNumber}} — Pre-Purchase Inspection Report</title>
+  <style>{{{css}}}</style>
+</head>
+<body>
+  {{> header}}
+
+  {{#if tableOfContents}}
+  <nav class="table-of-contents">
+    <h2>Table of Contents</h2>
+    {{{tableOfContents}}}
+  </nav>
+  {{/if}}
+
+  <main class="report-content">
+    {{{sections}}}
+  </main>
+
+  {{#if appendixContent}}
+  <div class="appendices">
+    {{{appendixContent}}}
+  </div>
+  {{/if}}
+
+  {{> footer}}
+</body>
+</html>

--- a/api/templates/ppi/cover.hbs
+++ b/api/templates/ppi/cover.hbs
@@ -1,0 +1,47 @@
+{{!-- PPI Cover Page Template --}}
+<div class="cover-page">
+  <div class="cover-content">
+    <div class="cover-header">
+      {{#if company.logoPath}}
+        <img src="{{company.logoPath}}" alt="{{company.name}}" class="cover-logo" />
+      {{else}}
+        <div class="cover-logo-placeholder">{{project.company}}</div>
+      {{/if}}
+    </div>
+
+    <div class="cover-title">
+      <h1>Pre-Purchase Inspection Report</h1>
+      <p class="cover-standard">NZS 4306:2005</p>
+    </div>
+
+    <div class="cover-details">
+      <div class="cover-address">{{project.address}}</div>
+      <div class="cover-client">
+        <span class="label">Client:</span> {{project.client}}
+      </div>
+      <div class="cover-job-number">
+        <span class="label">Job Number:</span> {{project.jobNumber}}
+      </div>
+      <div class="cover-date">
+        <span class="label">Date:</span> {{formatDate generatedAt}}
+      </div>
+    </div>
+
+    <div class="cover-footer">
+      <div class="cover-prepared-by">
+        <span class="label">Prepared by:</span> {{personnel.author.name}}
+        {{#if personnel.author.credentials}}
+          <span class="credentials">({{personnel.author.credentials}})</span>
+        {{/if}}
+      </div>
+      {{#if personnel.reviewer}}
+        <div class="cover-reviewed-by">
+          <span class="label">Reviewed by:</span> {{personnel.reviewer.name}}
+          {{#if personnel.reviewer.credentials}}
+            <span class="credentials">({{personnel.reviewer.credentials}})</span>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/api/templates/ppi/sections/01-executive-summary.hbs
+++ b/api/templates/ppi/sections/01-executive-summary.hbs
@@ -1,0 +1,51 @@
+<section class="report-section" id="section-1">
+  <h2>1. Executive Summary</h2>
+
+  <table class="summary-table">
+    <tr><th>Job Number</th><td>{{project.jobNumber}}</td></tr>
+    <tr><th>Address</th><td>{{project.address}}</td></tr>
+    <tr><th>Client</th><td>{{project.client}}</td></tr>
+    <tr><th>Inspection Date</th><td>{{formatDate inspection.date}}</td></tr>
+    <tr><th>Weather</th><td>{{inspection.weather}}</td></tr>
+  </table>
+
+  {{#if property}}
+  <h3>Property Details</h3>
+  <table class="property-table">
+    {{#if property.type}}<tr><th>Property Type</th><td>{{property.type}}</td></tr>{{/if}}
+    {{#if property.yearBuilt}}<tr><th>Year Built</th><td>{{property.yearBuilt}}</td></tr>{{/if}}
+    {{#if property.bedrooms}}<tr><th>Bedrooms</th><td>{{property.bedrooms}}</td></tr>{{/if}}
+    {{#if property.bathrooms}}<tr><th>Bathrooms</th><td>{{property.bathrooms}}</td></tr>{{/if}}
+    {{#if property.garaging}}<tr><th>Garaging</th><td>{{property.garaging}}</td></tr>{{/if}}
+    {{#if property.cccStatus}}<tr><th>CCC Status</th><td>{{property.cccStatus}}</td></tr>{{/if}}
+  </table>
+  {{/if}}
+
+  <h3>Personnel</h3>
+  <table class="personnel-table">
+    <tr>
+      <th>Prepared By</th>
+      <td>{{personnel.author.name}} — {{personnel.author.credentials}}</td>
+    </tr>
+    {{#if personnel.reviewer}}
+    <tr>
+      <th>Reviewed By</th>
+      <td>{{personnel.reviewer.name}} — {{personnel.reviewer.credentials}}</td>
+    </tr>
+    {{/if}}
+  </table>
+
+  {{#if personnel.inspectors}}
+  <h3>Inspection Team</h3>
+  <ul>
+    {{#each personnel.inspectors}}
+    <li>{{name}} — {{role}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if findings}}
+  <h3>Summary of Findings</h3>
+  <p>{{findings.summary}}</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/02-introduction.hbs
+++ b/api/templates/ppi/sections/02-introduction.hbs
@@ -1,0 +1,46 @@
+<section class="report-section" id="section-2">
+  <h2>2. Introduction</h2>
+
+  <h3>Purpose</h3>
+  <p>
+    This Pre-Purchase Inspection Report has been prepared in accordance with 
+    <strong>NZS 4306:2005 — Residential Property Inspection</strong>. The purpose 
+    of this inspection is to provide the client with an independent assessment of 
+    the property's condition at the time of inspection.
+  </p>
+
+  <h3>Scope of Inspection</h3>
+  <p>
+    This is a visual inspection of accessible areas only. The inspection covers:
+  </p>
+  <ul>
+    <li>Site and ground conditions</li>
+    <li>Exterior of the building (roof, cladding, joinery, foundation)</li>
+    <li>Interior of the building (all accessible rooms and spaces)</li>
+    <li>Service systems (electrical, plumbing, drainage, ventilation)</li>
+  </ul>
+
+  <h3>Limitations</h3>
+  <p>This inspection does not include:</p>
+  <ul>
+    <li>Invasive or destructive testing</li>
+    <li>Areas concealed by furniture, floor coverings, or stored items</li>
+    <li>Areas that are locked, sealed, or otherwise inaccessible</li>
+    <li>Specialist assessments (structural engineering, geotechnical, asbestos, etc.)</li>
+    <li>Compliance verification with building consents or code</li>
+  </ul>
+
+  {{#if methodology.areasNotAccessed}}
+  <h3>Areas Not Accessed</h3>
+  <p>{{methodology.areasNotAccessed}}</p>
+  {{/if}}
+
+  {{#if methodology.documentsReviewed}}
+  <h3>Documents Reviewed</h3>
+  <ul>
+    {{#each methodology.documentsReviewed}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/03-site-ground.hbs
+++ b/api/templates/ppi/sections/03-site-ground.hbs
@@ -1,0 +1,34 @@
+<section class="report-section" id="section-3">
+  <h2>3. Site and Ground Condition</h2>
+
+  {{#if siteGround}}
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each siteGround.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  {{#if siteGround.notes}}
+  <h3>Additional Notes</h3>
+  <p>{{siteGround.notes}}</p>
+  {{/if}}
+
+  {{else}}
+  <p>No site and ground observations recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/04-exterior.hbs
+++ b/api/templates/ppi/sections/04-exterior.hbs
@@ -1,0 +1,34 @@
+<section class="report-section" id="section-4">
+  <h2>4. Exterior of Building</h2>
+
+  {{#if exterior}}
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each exterior.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  {{#if exterior.notes}}
+  <h3>Additional Notes</h3>
+  <p>{{exterior.notes}}</p>
+  {{/if}}
+
+  {{else}}
+  <p>No exterior observations recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/05-interior.hbs
+++ b/api/templates/ppi/sections/05-interior.hbs
@@ -1,0 +1,204 @@
+<section class="report-section" id="section-5">
+  <h2>5. Interior of Building</h2>
+
+  {{#if interior}}
+
+  {{#if interior.living}}
+  <h3>5.1 Living Areas</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.living.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.kitchen}}
+  <h3>5.2 Kitchen</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.kitchen.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.bedrooms}}
+  <h3>5.3 Bedrooms</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.bedrooms.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.bathrooms}}
+  <h3>5.4 Bathrooms</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.bathrooms.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  {{#if interior.bathrooms.moistureReadings}}
+  <h4>Moisture Readings</h4>
+  <table class="moisture-table">
+    <thead>
+      <tr>
+        <th>Location</th>
+        <th>Reading (%)</th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.bathrooms.moistureReadings}}
+      <tr class="moisture-{{lowercase result}}">
+        <td>{{location}}</td>
+        <td>{{reading}}</td>
+        <td class="result-{{lowercase result}}">{{result}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+  {{/if}}
+
+  {{#if interior.laundry}}
+  <h3>5.5 Laundry</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.laundry.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.garage}}
+  <h3>5.6 Garage</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.garage.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.attic}}
+  <h3>5.7 Roof Space / Attic</h3>
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each interior.attic.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if interior.notes}}
+  <h3>Additional Notes</h3>
+  <p>{{interior.notes}}</p>
+  {{/if}}
+
+  {{else}}
+  <p>No interior observations recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/06-services.hbs
+++ b/api/templates/ppi/sections/06-services.hbs
@@ -1,0 +1,34 @@
+<section class="report-section" id="section-6">
+  <h2>6. Service Systems</h2>
+
+  {{#if services}}
+  <table class="inspection-table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Condition</th>
+        <th>Observations</th>
+        <th>Photos</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each services.items}}
+      <tr class="{{#if issue}}has-issue{{/if}}">
+        <td>{{name}}</td>
+        <td class="condition-{{lowercase condition}}">{{condition}}</td>
+        <td>{{observations}}</td>
+        <td>{{photoRef photoRefs}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  {{#if services.notes}}
+  <h3>Additional Notes</h3>
+  <p>{{services.notes}}</p>
+  {{/if}}
+
+  {{else}}
+  <p>No service system observations recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/07-conclusions.hbs
+++ b/api/templates/ppi/sections/07-conclusions.hbs
@@ -1,0 +1,41 @@
+<section class="report-section" id="section-7">
+  <h2>7. Conclusions and Recommendations</h2>
+
+  {{#if conclusions}}
+  <h3>Overall Assessment</h3>
+  <p class="conclusion-{{lowercase conclusions.rating}}">
+    <strong>{{conclusions.rating}}</strong>
+  </p>
+  <p>{{conclusions.summary}}</p>
+
+  {{#if conclusions.immediateAttention}}
+  <h3>Items Requiring Immediate Attention</h3>
+  <ul class="attention-list priority-high">
+    {{#each conclusions.immediateAttention}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if conclusions.maintenance}}
+  <h3>Maintenance Items</h3>
+  <ul class="maintenance-list">
+    {{#each conclusions.maintenance}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if conclusions.furtherInvestigation}}
+  <h3>Recommended Further Investigation</h3>
+  <ul class="investigation-list">
+    {{#each conclusions.furtherInvestigation}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{else}}
+  <p>No conclusions recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/08-signatures.hbs
+++ b/api/templates/ppi/sections/08-signatures.hbs
@@ -1,0 +1,34 @@
+<section class="report-section signatures" id="section-8">
+  <h2>8. Declaration</h2>
+
+  <div class="declaration">
+    <p>
+      I hereby declare that this inspection was carried out in accordance with 
+      NZS 4306:2005 — Residential Property Inspection. This report represents 
+      the condition of the property at the time of inspection and is based on 
+      visual examination of accessible areas only.
+    </p>
+    <p>
+      This report is prepared for the exclusive use of the client named herein 
+      and may not be relied upon by any other party without written consent.
+    </p>
+  </div>
+
+  <div class="signature-blocks">
+    <div class="signature-block">
+      <div class="signature-line"></div>
+      <p class="sig-name">{{personnel.author.name}}</p>
+      <p class="sig-credentials">{{personnel.author.credentials}}</p>
+      <p class="sig-date">Date: {{formatDate generatedAt}}</p>
+    </div>
+
+    {{#if personnel.reviewer}}
+    <div class="signature-block">
+      <div class="signature-line"></div>
+      <p class="sig-name">{{personnel.reviewer.name}}</p>
+      <p class="sig-credentials">{{personnel.reviewer.credentials}}</p>
+      <p class="sig-date">Date: {{formatDate generatedAt}}</p>
+    </div>
+    {{/if}}
+  </div>
+</section>

--- a/api/templates/ppi/styles/report.css
+++ b/api/templates/ppi/styles/report.css
@@ -1,0 +1,313 @@
+/* PPI Report — Print-Optimized Styles (NZS 4306:2005) */
+
+/* ─── Page Setup ─── */
+@page {
+  size: A4;
+  margin: 25mm 20mm;
+}
+
+@media print {
+  body { margin: 0; }
+  .report-section { page-break-inside: avoid; }
+  .appendix { page-break-before: always; }
+  .signatures { page-break-before: always; }
+  .photo-item { page-break-inside: avoid; }
+}
+
+/* ─── Base ─── */
+body {
+  font-family: 'Arial', 'Helvetica Neue', sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #1a1a1a;
+  max-width: 210mm;
+  margin: 0 auto;
+}
+
+h1 { font-size: 20pt; margin-bottom: 4mm; color: #003366; }
+h2 { font-size: 14pt; margin-top: 8mm; margin-bottom: 4mm; color: #003366; border-bottom: 1px solid #003366; padding-bottom: 2mm; }
+h3 { font-size: 12pt; margin-top: 6mm; margin-bottom: 3mm; color: #333; }
+h4 { font-size: 11pt; margin-top: 4mm; margin-bottom: 2mm; color: #333; }
+
+p { margin: 3mm 0; }
+ul { margin: 2mm 0; padding-left: 6mm; }
+li { margin: 1mm 0; }
+
+/* ─── Header / Footer ─── */
+.report-header {
+  border-bottom: 2px solid #003366;
+  padding-bottom: 4mm;
+  margin-bottom: 8mm;
+}
+
+.report-header h1 { margin: 0; }
+.job-number { font-size: 12pt; color: #666; margin: 1mm 0; }
+.report-date { font-size: 10pt; color: #666; }
+
+.report-footer {
+  margin-top: 10mm;
+  padding-top: 4mm;
+  border-top: 1px solid #ccc;
+  font-size: 9pt;
+  color: #666;
+  text-align: center;
+}
+
+.confidential { font-weight: bold; text-transform: uppercase; letter-spacing: 0.5mm; }
+
+/* ─── Tables ─── */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 4mm 0;
+  font-size: 10pt;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 2mm 3mm;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #f0f4f8;
+  font-weight: bold;
+  color: #003366;
+}
+
+.summary-table th { width: 35%; }
+.property-table th { width: 35%; }
+.personnel-table th { width: 25%; }
+
+/* ─── Inspection Tables ─── */
+.inspection-table th:nth-child(1) { width: 25%; }
+.inspection-table th:nth-child(2) { width: 15%; }
+.inspection-table th:nth-child(3) { width: 45%; }
+.inspection-table th:nth-child(4) { width: 15%; }
+
+.has-issue { background: #fff8f8; }
+
+/* Condition Styling */
+.condition-good { color: #27ae60; font-weight: bold; }
+.condition-fair { color: #f39c12; font-weight: bold; }
+.condition-poor { color: #e74c3c; font-weight: bold; }
+.condition-na { color: #7f8c8d; font-style: italic; }
+
+/* ─── Moisture Readings Table ─── */
+.moisture-table th { background: #003366; color: white; font-size: 9pt; }
+.moisture-table td { text-align: center; }
+.moisture-table td:first-child { text-align: left; }
+
+.result-acceptable { background: #d4edda; color: #155724; font-weight: bold; }
+.result-marginal { background: #fff3cd; color: #856404; font-weight: bold; }
+.result-unacceptable { background: #f8d7da; color: #721c24; font-weight: bold; }
+
+.moisture-acceptable { background: #f8fff8; }
+.moisture-marginal { background: #fffef8; }
+.moisture-unacceptable { background: #fff8f8; }
+
+/* ─── Conclusions ─── */
+.conclusion-good { 
+  color: #27ae60; 
+  font-size: 14pt;
+  padding: 4mm;
+  background: #d4edda;
+  border-radius: 2mm;
+}
+
+.conclusion-fair { 
+  color: #f39c12; 
+  font-size: 14pt;
+  padding: 4mm;
+  background: #fff3cd;
+  border-radius: 2mm;
+}
+
+.conclusion-poor { 
+  color: #e74c3c; 
+  font-size: 14pt;
+  padding: 4mm;
+  background: #f8d7da;
+  border-radius: 2mm;
+}
+
+.attention-list { color: #c0392b; }
+.attention-list li { font-weight: bold; }
+.maintenance-list { color: #333; }
+.investigation-list { color: #8e44ad; font-style: italic; }
+
+/* ─── Signatures ─── */
+.declaration {
+  margin: 6mm 0;
+  padding: 4mm;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 2mm;
+}
+
+.signature-blocks {
+  display: flex;
+  gap: 20mm;
+  margin-top: 10mm;
+}
+
+.signature-block {
+  flex: 1;
+}
+
+.signature-line {
+  border-bottom: 1px solid #333;
+  height: 15mm;
+  margin-bottom: 2mm;
+}
+
+.sig-name { font-weight: bold; margin: 1mm 0; }
+.sig-credentials { font-size: 10pt; color: #666; margin: 1mm 0; }
+.sig-date { font-size: 10pt; color: #666; margin: 1mm 0; }
+
+/* ─── Photo Grid ─── */
+.photo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6mm;
+  margin: 4mm 0;
+}
+
+.photo-item {
+  border: 1px solid #ddd;
+  padding: 2mm;
+}
+
+.photo-item img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.photo-item figcaption {
+  font-size: 9pt;
+  padding: 2mm 0;
+  text-align: center;
+}
+
+.photo-location { color: #666; font-style: italic; }
+
+/* ─── Cover Page ─── */
+.cover-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 20mm;
+}
+
+.cover-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15mm;
+  max-width: 160mm;
+}
+
+.cover-header {
+  margin-bottom: 10mm;
+}
+
+.cover-logo {
+  max-width: 80mm;
+  max-height: 30mm;
+  object-fit: contain;
+}
+
+.cover-logo-placeholder {
+  font-size: 18pt;
+  font-weight: bold;
+  color: #003366;
+  padding: 10mm 20mm;
+  border: 2px solid #003366;
+}
+
+.cover-title h1 {
+  font-size: 24pt;
+  color: #003366;
+  margin: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.cover-standard {
+  font-size: 12pt;
+  color: #666;
+  font-style: italic;
+  margin-top: 2mm;
+}
+
+.cover-details {
+  margin: 10mm 0;
+}
+
+.cover-address {
+  font-size: 16pt;
+  font-weight: bold;
+  margin-bottom: 8mm;
+  color: #1a1a1a;
+}
+
+.cover-client,
+.cover-job-number,
+.cover-date {
+  font-size: 12pt;
+  margin: 3mm 0;
+  color: #333;
+}
+
+.cover-details .label,
+.cover-footer .label {
+  font-weight: bold;
+  color: #003366;
+}
+
+.cover-footer {
+  margin-top: 20mm;
+  padding-top: 10mm;
+  border-top: 1px solid #ccc;
+}
+
+.cover-prepared-by,
+.cover-reviewed-by {
+  font-size: 11pt;
+  margin: 3mm 0;
+}
+
+.cover-footer .credentials {
+  font-size: 10pt;
+  color: #666;
+}
+
+/* ─── Table of Contents ─── */
+.table-of-contents {
+  margin: 8mm 0;
+  padding: 6mm;
+}
+
+.table-of-contents h2 {
+  font-size: 14pt;
+  color: #003366;
+  margin-bottom: 6mm;
+  border-bottom: 1px solid #003366;
+  padding-bottom: 2mm;
+}
+
+/* ─── Print: Cover & TOC Pages ─── */
+@media print {
+  .cover-page {
+    page-break-after: always;
+  }
+
+  .table-of-contents {
+    page-break-after: always;
+  }
+}


### PR DESCRIPTION
## Summary
Add Pre-Purchase Inspection (NZS 4306:2005) report template to enable PDF generation for PPI inspections.

## Changes
- Created `api/templates/ppi/` directory with full template structure:
  - `base.hbs`: Main layout with header, sections, appendices, footer
  - `cover.hbs`: Cover page with property details and credentials
  - `sections/01-08`: Executive summary, introduction, site/ground, exterior, interior (with moisture readings), services, conclusions/recommendations, signatures
  - `appendices/photos.hbs`: Photo grid with captions
  - `styles/report.css`: Print-optimized A4 styles

- Added comprehensive tests for PPI template rendering

## Testing
- All template-engine tests pass (17 tests)
- Typecheck passes
- Lint passes (only pre-existing warnings)

## Root Cause
PPI inspections could be completed via WhatsApp but PDF generation failed because no PPI template existed (only CCC and COA templates were present).

Fixes #535