### PR TITLE
[Riley] docs(design): update designs after code review

### DIFF
--- a/docs/developer/design/017-ppi-report-template.md
+++ b/docs/developer/design/017-ppi-report-template.md
@@ -1,6 +1,6 @@
 # Design: PPI Report Template
 
-**Status:** Draft
+**Status:** Approved (updated 2026-03-01 after code review)
 **Author:** Riley
 **Requirement:** #539
 **Date:** 2026-02-28
@@ -11,57 +11,89 @@ Pre-Purchase Inspection (PPI) reports follow NZS 4306:2005, not NZBC clause revi
 
 Analysis of real PPI reports (`docs/domain/report-analysis.md`) shows the Abacus/Eastern format has 11 sections + 3 appendices.
 
+## Current State
+
+**PPI already exists in the codebase:**
+- `PPI` is in the `ReportType` enum (Prisma schema)
+- `api/templates/ppi/` has 8 sections, cover, base, CSS, and photo appendix
+- Template engine is **generic** — `renderReport({reportType: 'ppi', data})` loads from `api/templates/ppi/`
+
+### Existing Template Files
+```
+api/templates/ppi/
+  base.hbs                           # ✅ exists
+  cover.hbs                          # ✅ exists
+  styles/report.css                  # ✅ exists
+  appendices/photos.hbs              # ✅ exists
+  sections/
+    01-executive-summary.hbs         # ✅ exists (report info summary)
+    02-introduction.hbs              # ✅ exists (NZS 4306:2005 reference)
+    03-site-ground.hbs               # ✅ exists
+    04-exterior.hbs                  # ✅ exists
+    05-interior.hbs                  # ✅ exists
+    06-services.hbs                  # ✅ exists
+    07-conclusions.hbs               # ✅ exists
+    08-signatures.hbs                # ✅ exists
+```
+
+### What's Missing (vs real PPI reports)
+1. **Building & Site Description** — property details, zone data, building info (bedrooms, year built, CCC status)
+2. **Inspection Methodology** — personnel credentials, approach, equipment
+3. **Limitations** — standard PPI disclaimers (asbestos, concealed elements, intermittent faults)
+4. **Appendix B — Thermal Imaging** — infrared results
+5. **Appendix C — Floor Level Survey** — laser level measurements
+
 ## Decision
 
-Add a PPI report type using the existing template engine (Handlebars + Puppeteer) with PPI-specific templates. Reuse shared infrastructure (template engine, PDF renderer, photo embedder, variable substitution) but with a new template directory and section structure.
+Add the 3 missing sections and 2 missing appendices. Renumber existing sections to accommodate.
 
 ## Architecture
 
-### Template Directory Structure
+### Template Engine Behaviour
+The engine (`api/src/services/template-engine.ts`) is generic:
+- Loads `api/templates/{reportType}/base.hbs` as main layout
+- Loads all `.hbs` files from `sections/` in **alphabetical sort order** → injected into `{{{sections}}}`
+- Loads all `.hbs` files from `appendices/` in **alphabetical sort order** → injected into `{{{appendixContent}}}`
+- Optional `document-control.hbs` at root → rendered before TOC as `{{{documentControlHtml}}}`
+- Shared partials from `api/templates/partials/` (header, footer)
+- Optional `styles/report.css` → injected as `{{{css}}}`
 
