### PR TITLE
feat(api): add missing PPI template sections 3, 4, 10

### DIFF
--- a/api/src/__tests__/template-engine.test.ts
+++ b/api/src/__tests__/template-engine.test.ts
@@ -275,8 +275,18 @@ function makePPIReportData() {
       bathrooms: '2',
       garaging: 'Single garage',
       cccStatus: 'Issued',
+      zones: {
+        wind: 'Medium',
+        earthquake: 'Zone 1',
+        exposure: 'Sheltered',
+      },
+      buildingHistory: [
+        { type: 'Building Consent', reference: 'BC/2020/1234', date: '2020-03-15' },
+      ],
     },
     methodology: {
+      description: 'Visual non-invasive inspection per NZS 4306:2005',
+      equipment: ['Moisture meter', 'Thermal camera'],
       areasNotAccessed: 'Sub-floor space (access hatch blocked)',
       documentsReviewed: ['LIM report', 'Title documents'],
     },
@@ -345,9 +355,9 @@ describe('PPI Templates', () => {
       const result = await listTemplates('ppi');
 
       expect(result.sections).toContain('01-executive-summary.hbs');
-      expect(result.sections).toContain('05-interior.hbs');
-      expect(result.sections).toContain('08-signatures.hbs');
-      expect(result.sections).toHaveLength(8);
+      expect(result.sections).toContain('07-interior.hbs');
+      expect(result.sections).toContain('11-signatures.hbs');
+      expect(result.sections).toHaveLength(11);
 
       expect(result.appendices).toContain('photos.hbs');
       expect(result.appendices).toHaveLength(1);
@@ -368,7 +378,7 @@ describe('PPI Templates', () => {
 
     it('renders PPI interior with moisture readings', async () => {
       const data = makePPIReportData();
-      const html = await renderSection('ppi', '05-interior.hbs', data);
+      const html = await renderSection('ppi', '07-interior.hbs', data);
 
       expect(html).toContain('Interior of Building');
       expect(html).toContain('Bathrooms');
@@ -380,13 +390,48 @@ describe('PPI Templates', () => {
 
     it('renders PPI conclusions with recommendations', async () => {
       const data = makePPIReportData();
-      const html = await renderSection('ppi', '07-conclusions.hbs', data);
+      const html = await renderSection('ppi', '09-conclusions.hbs', data);
 
       expect(html).toContain('Conclusions and Recommendations');
       expect(html).toContain('Fair');
       expect(html).toContain('Reseal shower grout');
       expect(html).toContain('Repaint weatherboard');
       expect(html).toContain('Structural engineer');
+    });
+
+    it('renders PPI building & site description with zones', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '03-building-site.hbs', data);
+
+      expect(html).toContain('Building and Site Description');
+      expect(html).toContain('Standalone dwelling');
+      expect(html).toContain('1985');
+      expect(html).toContain('Wind Zone');
+      expect(html).toContain('Medium');
+      expect(html).toContain('BC/2020/1234');
+    });
+
+    it('renders PPI methodology with equipment', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '04-methodology.hbs', data);
+
+      expect(html).toContain('Inspection Methodology');
+      expect(html).toContain('Visual non-invasive');
+      expect(html).toContain('Moisture meter');
+      expect(html).toContain('Thermal camera');
+      expect(html).toContain('Sub-floor space');
+      expect(html).toContain('LIM report');
+    });
+
+    it('renders PPI limitations with disclaimers', async () => {
+      const data = makePPIReportData();
+      const html = await renderSection('ppi', '10-limitations.hbs', data);
+
+      expect(html).toContain('Limitations');
+      expect(html).toContain('visual, non-invasive');
+      expect(html).toContain('asbestos');
+      expect(html).toContain('Concealed elements');
+      expect(html).toContain('Sub-floor space');
     });
   });
 
@@ -406,7 +451,7 @@ describe('PPI Templates', () => {
       expect(html).toContain('@page');
       expect(html).toContain('font-family');
 
-      // All 8 sections present
+      // All 11 sections present
       expect(html).toContain('id="section-1"');
       expect(html).toContain('id="section-2"');
       expect(html).toContain('id="section-3"');
@@ -415,6 +460,9 @@ describe('PPI Templates', () => {
       expect(html).toContain('id="section-6"');
       expect(html).toContain('id="section-7"');
       expect(html).toContain('id="section-8"');
+      expect(html).toContain('id="section-9"');
+      expect(html).toContain('id="section-10"');
+      expect(html).toContain('id="section-11"');
 
       // Appendix present
       expect(html).toContain('id="appendix-a"');

--- a/api/templates/ppi/sections/03-building-site.hbs
+++ b/api/templates/ppi/sections/03-building-site.hbs
@@ -1,0 +1,65 @@
+{{!-- Building & Site Description — Issue #549 --}}
+<section class="report-section" id="section-3">
+  <h2>3. Building and Site Description</h2>
+
+  <table class="summary-table">
+    {{#if property.type}}
+    <tr><th>Property Type</th><td>{{property.type}}</td></tr>
+    {{/if}}
+    {{#if property.yearBuilt}}
+    <tr><th>Year Built</th><td>{{property.yearBuilt}}</td></tr>
+    {{/if}}
+    {{#if property.bedrooms}}
+    <tr><th>Bedrooms</th><td>{{property.bedrooms}}</td></tr>
+    {{/if}}
+    {{#if property.bathrooms}}
+    <tr><th>Bathrooms</th><td>{{property.bathrooms}}</td></tr>
+    {{/if}}
+    {{#if property.garaging}}
+    <tr><th>Garaging</th><td>{{property.garaging}}</td></tr>
+    {{/if}}
+    {{#if property.cccStatus}}
+    <tr><th>CCC Status</th><td>{{property.cccStatus}}</td></tr>
+    {{/if}}
+  </table>
+
+  {{#if property.zones}}
+  <h3>Zone Data</h3>
+  <table class="summary-table">
+    {{#if property.zones.wind}}
+    <tr><th>Wind Zone</th><td>{{property.zones.wind}}</td></tr>
+    {{/if}}
+    {{#if property.zones.earthquake}}
+    <tr><th>Earthquake Zone</th><td>{{property.zones.earthquake}}</td></tr>
+    {{/if}}
+    {{#if property.zones.exposure}}
+    <tr><th>Exposure Zone</th><td>{{property.zones.exposure}}</td></tr>
+    {{/if}}
+    {{#if property.zones.corrosion}}
+    <tr><th>Corrosion Zone</th><td>{{property.zones.corrosion}}</td></tr>
+    {{/if}}
+  </table>
+  {{/if}}
+
+  {{#if property.buildingHistory}}
+  <h3>Building History</h3>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reference</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each property.buildingHistory}}
+      <tr>
+        <td>{{type}}</td>
+        <td>{{reference}}</td>
+        <td>{{formatDate date}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/04-methodology.hbs
+++ b/api/templates/ppi/sections/04-methodology.hbs
@@ -1,0 +1,61 @@
+{{!-- Inspection Methodology — Issue #549 --}}
+<section class="report-section" id="section-4">
+  <h2>4. Inspection Methodology</h2>
+
+  {{#if methodology.description}}
+  <h3>Approach</h3>
+  <p>{{methodology.description}}</p>
+  {{else}}
+  <h3>Approach</h3>
+  <p>A visual, non-invasive inspection was carried out in accordance with NZS 4306:2005.</p>
+  {{/if}}
+
+  {{#if personnel.inspectors}}
+  <h3>Inspection Personnel</h3>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Role</th>
+        {{#if personnel.inspectors.[0].credentials}}
+        <th>Credentials</th>
+        {{/if}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each personnel.inspectors}}
+      <tr>
+        <td>{{name}}</td>
+        <td>{{role}}</td>
+        {{#if credentials}}
+        <td>{{credentials}}</td>
+        {{/if}}
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
+
+  {{#if methodology.equipment}}
+  <h3>Equipment Used</h3>
+  <ul>
+    {{#each methodology.equipment}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if methodology.areasNotAccessed}}
+  <h3>Areas Not Accessed</h3>
+  <p>{{methodology.areasNotAccessed}}</p>
+  {{/if}}
+
+  {{#if methodology.documentsReviewed}}
+  <h3>Documents Reviewed</h3>
+  <ul>
+    {{#each methodology.documentsReviewed}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/05-site-ground.hbs
+++ b/api/templates/ppi/sections/05-site-ground.hbs
@@ -1,7 +1,7 @@
-<section class="report-section" id="section-4">
-  <h2>4. Exterior of Building</h2>
+<section class="report-section" id="section-5">
+  <h2>5. Site and Ground Condition</h2>
 
-  {{#if exterior}}
+  {{#if siteGround}}
   <table class="inspection-table">
     <thead>
       <tr>
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each exterior.items}}
+      {{#each siteGround.items}}
       <tr class="{{#if issue}}has-issue{{/if}}">
         <td>{{name}}</td>
         <td class="condition-{{lowercase condition}}">{{condition}}</td>
@@ -23,12 +23,12 @@
     </tbody>
   </table>
 
-  {{#if exterior.notes}}
+  {{#if siteGround.notes}}
   <h3>Additional Notes</h3>
-  <p>{{exterior.notes}}</p>
+  <p>{{siteGround.notes}}</p>
   {{/if}}
 
   {{else}}
-  <p>No exterior observations recorded.</p>
+  <p>No site and ground observations recorded.</p>
   {{/if}}
 </section>

--- a/api/templates/ppi/sections/06-exterior.hbs
+++ b/api/templates/ppi/sections/06-exterior.hbs
@@ -1,7 +1,7 @@
-<section class="report-section" id="section-3">
-  <h2>3. Site and Ground Condition</h2>
+<section class="report-section" id="section-6">
+  <h2>6. Exterior of Building</h2>
 
-  {{#if siteGround}}
+  {{#if exterior}}
   <table class="inspection-table">
     <thead>
       <tr>
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each siteGround.items}}
+      {{#each exterior.items}}
       <tr class="{{#if issue}}has-issue{{/if}}">
         <td>{{name}}</td>
         <td class="condition-{{lowercase condition}}">{{condition}}</td>
@@ -23,12 +23,12 @@
     </tbody>
   </table>
 
-  {{#if siteGround.notes}}
+  {{#if exterior.notes}}
   <h3>Additional Notes</h3>
-  <p>{{siteGround.notes}}</p>
+  <p>{{exterior.notes}}</p>
   {{/if}}
 
   {{else}}
-  <p>No site and ground observations recorded.</p>
+  <p>No exterior observations recorded.</p>
   {{/if}}
 </section>

--- a/api/templates/ppi/sections/07-interior.hbs
+++ b/api/templates/ppi/sections/07-interior.hbs
@@ -1,5 +1,5 @@
-<section class="report-section" id="section-5">
-  <h2>5. Interior of Building</h2>
+<section class="report-section" id="section-7">
+  <h2>7. Interior of Building</h2>
 
   {{#if interior}}
 

--- a/api/templates/ppi/sections/08-services.hbs
+++ b/api/templates/ppi/sections/08-services.hbs
@@ -1,5 +1,5 @@
-<section class="report-section" id="section-6">
-  <h2>6. Service Systems</h2>
+<section class="report-section" id="section-8">
+  <h2>8. Service Systems</h2>
 
   {{#if services}}
   <table class="inspection-table">

--- a/api/templates/ppi/sections/09-conclusions.hbs
+++ b/api/templates/ppi/sections/09-conclusions.hbs
@@ -1,5 +1,5 @@
-<section class="report-section" id="section-7">
-  <h2>7. Conclusions and Recommendations</h2>
+<section class="report-section" id="section-9">
+  <h2>9. Conclusions and Recommendations</h2>
 
   {{#if conclusions}}
   <h3>Overall Assessment</h3>

--- a/api/templates/ppi/sections/10-limitations.hbs
+++ b/api/templates/ppi/sections/10-limitations.hbs
@@ -1,0 +1,29 @@
+{{!-- Limitations — Issue #549 --}}
+<section class="report-section" id="section-10">
+  <h2>10. Limitations</h2>
+
+  <p>This report is subject to the following limitations:</p>
+
+  <ol class="limitations-list">
+    <li>This inspection is a <strong>visual, non-invasive assessment</strong> only. No destructive or invasive testing was undertaken.</li>
+    <li>The inspection does not include testing for the presence of <strong>asbestos, lead-based paint, methamphetamine contamination,</strong> or other hazardous materials.</li>
+    <li>Concealed elements such as framing, insulation, waterproofing membranes, and services within walls, floors, and ceilings were not inspected and no warranty is given regarding their condition.</li>
+    <li>The inspection does not cover <strong>intermittent or concealed faults</strong> in plumbing, drainage, electrical, or mechanical systems.</li>
+    <li>Areas that were inaccessible, locked, obstructed by furniture or stored items, or unsafe to access were not inspected.</li>
+    <li>This report does not constitute a <strong>compliance assessment</strong> against the New Zealand Building Code or any other regulatory standard.</li>
+    <li>Moisture readings are indicative only and do not confirm the presence or absence of moisture damage. Further invasive investigation may be required.</li>
+    <li>This report is prepared for the exclusive use of the named client and should not be relied upon by third parties without written consent.</li>
+  </ol>
+
+  {{#if methodology.areasNotAccessed}}
+  <h3>Specific Limitations — Areas Not Accessed</h3>
+  <p>{{methodology.areasNotAccessed}}</p>
+  {{/if}}
+
+  {{#if limitations.additional}}
+  <h3>Additional Limitations</h3>
+  {{#each limitations.additional}}
+  <p>{{this}}</p>
+  {{/each}}
+  {{/if}}
+</section>

--- a/api/templates/ppi/sections/11-signatures.hbs
+++ b/api/templates/ppi/sections/11-signatures.hbs
@@ -1,5 +1,5 @@
-<section class="report-section signatures" id="section-8">
-  <h2>8. Declaration</h2>
+<section class="report-section signatures" id="section-11">
+  <h2>11. Declaration</h2>
 
   <div class="declaration">
     <p>


### PR DESCRIPTION
## Summary

Completes the PPI report template with all 11 sections matching the NZS 4306:2005 report format.

### New Sections
- **03-building-site.hbs** — property details, zone data (wind/earthquake/exposure/corrosion), building history
- **04-methodology.hbs** — inspection approach, personnel credentials, equipment, areas not accessed, documents reviewed
- **10-limitations.hbs** — standard NZS 4306 disclaimers (asbestos, concealed elements, moisture readings, etc.)

### Renumbered Sections
- 03→05, 04→06, 05→07, 06→08, 07→09, 08→11
- Updated section IDs and heading numbers in all renamed files

### Tests
- 3 new section rendering tests
- Updated existing tests for new file names and 11-section count
- Added zone data, equipment, and building history to PPI test data
- 646 tests passing

### Acceptance Criteria
- [x] Building & Site Description with property details and zone data
- [x] Inspection Methodology with personnel, equipment, documents
- [x] Limitations with PPI-specific disclaimers
- [x] Section numbering updated (1-11)

Closes #549