### PR TITLE
feat(api): add report type routing for PPI generation

### DIFF
--- a/api/src/__tests__/report-type-routing.test.ts
+++ b/api/src/__tests__/report-type-routing.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Report Type Routing Tests — Issue #548
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getTemplateDir,
+  validateTemplatesExist,
+  listAvailableReportTypes,
+  UnsupportedReportTypeError,
+  TemplateNotAvailableError,
+} from '../services/report-type-routing.js';
+
+describe('Report Type Routing — #548', () => {
+  describe('getTemplateDir', () => {
+    it('maps COA to coa', () => {
+      expect(getTemplateDir('COA')).toBe('coa');
+    });
+
+    it('maps CCC_GAP to ccc', () => {
+      expect(getTemplateDir('CCC_GAP')).toBe('ccc');
+    });
+
+    it('maps PPI to ppi', () => {
+      expect(getTemplateDir('PPI')).toBe('ppi');
+    });
+
+    it('maps SAFE_SANITARY to ss', () => {
+      expect(getTemplateDir('SAFE_SANITARY')).toBe('ss');
+    });
+
+    it('maps TFA to tfa', () => {
+      expect(getTemplateDir('TFA')).toBe('tfa');
+    });
+  });
+
+  describe('validateTemplatesExist', () => {
+    it('validates COA templates exist', async () => {
+      const dir = await validateTemplatesExist('COA');
+      expect(dir).toBe('coa');
+    });
+
+    it('validates CCC templates exist', async () => {
+      const dir = await validateTemplatesExist('CCC_GAP');
+      expect(dir).toBe('ccc');
+    });
+
+    it('validates PPI templates exist', async () => {
+      const dir = await validateTemplatesExist('PPI');
+      expect(dir).toBe('ppi');
+    });
+
+    it('throws TemplateNotAvailableError for SAFE_SANITARY (no templates yet)', async () => {
+      await expect(validateTemplatesExist('SAFE_SANITARY')).rejects.toThrow(
+        TemplateNotAvailableError,
+      );
+    });
+
+    it('throws TemplateNotAvailableError for TFA (no templates yet)', async () => {
+      await expect(validateTemplatesExist('TFA')).rejects.toThrow(
+        TemplateNotAvailableError,
+      );
+    });
+
+    it('error message includes report type and path', async () => {
+      try {
+        await validateTemplatesExist('TFA');
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect((error as Error).message).toContain('TFA');
+        expect((error as Error).message).toContain('Templates not available');
+      }
+    });
+  });
+
+  describe('listAvailableReportTypes', () => {
+    it('includes COA, CCC_GAP, and PPI', async () => {
+      const available = await listAvailableReportTypes();
+      expect(available).toContain('COA');
+      expect(available).toContain('CCC_GAP');
+      expect(available).toContain('PPI');
+    });
+
+    it('does not include types without templates', async () => {
+      const available = await listAvailableReportTypes();
+      // SS and TFA templates don't exist yet
+      expect(available).not.toContain('SAFE_SANITARY');
+      expect(available).not.toContain('TFA');
+    });
+  });
+});

--- a/api/src/services/report-type-routing.ts
+++ b/api/src/services/report-type-routing.ts
@@ -1,0 +1,107 @@
+/**
+ * Report Type Routing — Issue #548
+ *
+ * Maps ReportType enum values to template engine directory names
+ * and validates template availability.
+ */
+
+import type { ReportType } from '@prisma/client';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = path.resolve(__dirname, '../../templates');
+
+/**
+ * Map from Prisma ReportType enum to template directory name.
+ */
+const REPORT_TYPE_TO_TEMPLATE_DIR: Record<ReportType, string> = {
+  COA: 'coa',
+  CCC_GAP: 'ccc',
+  PPI: 'ppi',
+  SAFE_SANITARY: 'ss',
+  TFA: 'tfa',
+};
+
+export class UnsupportedReportTypeError extends Error {
+  constructor(reportType: string) {
+    super(`Unsupported report type: ${reportType}`);
+    this.name = 'UnsupportedReportTypeError';
+  }
+}
+
+export class TemplateNotAvailableError extends Error {
+  constructor(reportType: string, templateDir: string) {
+    super(
+      `Templates not available for report type ${reportType}. ` +
+      `Expected template directory: ${templateDir}`
+    );
+    this.name = 'TemplateNotAvailableError';
+  }
+}
+
+/**
+ * Get the template directory name for a report type.
+ */
+export function getTemplateDir(reportType: ReportType): string {
+  const dir = REPORT_TYPE_TO_TEMPLATE_DIR[reportType];
+  if (!dir) {
+    throw new UnsupportedReportTypeError(reportType);
+  }
+  return dir;
+}
+
+/**
+ * Check whether templates exist for a report type.
+ * Returns the template directory name if available,
+ * throws TemplateNotAvailableError if not.
+ */
+export async function validateTemplatesExist(
+  reportType: ReportType,
+): Promise<string> {
+  const dir = getTemplateDir(reportType);
+  const fullPath = path.join(TEMPLATES_DIR, dir);
+
+  try {
+    const stat = await fs.stat(fullPath);
+    if (!stat.isDirectory()) {
+      throw new TemplateNotAvailableError(reportType, fullPath);
+    }
+
+    // Check for base.hbs
+    await fs.access(path.join(fullPath, 'base.hbs'));
+
+    // Check for at least one section
+    const sectionsDir = path.join(fullPath, 'sections');
+    const sections = await fs.readdir(sectionsDir);
+    const hbsFiles = sections.filter((f) => f.endsWith('.hbs'));
+    if (hbsFiles.length === 0) {
+      throw new TemplateNotAvailableError(reportType, fullPath);
+    }
+
+    return dir;
+  } catch (error) {
+    if (error instanceof TemplateNotAvailableError) throw error;
+    throw new TemplateNotAvailableError(reportType, fullPath);
+  }
+}
+
+/**
+ * List all report types that have templates available.
+ */
+export async function listAvailableReportTypes(): Promise<ReportType[]> {
+  const available: ReportType[] = [];
+
+  for (const [reportType, dir] of Object.entries(REPORT_TYPE_TO_TEMPLATE_DIR)) {
+    const fullPath = path.join(TEMPLATES_DIR, dir);
+    try {
+      await fs.access(path.join(fullPath, 'base.hbs'));
+      available.push(reportType as ReportType);
+    } catch {
+      // Not available
+    }
+  }
+
+  return available;
+}


### PR DESCRIPTION
## Summary

Adds a report type routing service that maps `ReportType` enum values to template engine directory names and validates template availability before generation.

### Changes
- **New:** `api/src/services/report-type-routing.ts` — maps enum to template dirs (PPI→ppi, CCC_GAP→ccc, etc.)
- **`validateTemplatesExist()`** — checks base.hbs + sections exist, throws clear `TemplateNotAvailableError` if not
- **`listAvailableReportTypes()`** — discovers which types have templates
- **13 tests** covering mapping, validation, and error messages

### Acceptance Criteria
- [x] PPI added to ReportType routing (enum already existed)
- [x] Generation service can route to PPI templates
- [x] Clear error when templates don't exist (SS, TFA)

Closes #548