+### Files to Change
+
+**Add new section templates:**
+- `api/templates/ppi/sections/03-building-site.hbs` (new)
+- `api/templates/ppi/sections/04-methodology.hbs` (new)
+- `api/templates/ppi/sections/10-limitations.hbs` (new)
+
+**Renumber existing sections:**
+- `03-site-ground.hbs` → `05-site-ground.hbs`
+- `04-exterior.hbs` → `06-exterior.hbs`
+- `05-interior.hbs` → `07-interior.hbs`
+- `06-services.hbs` → `08-services.hbs`
+- `07-conclusions.hbs` → `09-conclusions.hbs`
+- `08-signatures.hbs` → `11-signatures.hbs`
+
+**Add appendix templates:**
+- `api/templates/ppi/appendices/b-thermal-imaging.hbs` (new)
+- `api/templates/ppi/appendices/c-floor-level-survey.hbs` (new)
+
+**Final section order:**
 ```
-api/templates/ppi/
-  base.hbs                    # Main layout
-  cover.hbs                   # Cover page
-  sections/
-    01-report-info-summary.hbs
-    02-introduction.hbs
-    03-building-site-description.hbs
-    04-inspection-methodology.hbs
-    05-summary-of-inspection.hbs
-    06-site-ground-condition.hbs
-    07-exterior.hbs
-    08-interior.hbs
-    09-service-systems.hbs
-    10-limitations.hbs
-    11-signatures.hbs
-  appendices/
-    a-photos.hbs
-    b-thermal-imaging.hbs
-    c-floor-level-survey.hbs
-  partials/
-    header.hbs
-    footer.hbs
-    section-conclusion.hbs
+sections/
+  01-executive-summary.hbs      # existing
+  02-introduction.hbs           # existing
+  03-building-site.hbs          # NEW
+  04-methodology.hbs            # NEW
+  05-site-ground.hbs            # renamed from 03
+  06-exterior.hbs               # renamed from 04
+  07-interior.hbs               # renamed from 05
+  08-services.hbs               # renamed from 06
+  09-conclusions.hbs            # renamed from 07
+  10-limitations.hbs            # NEW
+  11-signatures.hbs             # renamed from 08
 ```
-
-### Data Model Changes
-
-```prisma
-// Add PPI to existing ReportType enum
-enum ReportType {
-  COA
-  CCC
-  PPI        // NEW
-  SS         // NEW (for #540)
-}
-```
-
-No new entities required — PPI uses the existing inspection data model. The key difference is **how the data is presented**, not what data is captured.
 
 ### PPI-Specific Template Data
-
-The template context needs these PPI-specific fields:
 
 ```typescript
 interface PPITemplateData {
@@ -93,31 +125,7 @@ interface PPITemplateData {
   thermalImaging?: ThermalImage[];
   floorLevelSurvey?: FloorLevelData;
 }
-
-interface PPISection {
-  narrativeText: string;
-  conclusion: string;       // "No obvious defects" or findings
-  photoRefs: string;        // "Photograph 1~10" (range notation)
-  needsAttention: boolean;
-  needsFurtherInvestigation: boolean;
-}
 ```
