### PR TITLE
[Riley] docs(design): PPI, SS, CCC doc control, property metadata

### DIFF
--- a/docs/developer/design/017-ppi-report-template.md
+++ b/docs/developer/design/017-ppi-report-template.md
@@ -1,0 +1,160 @@
+# Design: PPI Report Template
+
+**Status:** Draft
+**Author:** Riley
+**Requirement:** #539
+**Date:** 2026-02-28
+
+## Context
+
+Pre-Purchase Inspection (PPI) reports follow NZS 4306:2005, not NZBC clause review. The structure is fundamentally different from COA/CCC — inspectors assess by **building element** (site → exterior → interior → services) with narrative conclusions per section, not a clause-by-clause table.
+
+Analysis of real PPI reports (`docs/domain/report-analysis.md`) shows the Abacus/Eastern format has 11 sections + 3 appendices.
+
+## Decision
+
+Add a PPI report type using the existing template engine (Handlebars + Puppeteer) with PPI-specific templates. Reuse shared infrastructure (template engine, PDF renderer, photo embedder, variable substitution) but with a new template directory and section structure.
+
+## Architecture
+
+### Template Directory Structure
+
+```
+api/templates/ppi/
+  base.hbs                    # Main layout
+  cover.hbs                   # Cover page
+  sections/
+    01-report-info-summary.hbs
+    02-introduction.hbs
+    03-building-site-description.hbs
+    04-inspection-methodology.hbs
+    05-summary-of-inspection.hbs
+    06-site-ground-condition.hbs
+    07-exterior.hbs
+    08-interior.hbs
+    09-service-systems.hbs
+    10-limitations.hbs
+    11-signatures.hbs
+  appendices/
+    a-photos.hbs
+    b-thermal-imaging.hbs
+    c-floor-level-survey.hbs
+  partials/
+    header.hbs
+    footer.hbs
+    section-conclusion.hbs
+```
+
+### Data Model Changes
+
+```prisma
+// Add PPI to existing ReportType enum
+enum ReportType {
+  COA
+  CCC
+  PPI        // NEW
+  SS         // NEW (for #540)
+}
+```
+
+No new entities required — PPI uses the existing inspection data model. The key difference is **how the data is presented**, not what data is captured.
+
+### PPI-Specific Template Data
+
+The template context needs these PPI-specific fields:
+
+```typescript
+interface PPITemplateData {
+  // Report metadata (shared)
+  reportInfo: ReportInfoSummary;
+
+  // Building info (PPI-specific additions)
+  buildingInfo: {
+    bedrooms: number;
+    bathrooms: number;
+    yearBuilt: number;
+    cccStatus: string;    // "CCC & Title Issued" | "No CCC" | etc.
+    garaging: string;
+  };
+
+  // Section assessments (PPI-specific structure)
+  sections: {
+    siteAndGround: PPISection;
+    exterior: PPISection;
+    interior: PPISection;
+    serviceSystems: PPISection;
+  };
+
+  // Overall condition (PPI-specific)
+  overallCondition: 'above-average' | 'average' | 'below-average';
+  summaryText: string;
+
+  // Appendices
+  thermalImaging?: ThermalImage[];
+  floorLevelSurvey?: FloorLevelData;
+}
+
+interface PPISection {
+  narrativeText: string;
+  conclusion: string;       // "No obvious defects" or findings
+  photoRefs: string;        // "Photograph 1~10" (range notation)
+  needsAttention: boolean;
+  needsFurtherInvestigation: boolean;
+}
+```
+
+### Section Content Guide
+
+| Section | Content | Data Source |
+|---------|---------|-------------|
+| Report Info Summary | Project #, activity ("Pre-purchase Inspection"), address, client, TA, author, inspector, date, weather | Report + Project + Personnel |
+| Introduction | Engagement statement + purpose (NZS 4306:2005 reference) | Template boilerplate + variables |
+| Building & Site | Site info (zones from BRANZ), building info (rooms, year, CCC status) | Property + zone data (#543) |
+| Methodology | Personnel credentials, inspection approach, equipment | Personnel + template |
+| Summary | Overall condition rating + key findings | Inspector input |
+| Site & Ground | Topography, access paths, garden areas | Inspector narrative |
+| Exterior | Roof, cladding, joinery, foundation | Inspector narrative |
+| Interior | Room-by-room condition | Inspector narrative |
+| Service Systems | Power, water, gas, drainage, alarms, ventilation | Inspector narrative |
+| Limitations | Standard disclaimers | Template boilerplate |
+| Signatures | Author signature block | Personnel |
+
+### Photo Reference Convention
+
+PPI uses range notation: `[ Appendix A ] Photograph 1~10`
+
+The photo embedder needs to support this format alongside the existing comma-separated format used by COA (`Photograph 7,8,9`).
+
+### Seed Templates
+
+Seed the following PPI boilerplate templates:
+
+**Introduction:**
+> "[Company Name] have been engaged to carry out a pre-purchase inspection at [Property Address]. The purpose of this inspection is to independently inspect and report on the condition of the building works and findings of defects during inspection against relevant clauses of the New Zealand Standard 4306:2005 [Residential Property Inspection]."
+
+**Limitations:**
+> Standard PPI limitations text (longer than COA — covers asbestos, concealed elements, intermittent faults, etc.)
+
+## Dependencies
+
+- #543 (BRANZ zone data) — needed for Building & Site Description section
+- Existing template engine, PDF renderer, variable substitution
+
+## Stories Breakdown
+
+_(To be created after design approval)_
+
+Estimated stories:
+1. Add PPI to ReportType enum + API support
+2. Create PPI Handlebars templates (sections 1-11)
+3. Create PPI appendix templates (photos, thermal, floor survey)
+4. Add PPI section data capture API (narrative + conclusion per section)
+5. Seed PPI boilerplate templates
+6. Add PPI to report generation service
+7. PPI photo range notation support
+
+## Alternatives Considered
+
+**Reuse COA template with different sections** — Rejected. The structure is too different (narrative vs table). Sharing a base template would create a mess of conditionals.
+
+**Separate PPI inspection flow** — Rejected. PPI uses the same inspection data; only the report presentation differs. No need for a separate inspection model.

--- a/docs/developer/design/018-safe-sanitary-template.md
+++ b/docs/developer/design/018-safe-sanitary-template.md
@@ -1,0 +1,152 @@
+# Design: Safe & Sanitary Report Template
+
+**Status:** Draft
+**Author:** Riley
+**Requirement:** #540
+**Date:** 2026-02-28
+
+## Context
+
+Safe & Sanitary (SS) reports assess pre-1992 building work against Building Act 1991 s.64 — not NZBC clauses. The report determines:
+1. Is the building **unsafe** (s.64(1))? — likely to cause injury/death
+2. Is the building **insanitary** (s.64(4))? — offensive, damp, no potable water, inadequate facilities
+
+SS reports are the simplest type (10–20 pages). They share boilerplate with COA but use a different assessment framework.
+
+Analysis: `docs/domain/report-analysis.md` — Type 4: SS section.
+
+## Decision
+
+Add an SS report type using the existing template engine. Shares many partials with COA (cover, intro, limitations, signatures) but has its own assessment framework table template.
+
+## Architecture
+
+### Template Directory Structure
+
+```
+api/templates/ss/
+  base.hbs
+  cover.hbs
+  sections/
+    01-report-info-summary.hbs
+    02-introduction.hbs
+    03-building-site-description.hbs
+    04-assessment-methodology.hbs
+    05-assessment-framework.hbs    # Core — unique to SS
+    06-remedial-works.hbs
+    07-summary.hbs
+    08-limitations.hbs
+    09-signatures.hbs
+  appendices/
+    a-photos.hbs
+  partials/
+    header.hbs
+    footer.hbs
+```
+
+### Data Model Changes
+
+```prisma
+enum ReportType {
+  COA
+  CCC
+  PPI
+  SS        // NEW
+}
+```
+
+### Assessment Framework Table
+
+The core of SS reports — a table assessing building elements against s.64:
+
+```typescript
+interface SSAssessmentItem {
+  // Building element group
+  items: string;              // "Foundation", "Walls", "Roof", "Joinery", etc.
+  details: string;            // "Raised Perimeter Block Wall and Post and Pier Foundation"
+
+  // Assessment
+  photoRefs: string;          // "Photograph 5,6,7,8,9,10,11"
+  observations: string;       // Detailed observations
+  complianceRequirement: string; // Building Act 1991 s.64(1) or s.64(4) text
+  remedialWorks: string;      // "Nil" or specific works
+
+  // Classification
+  assessmentType: 'safety' | 'sanitary';
+}
+
+interface SSTemplateData {
+  reportInfo: ReportInfoSummary;
+  buildingInfo: SSBuildingInfo;
+  assessmentItems: SSAssessmentItem[];
+
+  // Conclusions
+  isSafe: boolean;
+  isSanitary: boolean;
+  summaryText: string;
+  remedialWorksNeeded: boolean;
+  remedialWorksSummary: string;
+}
+
+interface SSBuildingInfo {
+  buildingType: string;       // "Townhouse"
+  buildingYear: number;       // 1969
+  climateZone: string;
+  earthquakeZone: string;
+  exposureZone: string;
+  windZone: string;
+  rainfallRange: string;
+}
+```
+
+### Safety vs Sanitary Assessment
+
+The assessment table is split into two blocks:
+
+**Safety (s.64(1)):** Foundation, Walls, Roof, Joinery, Block Party Wall, Smoke Alarms
+> "Based on the on-site visual inspection... no apparent unsafe conditions were observed. Considering the building has been in safe service for over [X] years, it is concluded that the building does not meet the definition of an unsafe building under Building Act 1991, Section 64(1)."
+
+**Sanitary (s.64(4)):** Shower, Vanity, Bath, Toilet, Kitchen Sink, Hot Water, Drainage, Ventilation
+> "As observations and analysis above, it is concluded that the building does not meet the definition of an insanitary building under Building Act 1991, Section 64(4)."
+
+### Shared Partials
+
+Reuse from COA where text is identical:
+- Cover page layout (shared partial, different title)
+- Report Information Summary format
+- Limitations boilerplate
+- Signature block format
+- Photo appendix format
+
+### Seed Templates
+
+**Introduction:**
+> "[Company Name] have been engaged to carry out an independent assessment of the building works carried out before 1 July 1992 at [Property Address] to verify on reasonable grounds that the building work is safe and sanitary for its intended purpose."
+
+**Summary (pass):**
+> "Following review of site works and comparing with compliance requirement, it is concluded that the building of [Property Address] is in Safe and Sanitary condition."
+
+**Summary (fail):**
+> "Following review of site works, remedial works are required to bring the building into safe and sanitary condition as outlined in Section [X]."
+
+## Dependencies
+
+- #543 (BRANZ zone data) — needed for building info
+- Shared partials from COA templates
+
+## Stories Breakdown
+
+_(To be created after design approval)_
+
+Estimated stories:
+1. Add SS to ReportType enum + API support
+2. Create SS Handlebars templates (sections 1-9)
+3. Create SS assessment framework data capture API
+4. Seed SS boilerplate templates
+5. Add SS to report generation service
+
+## Alternatives Considered
+
+**Reuse COA assessment table** — Rejected. COA assesses against NZBC clauses; SS assesses against Building Act 1991 s.64. Different columns, different compliance text.
+
+**Merge with COA as "compliance report"** — Rejected. SS is specifically for pre-1992 work and uses a different legal framework. Merging would confuse the user.

--- a/docs/developer/design/019-ccc-document-control.md
+++ b/docs/developer/design/019-ccc-document-control.md
@@ -1,0 +1,171 @@
+# Design: CCC Executive Summary & Document Control
+
+**Status:** Draft
+**Author:** Riley
+**Requirement:** #541
+**Date:** 2026-02-28
+
+## Context
+
+Real CCC Gap Analysis reports have two sections our templates don't generate:
+
+1. **Document Control Records** (page 2, before TOC) — revision history + acceptance sign-off
+2. **Executive Summary** (after TOC, before Section 1) — key findings at a glance
+
+These are CCC-specific — COA/PPI/SS reports do not use them.
+
+Analysis: `docs/domain/report-analysis.md` — Type 2: CCC section.
+
+## Decision
+
+Add two new template sections to the CCC report template. Both can be auto-populated from existing data.
+
+## Architecture
+
+### 1. Document Control Records
+
+Added after cover page, before TOC.
+
+```
+Document Control Records
+
+Document Prepared by:
+  [Author Name]
+  for and on behalf of [Company Name]
+
+  Telephone:    [Phone]
+  Email:        [Email]
+
+Revision History
+| Revision No. | Prepared By | Description        | Date       |
+|--------------|-------------|--------------------|------------|
+| R1           | Jake Li     | First draft        | 01/12/2025 |
+| R2           | Ian Fong    | Review comments    | 05/12/2025 |
+| R3           | Ian Fong    | Final              | 16/12/2025 |
+
+Document Acceptance
+| Action    | Name     | Signed | Date       |
+|-----------|----------|--------|------------|
+| Prepared  | Jake Li  |        | 16/12/2025 |
+| Reviewed  | Ian Fong |        | 16/12/2025 |
+```
+
+**Data source:** Existing report versioning data + personnel data. No new entities needed.
+
+```typescript
+interface DocumentControlData {
+  preparedBy: {
+    name: string;
+    company: string;
+    phone: string;
+    email: string;
+  };
+  revisionHistory: {
+    revisionNo: string;      // "R1", "R2", "R3"
+    preparedBy: string;
+    description: string;
+    date: string;
+  }[];
+  documentAcceptance: {
+    action: string;          // "Prepared", "Reviewed"
+    name: string;
+    signed: boolean;
+    date: string;
+  }[];
+}
+```
+
+### 2. Executive Summary
+
+Added after TOC, before Section 1.
+
+Auto-generated from defect data:
+
+```
+EXECUTIVE SUMMARY
+
+Non-invasive site investigations to the property has identified the following:
+
+  • Roof parapet – absence of cap flashings and kick-out flashings.
+  • Wall Claddings – lack of control joints / deck and ground clearance
+  • Window / Door Joinery – lack of head / jamb / sill flashings
+  • Sub-floor – Garage timber-framed walls in direct-contact with natural ground
+
+The above result in a breach of Building Code clauses:
+  o B1 Structure
+  o B2 Durability
+  o E2 External Moisture
+  o F7 Warning Systems
+
+To resolve this, [remedial recommendation summary].
+```
+
+**Data source:** Generated from defect schedule data.
+
+```typescript
+interface ExecutiveSummaryData {
+  findings: string[];           // Bullet list of key findings
+  breachedClauses: string[];    // ["B1 Structure", "B2 Durability", ...]
+  remedialRecommendation: string; // High-level recommendation
+}
+
+// Auto-generation logic:
+// 1. findings = defects grouped by area, summarised
+// 2. breachedClauses = unique NZBC clauses from all defects
+// 3. remedialRecommendation = from report's recommendation field
+```
+
+### Template Changes
+
+```
+api/templates/ccc/
+  sections/
+    00-document-control.hbs    # NEW
+    00-executive-summary.hbs   # NEW
+    ... (existing sections unchanged)
+```
+
+Update `base.hbs` to include new sections in render order:
+1. Cover → **Document Control** → TOC → **Executive Summary** → Section 1...
+
+### API Changes
+
+New endpoint to set/override executive summary text:
+
+```
+PUT /api/reports/:id/executive-summary
+{
+  "findings": ["string"],
+  "breachedClauses": ["string"],
+  "remedialRecommendation": "string"
+}
+```
+
+Auto-generation endpoint:
+```
+POST /api/reports/:id/executive-summary/generate
+```
+→ Generates from defect data, returns preview. Inspector can edit before finalizing.
+
+## Dependencies
+
+- Existing CCC templates
+- Existing defect schedule data
+- Existing report versioning
+
+## Stories Breakdown
+
+_(To be created after design approval)_
+
+Estimated stories:
+1. Create Document Control template + data mapping
+2. Create Executive Summary template + auto-generation service
+3. Executive Summary API (generate + override)
+4. Update CCC base template render order
+5. Seed Document Control boilerplate
+
+## Alternatives Considered
+
+**Manual-only Executive Summary** — Rejected. Can be 80% auto-generated from defect data. Manual override for the remaining 20%.
+
+**Add Document Control to all report types** — Rejected. Only CCC uses it per industry practice. Can extend later if needed.

--- a/docs/developer/design/020-property-metadata.md
+++ b/docs/developer/design/020-property-metadata.md
@@ -1,0 +1,174 @@
+# Design: Property Metadata — Building History & Zone Data
+
+**Status:** Draft
+**Author:** Riley
+**Requirement:** #542, #543
+**Date:** 2026-02-28
+
+## Context
+
+Real reports across all types include two standard property metadata sections we don't capture:
+
+1. **Building History** (#542) — consent history table showing what work was done and when
+2. **BRANZ Zone Data** (#543) — climate, earthquake, wind, exposure zones from BRANZ Maps
+
+Both appear in the Building & Site Description section of every report type.
+
+Analysis: `docs/domain/report-analysis.md` — Cross-Type Patterns section.
+
+## Decision
+
+Extend the Property entity with zone data fields and add a new BuildingHistory entity. Both are simple schema additions with CRUD API and template rendering.
+
+## Architecture
+
+### Data Model Changes
+
+```prisma
+// Extend existing Property model
+model Property {
+  // ... existing fields ...
+
+  // BRANZ Zone Data (#543)
+  climateZone       String?    // "1", "2", "3"
+  earthquakeZone    String?    // "Zone 1", "Zone 2"
+  exposureZone      String?    // "Zone A", "Zone B", "Zone C", "Zone D"
+  leeZone           String?    // "Yes", "No"
+  rainfallRange     String?    // "80-90", "90-100"
+  windRegion        String?    // "A", "W"
+  windZone          String?    // "Low", "Medium", "High", "Very High", "Extra High"
+
+  // Relations
+  buildingHistory   BuildingHistory[]
+}
+
+// New entity (#542)
+model BuildingHistory {
+  id              String    @id @default(uuid())
+  propertyId      String
+  property        Property  @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  description     String    // "Multi unit dwelling", "Extension", "Garage conversion"
+  consentType     String?   // "Building Permit", "Building Consent"
+  consentNumber   String?   // "E15938", "BA/05236/02"
+  dateGranted     DateTime?
+  notes           String?
+
+  sortOrder       Int       @default(0)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@index([propertyId])
+}
+```
+
+### API Endpoints
+
+#### Zone Data (on Property)
+
+Existing property CRUD handles this — just new fields on `PUT /api/properties/:id`.
+
+#### Building History
+
+```
+POST   /api/properties/:id/building-history     # Add entry
+GET    /api/properties/:id/building-history     # List entries (sorted)
+PUT    /api/building-history/:id               # Update entry
+DELETE /api/building-history/:id               # Remove entry
+```
+
+Request body:
+```json
+{
+  "description": "Extension",
+  "consentType": "Building Consent",
+  "consentNumber": "BA/05236/02",
+  "dateGranted": "2002-04-05",
+  "notes": "Ground floor extension + exterior decks"
+}
+```
+
+### Template Rendering
+
+#### Zone Data Table (all report types)
+
+```handlebars
+<table>
+  <tr><td>Climate Zone</td><td>{{property.climateZone}}</td></tr>
+  <tr><td>Earthquake Zone</td><td>{{property.earthquakeZone}}</td></tr>
+  <tr><td>Exposure Zone</td><td>{{property.exposureZone}}</td></tr>
+  <tr><td>Lee Zone</td><td>{{property.leeZone}}</td></tr>
+  <tr><td>Rainfall Range</td><td>{{property.rainfallRange}}</td></tr>
+  <tr><td>Wind Region</td><td>{{property.windRegion}}</td></tr>
+  <tr><td>Wind Zone</td><td>{{property.windZone}}</td></tr>
+</table>
+```
+
+#### Building History Table (COA, CCC)
+
+```handlebars
+<table>
+  <tr>
+    <th>Building Works</th>
+    <th>Consent</th>
+    <th>Date Granted</th>
+  </tr>
+  {{#each buildingHistory}}
+  <tr>
+    <td>{{this.description}}</td>
+    <td>{{this.consentType}} # {{this.consentNumber}}</td>
+    <td>{{formatDate this.dateGranted}}</td>
+  </tr>
+  {{/each}}
+</table>
+```
+
+### Frontend Changes
+
+#### Property Form — Zone Data Fields
+
+Add 7 new fields to the property edit form:
+- Climate Zone (dropdown: 1, 2, 3)
+- Earthquake Zone (dropdown: Zone 1, Zone 2)
+- Exposure Zone (dropdown: Zone A, B, C, D)
+- Lee Zone (dropdown: Yes, No)
+- Rainfall Range (text input)
+- Wind Region (dropdown: A, W)
+- Wind Zone (dropdown: Low, Medium, High, Very High, Extra High)
+
+Group under a "Site Data (BRANZ Maps)" section.
+
+#### Property Page — Building History Table
+
+Add an editable table on the property page:
+- Add row button
+- Inline editing for description, consent type, consent number, date
+- Delete row button
+- Drag to reorder (sortOrder)
+
+### Nice to Have (Future)
+
+**BRANZ Maps Auto-Lookup:** If BRANZ provides a geocoding API, auto-populate zone data from the property address. Out of scope for now — manual entry first.
+
+## Dependencies
+
+- Existing Property model
+- Template rendering for all report types
+
+## Stories Breakdown
+
+_(To be created after design approval)_
+
+Estimated stories:
+1. Add zone data fields to Property schema + migration
+2. Add BuildingHistory entity + CRUD API
+3. Update property form with zone data fields (frontend)
+4. Add building history table to property page (frontend)
+5. Add zone data + building history to report templates (all types)
+6. Register new endpoints in OpenAPI
+
+## Alternatives Considered
+
+**Separate ZoneData entity** — Rejected. Zone data is 1:1 with Property. Flat fields are simpler than a separate table.
+
+**Building history as JSON column** — Rejected. Separate entity allows proper CRUD, validation, and ordering. Worth the extra table.


### PR DESCRIPTION
📐 **Riley** — Design Docs

4 design documents for the new requirements identified from report analysis (#537).

| Doc | Requirement | Summary |
|-----|------------|---------|
| `017-ppi-report-template.md` | #539 | PPI report type — NZS 4306:2005 element-based assessment, 11 sections + 3 appendices (photos, thermal imaging, floor survey) |
| `018-safe-sanitary-template.md` | #540 | SS report type — Building Act 1991 s.64 framework, safety + sanitary assessment table |
| `019-ccc-document-control.md` | #541 | CCC additions — Document Control (revision history) + Executive Summary (auto-generated from defects) |
| `020-property-metadata.md` | #542, #543 | Property schema additions — BRANZ zone data (7 fields) + BuildingHistory entity (consent table) |

Each doc includes: context, data model, template structure, API changes, frontend needs, story breakdown estimates, and alternatives considered.

**Awaiting Master approval before creating user stories.**