### PR TITLE
feat(api): add Document Control page to CCC reports

### DIFF
--- a/api/src/__tests__/template-engine.test.ts
+++ b/api/src/__tests__/template-engine.test.ts
@@ -433,3 +433,140 @@ describe('PPI Templates', () => {
     });
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CCC Document Control Tests — Issue #546
+// ──────────────────────────────────────────────────────────────────────────────
+
+function makeCCCReportData(withDocControl = true) {
+  const base = {
+    generatedAt: new Date('2026-02-20T10:00:00Z'),
+    project: {
+      jobNumber: 'CCC-2026-001',
+      activity: 'Bathroom renovation',
+      address: '123 Test Street, Auckland',
+      client: 'Test Client Ltd',
+      council: 'Auckland Council',
+      company: 'Apex Inspection Services',
+    },
+    personnel: {
+      author: {
+        name: 'Jake Li',
+        credentials: 'BSCE, LBP #12345',
+        phone: '021 123 4567',
+        email: 'jake@eastern.co.nz',
+      },
+      reviewer: {
+        name: 'John Smith',
+        credentials: 'MSCE, LBP #67890',
+      },
+      inspectors: [
+        { name: 'Jake Li', role: 'Lead Inspector' },
+      ],
+    },
+    inspection: {
+      date: '2026-02-15T00:00:00Z',
+      weather: 'Fine, 22°C',
+    },
+    defects: [
+      { description: 'Flashing issue at window', severity: 'major' },
+    ],
+  };
+
+  if (withDocControl) {
+    return {
+      ...base,
+      documentControl: {
+        revisions: [
+          { revNo: 1, preparedBy: 'J. Li', description: 'Initial Issue', date: '2026-02-15' },
+          { revNo: 2, preparedBy: 'J. Li', description: 'Updated findings', date: '2026-02-18' },
+        ],
+        acceptance: [
+          { action: 'Prepared', name: 'Jake Li', signed: true, date: '2026-02-18' },
+          { action: 'Reviewed', name: 'John Smith', signed: false },
+          { action: 'Approved', name: '', signed: false },
+        ],
+      },
+    };
+  }
+
+  return base;
+}
+
+describe('CCC Document Control — #546', () => {
+  describe('renderReport', () => {
+    it('renders Document Control page when documentControl data is provided', async () => {
+      const data = makeCCCReportData(true);
+      const html = await renderReport({ reportType: 'ccc', data });
+
+      // Document Control content appears
+      expect(html).toContain('Document Control Records');
+      expect(html).toContain('Revision History');
+      expect(html).toContain('Initial Issue');
+      expect(html).toContain('Updated findings');
+      expect(html).toContain('J. Li');
+
+      // Document Acceptance
+      expect(html).toContain('Document Acceptance');
+      expect(html).toContain('Prepared');
+      expect(html).toContain('Reviewed');
+      expect(html).toContain('Approved');
+      expect(html).toContain('Jake Li');
+      expect(html).toContain('John Smith');
+    });
+
+    it('omits Document Control page when no documentControl data', async () => {
+      const data = makeCCCReportData(false);
+      const html = await renderReport({ reportType: 'ccc', data });
+
+      expect(html).not.toContain('Document Control Records');
+      expect(html).not.toContain('Revision History');
+    });
+
+    it('Document Control appears before Table of Contents in HTML', async () => {
+      const data = makeCCCReportData(true);
+      (data as Record<string, unknown>).tableOfContents = '<ul><li>Section 1</li></ul>';
+      const html = await renderReport({ reportType: 'ccc', data });
+
+      const docControlPos = html.indexOf('Document Control Records');
+      const tocPos = html.indexOf('<nav class="table-of-contents"');
+
+      // If TOC exists, Document Control must come first
+      if (tocPos !== -1) {
+        expect(docControlPos).toBeLessThan(tocPos);
+      }
+      // Document Control must exist regardless
+      expect(docControlPos).toBeGreaterThan(-1);
+    });
+
+    it('includes preparer contact details', async () => {
+      const data = makeCCCReportData(true);
+      const html = await renderReport({ reportType: 'ccc', data });
+
+      expect(html).toContain('021 123 4567');
+      expect(html).toContain('jake@eastern.co.nz');
+    });
+  });
+
+  it('COA report does NOT include Document Control', async () => {
+    const data = makeReportData();
+    (data as Record<string, unknown>).documentControl = {
+      revisions: [{ revNo: 1, preparedBy: 'Test', description: 'Test', date: '2026-01-01' }],
+      acceptance: [],
+    };
+    const html = await renderReport({ reportType: 'coa', data });
+
+    expect(html).not.toContain('Document Control Records');
+  });
+
+  it('PPI report does NOT include Document Control', async () => {
+    const data = makePPIReportData();
+    (data as Record<string, unknown>).documentControl = {
+      revisions: [{ revNo: 1, preparedBy: 'Test', description: 'Test', date: '2026-01-01' }],
+      acceptance: [],
+    };
+    const html = await renderReport({ reportType: 'ppi', data });
+
+    expect(html).not.toContain('Document Control Records');
+  });
+});