-
-### Section Content Guide
-
-| Section | Content | Data Source |
-|---------|---------|-------------|
-| Report Info Summary | Project #, activity ("Pre-purchase Inspection"), address, client, TA, author, inspector, date, weather | Report + Project + Personnel |
-| Introduction | Engagement statement + purpose (NZS 4306:2005 reference) | Template boilerplate + variables |
-| Building & Site | Site info (zones from BRANZ), building info (rooms, year, CCC status) | Property + zone data (#543) |
-| Methodology | Personnel credentials, inspection approach, equipment | Personnel + template |
-| Summary | Overall condition rating + key findings | Inspector input |
-| Site & Ground | Topography, access paths, garden areas | Inspector narrative |
-| Exterior | Roof, cladding, joinery, foundation | Inspector narrative |
-| Interior | Room-by-room condition | Inspector narrative |
-| Service Systems | Power, water, gas, drainage, alarms, ventilation | Inspector narrative |
-| Limitations | Standard disclaimers | Template boilerplate |
-| Signatures | Author signature block | Personnel |
 
 ### Photo Reference Convention
 
@@ -125,36 +133,21 @@ PPI uses range notation: `[ Appendix A ] Photograph 1~10`
 
 The photo embedder needs to support this format alongside the existing comma-separated format used by COA (`Photograph 7,8,9`).
 
-### Seed Templates
-
-Seed the following PPI boilerplate templates:
-
-**Introduction:**
-> "[Company Name] have been engaged to carry out a pre-purchase inspection at [Property Address]. The purpose of this inspection is to independently inspect and report on the condition of the building works and findings of defects during inspection against relevant clauses of the New Zealand Standard 4306:2005 [Residential Property Inspection]."
-
-**Limitations:**
-> Standard PPI limitations text (longer than COA — covers asbestos, concealed elements, intermittent faults, etc.)
-
 ## Dependencies
 
 - #543 (BRANZ zone data) — needed for Building & Site Description section
-- Existing template engine, PDF renderer, variable substitution
 
-## Stories Breakdown
+## Stories
 
-_(To be created after design approval)_
-
-Estimated stories:
-1. Add PPI to ReportType enum + API support
-2. Create PPI Handlebars templates (sections 1-11)
-3. Create PPI appendix templates (photos, thermal, floor survey)
-4. Add PPI section data capture API (narrative + conclusion per section)
-5. Seed PPI boilerplate templates
-6. Add PPI to report generation service
-7. PPI photo range notation support
+| # | Story | Status |
+|---|-------|--------|
+| ~~#548~~ | ~~Add PPI to ReportType enum~~ | Closed — already exists |
+| #549 | Add missing PPI sections (building/site, methodology, limitations) | Ready |
+| #550 | Add thermal imaging + floor survey appendices | Ready |
+| #551 | Seed PPI boilerplate templates | Ready |
 
 ## Alternatives Considered
 
 **Reuse COA template with different sections** — Rejected. The structure is too different (narrative vs table). Sharing a base template would create a mess of conditionals.
 
-**Separate PPI inspection flow** — Rejected. PPI uses the same inspection data; only the report presentation differs. No need for a separate inspection model.
+**Separate PPI inspection flow** — Rejected. PPI uses the same inspection data; only the report presentation differs.

--- a/docs/developer/design/018-safe-sanitary-template.md
+++ b/docs/developer/design/018-safe-sanitary-template.md
@@ -1,6 +1,6 @@
 # Design: Safe & Sanitary Report Template
 
-**Status:** Draft
+**Status:** Approved (updated 2026-03-01 after code review)
 **Author:** Riley
 **Requirement:** #540
 **Date:** 2026-02-28
@@ -15,16 +15,28 @@ SS reports are the simplest type (10–20 pages). They share boilerplate with CO
 
 Analysis: `docs/domain/report-analysis.md` — Type 4: SS section.
 
+## Current State
+
+**`SAFE_SANITARY` already exists in the `ReportType` enum** but no templates exist yet. The template engine will look for `api/templates/safe_sanitary/` (needs verification — check how the enum value maps to directory name in `renderReport()`).
+
 ## Decision
 
-Add an SS report type using the existing template engine. Shares many partials with COA (cover, intro, limitations, signatures) but has its own assessment framework table template.
+Create a full SS template directory. Shares some styling with COA but has its own assessment framework table.
 
 ## Architecture
 
-### Template Directory Structure
+### Template Engine Behaviour
+The engine (`api/src/services/template-engine.ts`) is generic:
+- `renderReport({reportType, data})` loads templates from `api/templates/{reportType}/`
+- `reportType` string maps to directory name — **verify** whether `SAFE_SANITARY` maps to `safe_sanitary` or something else in the calling code
+- Sections loaded alphabetically from `sections/`
+- Appendices loaded alphabetically from `appendices/`
+- Shared partials from `api/templates/partials/`
+
+### Files to Create
 
 ```
-api/templates/ss/
+api/templates/safe_sanitary/     # verify directory name against enum mapping
   base.hbs
   cover.hbs
   sections/
@@ -38,40 +50,23 @@ api/templates/ss/
     08-limitations.hbs
     09-signatures.hbs
   appendices/
-    a-photos.hbs
-  partials/
-    header.hbs
-    footer.hbs
+    photos.hbs
+  styles/
+    report.css
 ```
 
-### Data Model Changes
+### Assessment Framework Table (Core of SS)
 
-```prisma
-enum ReportType {
-  COA
-  CCC
-  PPI
-  SS        // NEW
-}
-```
-
-### Assessment Framework Table
-
-The core of SS reports — a table assessing building elements against s.64:
+The key section — a table assessing building elements against Building Act 1991 s.64:
 
 ```typescript
 interface SSAssessmentItem {
-  // Building element group
-  items: string;              // "Foundation", "Walls", "Roof", "Joinery", etc.
+  items: string;              // "Foundation", "Walls", "Roof", etc.
   details: string;            // "Raised Perimeter Block Wall and Post and Pier Foundation"
-
-  // Assessment
-  photoRefs: string;          // "Photograph 5,6,7,8,9,10,11"
+  photoRefs: string;          // "Photograph 5,6,7"
   observations: string;       // Detailed observations
   complianceRequirement: string; // Building Act 1991 s.64(1) or s.64(4) text
   remedialWorks: string;      // "Nil" or specific works
-
-  // Classification
   assessmentType: 'safety' | 'sanitary';
 }
 
@@ -79,44 +74,20 @@ interface SSTemplateData {
   reportInfo: ReportInfoSummary;
   buildingInfo: SSBuildingInfo;
   assessmentItems: SSAssessmentItem[];
-
-  // Conclusions
   isSafe: boolean;
   isSanitary: boolean;
   summaryText: string;
   remedialWorksNeeded: boolean;
   remedialWorksSummary: string;
 }
-
-interface SSBuildingInfo {
-  buildingType: string;       // "Townhouse"
-  buildingYear: number;       // 1969
-  climateZone: string;
-  earthquakeZone: string;
-  exposureZone: string;
-  windZone: string;
-  rainfallRange: string;
-}
 ```
 
 ### Safety vs Sanitary Assessment
 
-The assessment table is split into two blocks:
+The table is split into two blocks:
 
 **Safety (s.64(1)):** Foundation, Walls, Roof, Joinery, Block Party Wall, Smoke Alarms
-> "Based on the on-site visual inspection... no apparent unsafe conditions were observed. Considering the building has been in safe service for over [X] years, it is concluded that the building does not meet the definition of an unsafe building under Building Act 1991, Section 64(1)."
-
 **Sanitary (s.64(4)):** Shower, Vanity, Bath, Toilet, Kitchen Sink, Hot Water, Drainage, Ventilation
-> "As observations and analysis above, it is concluded that the building does not meet the definition of an insanitary building under Building Act 1991, Section 64(4)."
-
-### Shared Partials
-
-Reuse from COA where text is identical:
-- Cover page layout (shared partial, different title)
-- Report Information Summary format
-- Limitations boilerplate
-- Signature block format
-- Photo appendix format
 
 ### Seed Templates
 
@@ -126,27 +97,24 @@ Reuse from COA where text is identical:
 **Summary (pass):**
 > "Following review of site works and comparing with compliance requirement, it is concluded that the building of [Property Address] is in Safe and Sanitary condition."
 
-**Summary (fail):**
-> "Following review of site works, remedial works are required to bring the building into safe and sanitary condition as outlined in Section [X]."
+**Limitations:**
+> Same boilerplate as COA (identical text per real report analysis).
 
 ## Dependencies
 
 - #543 (BRANZ zone data) — needed for building info
-- Shared partials from COA templates
+- Shared partials from `api/templates/partials/`
 
-## Stories Breakdown
+## Stories
 
-_(To be created after design approval)_
-
-Estimated stories:
-1. Add SS to ReportType enum + API support
-2. Create SS Handlebars templates (sections 1-9)
-3. Create SS assessment framework data capture API
-4. Seed SS boilerplate templates
-5. Add SS to report generation service
+| # | Story | Status |
+|---|-------|--------|
+| ~~#552~~ | ~~Add SS to ReportType enum~~ | Closed — already exists |
+| #553 | Create SS Handlebars templates (full set) | Ready |
+| #554 | Seed SS boilerplate templates | Ready |
 
 ## Alternatives Considered
 
 **Reuse COA assessment table** — Rejected. COA assesses against NZBC clauses; SS assesses against Building Act 1991 s.64. Different columns, different compliance text.
 
-**Merge with COA as "compliance report"** — Rejected. SS is specifically for pre-1992 work and uses a different legal framework. Merging would confuse the user.
+**Merge with COA as "compliance report"** — Rejected. SS is specifically for pre-1992 work and uses a different legal framework.

--- a/docs/developer/design/019-ccc-document-control.md
+++ b/docs/developer/design/019-ccc-document-control.md
@@ -1,171 +1,39 @@
 # Design: CCC Executive Summary & Document Control
 
-**Status:** Draft
+**Status:** Approved (updated 2026-03-01 — both delivered)
 **Author:** Riley
 **Requirement:** #541
 **Date:** 2026-02-28
 
 ## Context
 
-Real CCC Gap Analysis reports have two sections our templates don't generate:
+Real CCC Gap Analysis reports have two sections our templates didn't generate:
 
-1. **Document Control Records** (page 2, before TOC) — revision history + acceptance sign-off
+1. **Document Control Records** (after cover, before TOC) — revision history + acceptance sign-off
 2. **Executive Summary** (after TOC, before Section 1) — key findings at a glance
 
-These are CCC-specific — COA/PPI/SS reports do not use them.
+## Current State — DELIVERED ✅
 
-Analysis: `docs/domain/report-analysis.md` — Type 2: CCC section.
+Both features have been implemented:
 
-## Decision
+### Document Control (#546, PR #557)
+- Template: `api/templates/ccc/document-control.hbs` (root level, not in sections/)
+- Template engine loads it via `compileTemplate('{reportType}/document-control.hbs')` with try/catch fallback
+- Rendered as `{{{documentControlHtml}}}` in `base.hbs` between header and TOC
+- **Architecture note:** This is a special slot, not a regular section file, because it must appear before the TOC
 
-Add two new template sections to the CCC report template. Both can be auto-populated from existing data.
+### Executive Summary (#547)
+- Template: `api/templates/ccc/sections/00-executive-summary.hbs`
+- Auto-generated from defect data
+- API: `POST /api/reports/:id/executive-summary/generate`, `PUT /api/reports/:id/executive-summary`
 
-## Architecture
+## Architecture Lesson
 
-### 1. Document Control Records
+The original design said "create `sections/00-document-control.hbs`" but the template engine renders ALL sections AFTER the TOC. Document Control needed to be BEFORE the TOC, requiring a special slot in `base.hbs`. The design should have specified this after reading the template engine code.
 
-Added after cover page, before TOC.
+## Stories
 
-```
-Document Control Records
-
-Document Prepared by:
-  [Author Name]
-  for and on behalf of [Company Name]
-
-  Telephone:    [Phone]
-  Email:        [Email]
-
-Revision History
-| Revision No. | Prepared By | Description        | Date       |
-|--------------|-------------|--------------------|------------|
-| R1           | Jake Li     | First draft        | 01/12/2025 |
-| R2           | Ian Fong    | Review comments    | 05/12/2025 |
-| R3           | Ian Fong    | Final              | 16/12/2025 |
-
-Document Acceptance
-| Action    | Name     | Signed | Date       |
-|-----------|----------|--------|------------|
-| Prepared  | Jake Li  |        | 16/12/2025 |
-| Reviewed  | Ian Fong |        | 16/12/2025 |
-```
-
-**Data source:** Existing report versioning data + personnel data. No new entities needed.
-
-```typescript
-interface DocumentControlData {
-  preparedBy: {
-    name: string;
-    company: string;
-    phone: string;
-    email: string;
-  };
-  revisionHistory: {
-    revisionNo: string;      // "R1", "R2", "R3"
-    preparedBy: string;
-    description: string;
-    date: string;
-  }[];
-  documentAcceptance: {
-    action: string;          // "Prepared", "Reviewed"
-    name: string;
-    signed: boolean;
-    date: string;
-  }[];
-}
-```
-
-### 2. Executive Summary
-
-Added after TOC, before Section 1.
-
-Auto-generated from defect data:
-
-```
-EXECUTIVE SUMMARY
-
-Non-invasive site investigations to the property has identified the following:
-
-  • Roof parapet – absence of cap flashings and kick-out flashings.
-  • Wall Claddings – lack of control joints / deck and ground clearance
-  • Window / Door Joinery – lack of head / jamb / sill flashings
-  • Sub-floor – Garage timber-framed walls in direct-contact with natural ground
-
-The above result in a breach of Building Code clauses:
-  o B1 Structure
-  o B2 Durability
-  o E2 External Moisture
-  o F7 Warning Systems
-
-To resolve this, [remedial recommendation summary].
-```
-
-**Data source:** Generated from defect schedule data.
-
-```typescript
-interface ExecutiveSummaryData {
-  findings: string[];           // Bullet list of key findings
-  breachedClauses: string[];    // ["B1 Structure", "B2 Durability", ...]
-  remedialRecommendation: string; // High-level recommendation
-}
-
-// Auto-generation logic:
-// 1. findings = defects grouped by area, summarised
-// 2. breachedClauses = unique NZBC clauses from all defects
-// 3. remedialRecommendation = from report's recommendation field
-```
-
-### Template Changes
-
-```
-api/templates/ccc/
-  sections/
-    00-document-control.hbs    # NEW
-    00-executive-summary.hbs   # NEW
-    ... (existing sections unchanged)
-```
-
-Update `base.hbs` to include new sections in render order:
-1. Cover → **Document Control** → TOC → **Executive Summary** → Section 1...
-
-### API Changes
-
-New endpoint to set/override executive summary text:
-
-```
-PUT /api/reports/:id/executive-summary
-{
-  "findings": ["string"],
-  "breachedClauses": ["string"],
-  "remedialRecommendation": "string"
-}
-```
-
-Auto-generation endpoint:
-```
-POST /api/reports/:id/executive-summary/generate
-```
-→ Generates from defect data, returns preview. Inspector can edit before finalizing.
-
-## Dependencies
-
-- Existing CCC templates
-- Existing defect schedule data
-- Existing report versioning
-
-## Stories Breakdown
-
-_(To be created after design approval)_
-
-Estimated stories:
-1. Create Document Control template + data mapping
-2. Create Executive Summary template + auto-generation service
-3. Executive Summary API (generate + override)
-4. Update CCC base template render order
-5. Seed Document Control boilerplate
-
-## Alternatives Considered
-
-**Manual-only Executive Summary** — Rejected. Can be 80% auto-generated from defect data. Manual override for the remaining 20%.
-
-**Add Document Control to all report types** — Rejected. Only CCC uses it per industry practice. Can extend later if needed.
+| # | Story | Status |
+|---|-------|--------|
+| #546 | Document Control section | ✅ Delivered |
+| #547 | Executive Summary | ✅ Delivered |

--- a/docs/developer/design/020-property-metadata.md
+++ b/docs/developer/design/020-property-metadata.md
@@ -1,6 +1,6 @@
 # Design: Property Metadata — Building History & Zone Data
 
-**Status:** Draft
+**Status:** Approved
 **Author:** Riley
 **Requirement:** #542, #543
 **Date:** 2026-02-28


### PR DESCRIPTION
📐 **Riley** — Design Doc Updates

Updated all 4 design docs after reviewing the actual codebase:

| Doc | Key Changes |
|-----|-------------|
| **017 PPI** | Documented existing 8 templates, specified only 3 missing sections + 2 appendices (was incorrectly specifying full creation from scratch) |
| **018 SS** | Noted `SAFE_SANITARY` enum already exists, added template engine architecture notes, flagged directory name verification |
| **019 CCC** | Marked as delivered (#546, #547 done). Documented architecture lesson — document-control needs special slot before TOC, not a regular section file |
| **020 Property** | Status → Approved (no changes needed — was already correct) |

**Lesson:** Design docs must be written after reading the code, not from assumptions.