--- a/api/src/services/template-engine.ts
+++ b/api/src/services/template-engine.ts
@@ -148,6 +148,18 @@ export async function renderReport(
   // Load base template
   const baseTemplate = await compileTemplate(`${reportType}/base.hbs`);
 
+
+  // Load optional document control template (rendered before TOC)
+  let documentControlHtml = '';
+  try {
+    const docControlTemplate = await compileTemplate(
+      `${reportType}/document-control.hbs`,
+    );
+    documentControlHtml = docControlTemplate(data);
+  } catch {
+    // No document control template — fine
+  }
+
   // Load section templates
   const sectionsDir = path.join(TEMPLATES_DIR, reportType, 'sections');
   const sectionFiles = await fs.readdir(sectionsDir);
@@ -191,6 +203,7 @@ export async function renderReport(
   // Render base with sections injected
   return baseTemplate({
     ...data,
+    documentControlHtml,
     sections: sectionHtmls.join('\n'),
     appendixContent: appendixHtmls.join('\n'),
     css,

--- a/api/templates/ccc/base.hbs
+++ b/api/templates/ccc/base.hbs
@@ -8,6 +8,10 @@
 <body>
   {{> header}}
 
+  {{#if documentControlHtml}}
+  {{{documentControlHtml}}}
+  {{/if}}
+
   {{#if tableOfContents}}
   <nav class="table-of-contents">
     <h2>Table of Contents</h2>

--- a/api/templates/ccc/document-control.hbs
+++ b/api/templates/ccc/document-control.hbs
@@ -1,0 +1,91 @@
+{{!-- Document Control Page — Issue #546 --}}
+{{#if documentControl}}
+<div class="document-control-page page-break-before">
+  <h2>Document Control Records</h2>
+
+  <div class="prepared-by-info">
+    <h3>Prepared by</h3>
+    <table class="info-table">
+      <tr><th>Name</th><td>{{personnel.author.name}}</td></tr>
+      {{#if personnel.author.phone}}
+      <tr><th>Phone</th><td>{{personnel.author.phone}}</td></tr>
+      {{/if}}
+      {{#if personnel.author.email}}
+      <tr><th>Email</th><td>{{personnel.author.email}}</td></tr>
+      {{/if}}
+    </table>
+  </div>
+
+  {{#if documentControl.revisions}}
+  <div class="revision-history">
+    <h3>Revision History</h3>
+    <table class="revision-table">
+      <thead>
+        <tr>
+          <th>Rev No</th>
+          <th>Prepared By</th>
+          <th>Description</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each documentControl.revisions}}
+        <tr>
+          <td>{{revNo}}</td>
+          <td>{{preparedBy}}</td>
+          <td>{{description}}</td>
+          <td>{{formatDate date}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  {{/if}}
+
+  <div class="document-acceptance">
+    <h3>Document Acceptance</h3>
+    <table class="acceptance-table">
+      <thead>
+        <tr>
+          <th>Action</th>
+          <th>Name</th>
+          <th>Signed</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each documentControl.acceptance}}
+        <tr>
+          <td>{{action}}</td>
+          <td>{{name}}</td>
+          <td>{{#if signed}}✓{{/if}}</td>
+          <td>{{#if date}}{{formatDate date}}{{/if}}</td>
+        </tr>
+        {{/each}}
+        {{#unless documentControl.acceptance}}
+        <tr>
+          <td>Prepared</td>
+          <td>{{personnel.author.name}}</td>
+          <td></td>
+          <td></td>
+        </tr>
+        {{#if personnel.reviewer}}
+        <tr>
+          <td>Reviewed</td>
+          <td>{{personnel.reviewer.name}}</td>
+          <td></td>
+          <td></td>
+        </tr>
+        {{/if}}
+        <tr>
+          <td>Approved</td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        {{/unless}}
+      </tbody>
+    </table>
+  </div>
+</div>
+{{/if}}


### PR DESCRIPTION
## Summary

Adds a Document Control page to CCC Gap Analysis reports, rendered between the header and Table of Contents.

### Changes
- **New template:** `api/templates/ccc/document-control.hbs` — revision history, preparer contact info, and document acceptance table
- **Updated:** `api/templates/ccc/base.hbs` — added `{{{documentControlHtml}}}` slot before TOC
- **Updated:** `api/src/services/template-engine.ts` — loads optional `document-control.hbs` per report type
- **Tests:** 6 new tests covering rendering, ordering, preparer details, and COA/PPI exclusion

### Acceptance Criteria
- [x] Document Control page appears after cover, before TOC
- [x] Revision History table shows all versions (Rev No, Prepared By, Description, Date)
- [x] Document Acceptance table shows Prepared/Reviewed/Approved rows
- [x] COA/PPI/SS reports do NOT include Document Control

Closes #546