### PR TITLE
feat(api): create SS Handlebars templates (sections 1-9 + appendix)

### DIFF
--- a/api/src/__tests__/report-type-routing.test.ts
+++ b/api/src/__tests__/report-type-routing.test.ts
@@ -50,11 +50,6 @@ describe('Report Type Routing — #548', () => {
       expect(dir).toBe('ppi');
     });
 
-    it('throws TemplateNotAvailableError for SAFE_SANITARY (no templates yet)', async () => {
-      await expect(validateTemplatesExist('SAFE_SANITARY')).rejects.toThrow(
-        TemplateNotAvailableError,
-      );
-    });
 
     it('throws TemplateNotAvailableError for TFA (no templates yet)', async () => {
       await expect(validateTemplatesExist('TFA')).rejects.toThrow(
@@ -74,17 +69,17 @@ describe('Report Type Routing — #548', () => {
   });
 
   describe('listAvailableReportTypes', () => {
-    it('includes COA, CCC_GAP, and PPI', async () => {
+    it('includes COA, CCC_GAP, PPI, and SAFE_SANITARY', async () => {
       const available = await listAvailableReportTypes();
       expect(available).toContain('COA');
       expect(available).toContain('CCC_GAP');
       expect(available).toContain('PPI');
+      expect(available).toContain('SAFE_SANITARY');
     });
 
     it('does not include types without templates', async () => {
       const available = await listAvailableReportTypes();
       // SS and TFA templates don't exist yet
-      expect(available).not.toContain('SAFE_SANITARY');
       expect(available).not.toContain('TFA');
     });
   });

--- a/api/src/__tests__/ss-templates.test.ts
+++ b/api/src/__tests__/ss-templates.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Safe & Sanitary Template Tests — Issue #553
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  renderReport,
+  renderSection,
+  listTemplates,
+} from '../services/template-engine.js';
+
+function makeSSReportData() {
+  return {
+    generatedAt: new Date('2026-02-20T10:00:00Z'),
+    project: {
+      jobNumber: 'SS-2026-001',
+      address: '42 Heritage Lane, Wellington',
+      client: 'Heritage Trust Ltd',
+      council: 'Wellington City Council',
+      company: 'Apex Inspection Services',
+    },
+    personnel: {
+      author: {
+        name: 'John Smith',
+        credentials: 'BSCE, LBP #12345',
+      },
+      reviewer: {
+        name: 'Jane Doe',
+        credentials: 'MSCE, LBP #67890',
+      },
+      inspectors: [
+        { name: 'John Smith', role: 'Lead Inspector' },
+      ],
+    },
+    inspection: {
+      date: '2026-02-15T00:00:00Z',
+      weather: 'Fine, 20°C',
+    },
+    buildingInfo: {
+      buildingType: 'Townhouse',
+      buildingYear: 1969,
+      climateZone: 'Zone 2',
+      earthquakeZone: 'Zone 1',
+      exposureZone: 'Sheltered',
+      windZone: 'Medium',
+      rainfallRange: '1200-1600mm',
+    },
+    methodology: {
+      description: 'Visual, non-invasive inspection of the building and site.',
+      equipment: ['Moisture meter', 'Thermal camera'],
+      areasNotAccessed: 'Sub-floor space not accessible.',
+      documentsReviewed: ['LIM report', 'Title documents'],
+    },
+    assessmentItems: [
+      {
+        items: 'Foundation',
+        details: 'Raised Perimeter Block Wall and Post and Pier Foundation',
+        photoRefs: 'Photograph 5, 6, 7',
+        observations: 'Foundation in good condition, no visible cracking.',
+        complianceRequirement: 'Building Act 1991 s.64(1) — not unsafe',
+        remedialWorks: 'Nil',
+        assessmentType: 'safety',
+      },
+      {
+        items: 'Walls',
+        details: 'Weatherboard cladding',
+        photoRefs: 'Photograph 8, 9',
+        observations: 'Walls intact, minor paint deterioration.',
+        complianceRequirement: 'Building Act 1991 s.64(1) — not unsafe',
+        remedialWorks: 'Nil',
+        assessmentType: 'safety',
+      },
+      {
+        items: 'Shower',
+        details: 'Tiled shower over bath',
+        photoRefs: 'Photograph 12',
+        observations: 'Functional, grout in acceptable condition.',
+        complianceRequirement: 'Building Act 1991 s.64(4) — not insanitary',
+        remedialWorks: 'Nil',
+        assessmentType: 'sanitary',
+      },
+      {
+        items: 'Hot Water',
+        details: 'Electric cylinder',
+        photoRefs: 'Photograph 15',
+        observations: 'Operational, adequate supply.',
+        complianceRequirement: 'Building Act 1991 s.64(4) — not insanitary',
+        remedialWorks: 'Nil',
+        assessmentType: 'sanitary',
+      },
+    ],
+    isSafe: true,
+    isSanitary: true,
+    remedialWorksNeeded: false,
+    appendices: {
+      photos: [
+        { number: 1, caption: 'Front elevation', location: 'Street view', base64: 'dGVzdA==' },
+        { number: 2, caption: 'Foundation detail', location: 'South side', base64: 'dGVzdA==' },
+      ],
+    },
+  };
+}
+
+describe('SS Templates — #553', () => {
+  describe('listTemplates', () => {
+    it('lists SS section and appendix templates', async () => {
+      const result = await listTemplates('ss');
+
+      expect(result.sections).toHaveLength(9);
+      expect(result.sections).toContain('01-report-info-summary.hbs');
+      expect(result.sections).toContain('05-assessment-framework.hbs');
+      expect(result.sections).toContain('09-signatures.hbs');
+
+      expect(result.appendices).toContain('photos.hbs');
+      expect(result.appendices).toHaveLength(1);
+    });
+  });
+
+  describe('renderSection', () => {
+    it('renders report info summary with job details', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '01-report-info-summary.hbs', data);
+
+      expect(html).toContain('Report Information Summary');
+      expect(html).toContain('SS-2026-001');
+      expect(html).toContain('42 Heritage Lane, Wellington');
+      expect(html).toContain('John Smith');
+    });
+
+    it('renders introduction with Building Act reference', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '02-introduction.hbs', data);
+
+      expect(html).toContain('Introduction');
+      expect(html).toContain('Building Act 1991, Section 64');
+      expect(html).toContain('42 Heritage Lane, Wellington');
+    });
+
+    it('renders building description with zone data', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '03-building-site-description.hbs', data);
+
+      expect(html).toContain('Townhouse');
+      expect(html).toContain('1969');
+      expect(html).toContain('Zone 2');
+      expect(html).toContain('Medium');
+    });
+
+    it('renders assessment framework with safety items', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '05-assessment-framework.hbs', data);
+
+      expect(html).toContain('Assessment Framework');
+      expect(html).toContain('Safety Assessment');
+      expect(html).toContain('s.64(1)');
+      expect(html).toContain('Foundation');
+      expect(html).toContain('Walls');
+    });
+
+    it('renders assessment framework with sanitary items', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '05-assessment-framework.hbs', data);
+
+      expect(html).toContain('Sanitary Assessment');
+      expect(html).toContain('s.64(4)');
+      expect(html).toContain('Shower');
+      expect(html).toContain('Hot Water');
+    });
+
+    it('renders summary with safe and sanitary conclusion', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '07-summary.hbs', data);
+
+      expect(html).toContain('Safe and Sanitary condition');
+      expect(html).toContain('42 Heritage Lane, Wellington');
+    });
+
+    it('renders summary with remedial works when not safe', async () => {
+      const data = makeSSReportData();
+      data.isSafe = false;
+      const html = await renderSection('ss', '07-summary.hbs', data);
+
+      expect(html).toContain('remedial works are required');
+    });
+
+    it('renders no remedial works message when none needed', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '06-remedial-works.hbs', data);
+
+      expect(html).toContain('No remedial works are required');
+    });
+
+    it('renders signatures with declaration', async () => {
+      const data = makeSSReportData();
+      const html = await renderSection('ss', '09-signatures.hbs', data);
+
+      expect(html).toContain('Declaration');
+      expect(html).toContain('John Smith');
+      expect(html).toContain('Jane Doe');
+    });
+  });
+
+  describe('renderReport', () => {
+    it('renders full SS report with all 9 sections', async () => {
+      const data = makeSSReportData();
+      const html = await renderReport({ reportType: 'ss', data });
+
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('Safe & Sanitary Report');
+      expect(html).toContain('SS-2026-001');
+
+      // All 9 sections
+      for (let i = 1; i <= 9; i++) {
+        expect(html).toContain(`id="section-${i}"`);
+      }
+
+      // Appendix
+      expect(html).toContain('id="appendix-a"');
+
+      // Footer
+      expect(html).toContain('CONFIDENTIAL');
+    });
+
+    it('includes photo data in appendix', async () => {
+      const data = makeSSReportData();
+      const html = await renderReport({ reportType: 'ss', data });
+
+      expect(html).toContain('Photograph 1');
+      expect(html).toContain('Front elevation');
+      expect(html).toContain('data:image/jpeg;base64,dGVzdA==');
+    });
+
+    it('includes CSS', async () => {
+      const data = makeSSReportData();
+      const html = await renderReport({ reportType: 'ss', data });
+
+      expect(html).toContain('@page');
+      expect(html).toContain('assessment-table');
+    });
+  });
+});

--- a/api/templates/ss/appendices/photos.hbs
+++ b/api/templates/ss/appendices/photos.hbs
@@ -1,0 +1,23 @@
+<section class="appendix" id="appendix-a">
+  <h2>Appendix A — Photographs</h2>
+
+  {{#if appendices.photos}}
+  <div class="photo-grid">
+    {{#each appendices.photos}}
+    <figure class="photo-item">
+      {{#if base64}}
+      <img src="data:image/jpeg;base64,{{{base64}}}" alt="{{caption}}" />
+      {{/if}}
+      <figcaption>
+        <strong>Photograph {{number}}</strong>: {{caption}}
+        {{#if location}}
+        <span class="photo-location">({{location}})</span>
+        {{/if}}
+      </figcaption>
+    </figure>
+    {{/each}}
+  </div>
+  {{else}}
+  <p>No photographs were taken during this assessment.</p>
+  {{/if}}
+</section>

--- a/api/templates/ss/base.hbs
+++ b/api/templates/ss/base.hbs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{project.jobNumber}} — Safe & Sanitary Report</title>
+  <style>{{{css}}}</style>
+</head>
+<body>
+  {{> header}}
+
+  {{#if documentControlHtml}}
+  {{{documentControlHtml}}}
+  {{/if}}
+
+  {{#if tableOfContents}}
+  <nav class="table-of-contents">
+    <h2>Table of Contents</h2>
+    {{{tableOfContents}}}
+  </nav>
+  {{/if}}
+
+  <main class="report-content">
+    {{{sections}}}
+  </main>
+
+  {{#if appendixContent}}
+  <div class="appendices">
+    {{{appendixContent}}}
+  </div>
+  {{/if}}
+
+  {{> footer}}
+</body>
+</html>

--- a/api/templates/ss/cover.hbs
+++ b/api/templates/ss/cover.hbs
@@ -1,0 +1,47 @@
+{{!-- Cover Page Template — SS Report --}}
+<div class="cover-page">
+  <div class="cover-content">
+    <div class="cover-header">
+      {{#if company.logoPath}}
+        <img src="{{company.logoPath}}" alt="{{company.name}}" class="cover-logo" />
+      {{else}}
+        <div class="cover-logo-placeholder">{{project.company}}</div>
+      {{/if}}
+    </div>
+
+    <div class="cover-title">
+      <h1>Safe &amp; Sanitary Report</h1>
+      <p class="cover-subtitle">Building Act 1991, Section 64</p>
+    </div>
+
+    <div class="cover-details">
+      <div class="cover-address">{{project.address}}</div>
+      <div class="cover-client">
+        <span class="label">Client:</span> {{project.client}}
+      </div>
+      <div class="cover-job-number">
+        <span class="label">Job Number:</span> {{project.jobNumber}}
+      </div>
+      <div class="cover-date">
+        <span class="label">Date:</span> {{formatDate generatedAt}}
+      </div>
+    </div>
+
+    <div class="cover-footer">
+      <div class="cover-prepared-by">
+        <span class="label">Prepared by:</span> {{personnel.author.name}}
+        {{#if personnel.author.credentials}}
+          <span class="credentials">({{personnel.author.credentials}})</span>
+        {{/if}}
+      </div>
+      {{#if personnel.reviewer}}
+        <div class="cover-reviewed-by">
+          <span class="label">Reviewed by:</span> {{personnel.reviewer.name}}
+          {{#if personnel.reviewer.credentials}}
+            <span class="credentials">({{personnel.reviewer.credentials}})</span>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/api/templates/ss/sections/01-report-info-summary.hbs
+++ b/api/templates/ss/sections/01-report-info-summary.hbs
@@ -1,0 +1,27 @@
+<section class="report-section" id="section-1">
+  <h2>1. Report Information Summary</h2>
+
+  <table class="summary-table">
+    <tr><th>Job Number</th><td>{{project.jobNumber}}</td></tr>
+    <tr><th>Activity</th><td>Safe &amp; Sanitary Assessment — Building Act 1991, s.64</td></tr>
+    <tr><th>Address</th><td>{{project.address}}</td></tr>
+    <tr><th>Client</th><td>{{project.client}}</td></tr>
+    <tr><th>Council</th><td>{{project.council}}</td></tr>
+    <tr><th>Inspection Date</th><td>{{formatDate inspection.date}}</td></tr>
+    <tr><th>Weather</th><td>{{inspection.weather}}</td></tr>
+  </table>
+
+  <h3>Personnel</h3>
+  <table class="personnel-table">
+    <tr>
+      <th>Prepared By</th>
+      <td>{{personnel.author.name}} — {{personnel.author.credentials}}</td>
+    </tr>
+    {{#if personnel.reviewer}}
+    <tr>
+      <th>Reviewed By</th>
+      <td>{{personnel.reviewer.name}} — {{personnel.reviewer.credentials}}</td>
+    </tr>
+    {{/if}}
+  </table>
+</section>

--- a/api/templates/ss/sections/02-introduction.hbs
+++ b/api/templates/ss/sections/02-introduction.hbs
@@ -1,0 +1,25 @@
+<section class="report-section" id="section-2">
+  <h2>2. Introduction</h2>
+
+  <p>
+    {{#if introduction.text}}
+      {{introduction.text}}
+    {{else}}
+      {{project.company}} have been engaged to carry out an independent assessment
+      of the building works carried out before 1 July 1992 at
+      <strong>{{project.address}}</strong> to verify on reasonable grounds that the
+      building work is safe and sanitary for its intended purpose.
+    {{/if}}
+  </p>
+
+  <p>
+    This report assesses the building against the requirements of the
+    Building Act 1991, Section 64, which defines an <em>unsafe building</em>
+    (s.64(1)) and an <em>insanitary building</em> (s.64(4)).
+  </p>
+
+  {{#if introduction.scope}}
+  <h3>Scope</h3>
+  <p>{{introduction.scope}}</p>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/03-building-site-description.hbs
+++ b/api/templates/ss/sections/03-building-site-description.hbs
@@ -1,0 +1,31 @@
+<section class="report-section" id="section-3">
+  <h2>3. Building &amp; Site Description</h2>
+
+  <table class="building-info-table">
+    {{#if buildingInfo.buildingType}}
+    <tr><th>Building Type</th><td>{{buildingInfo.buildingType}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.buildingYear}}
+    <tr><th>Year Built</th><td>{{buildingInfo.buildingYear}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.climateZone}}
+    <tr><th>Climate Zone</th><td>{{buildingInfo.climateZone}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.earthquakeZone}}
+    <tr><th>Earthquake Zone</th><td>{{buildingInfo.earthquakeZone}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.exposureZone}}
+    <tr><th>Exposure Zone</th><td>{{buildingInfo.exposureZone}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.windZone}}
+    <tr><th>Wind Zone</th><td>{{buildingInfo.windZone}}</td></tr>
+    {{/if}}
+    {{#if buildingInfo.rainfallRange}}
+    <tr><th>Rainfall Range</th><td>{{buildingInfo.rainfallRange}}</td></tr>
+    {{/if}}
+  </table>
+
+  {{#if buildingDescription}}
+  <p>{{buildingDescription}}</p>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/04-assessment-methodology.hbs
+++ b/api/templates/ss/sections/04-assessment-methodology.hbs
@@ -1,0 +1,35 @@
+<section class="report-section" id="section-4">
+  <h2>4. Assessment Methodology</h2>
+
+  <p>
+    {{#if methodology.description}}
+      {{methodology.description}}
+    {{else}}
+      The assessment was conducted by way of a visual, non-invasive inspection
+      of the building and site. No destructive testing was undertaken.
+    {{/if}}
+  </p>
+
+  {{#if methodology.equipment}}
+  <h3>Equipment Used</h3>
+  <ul>
+    {{#each methodology.equipment}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+
+  {{#if methodology.areasNotAccessed}}
+  <h3>Areas Not Accessed</h3>
+  <p>{{methodology.areasNotAccessed}}</p>
+  {{/if}}
+
+  {{#if methodology.documentsReviewed}}
+  <h3>Documents Reviewed</h3>
+  <ul>
+    {{#each methodology.documentsReviewed}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/05-assessment-framework.hbs
+++ b/api/templates/ss/sections/05-assessment-framework.hbs
@@ -1,0 +1,77 @@
+<section class="report-section" id="section-5">
+  <h2>5. Assessment Framework</h2>
+
+  {{#if assessmentItems}}
+  <h3>5.1 Safety Assessment — Building Act 1991 s.64(1)</h3>
+  <p>
+    An unsafe building is one that, in the ordinary course of events, is likely
+    to cause injury or death to persons in or around the building.
+  </p>
+
+  <table class="assessment-table">
+    <thead>
+      <tr>
+        <th>Items</th>
+        <th>Photographic Reference</th>
+        <th>Observations</th>
+        <th>Compliance Requirement (s.64)</th>
+        <th>Remedial Works</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each assessmentItems}}
+      {{#if (eq assessmentType "safety")}}
+      <tr>
+        <td class="item-name">
+          <strong>{{items}}</strong>
+          {{#if details}}<br><span class="item-details">{{details}}</span>{{/if}}
+        </td>
+        <td class="photo-refs">{{photoRefs}}</td>
+        <td class="observations">{{observations}}</td>
+        <td class="compliance">{{complianceRequirement}}</td>
+        <td class="remedial">{{remedialWorks}}</td>
+      </tr>
+      {{/if}}
+      {{/each}}
+    </tbody>
+  </table>
+
+  <h3>5.2 Sanitary Assessment — Building Act 1991 s.64(4)</h3>
+  <p>
+    An insanitary building is one that is offensive or likely to be injurious
+    to health because of how it is situated, constructed, or is in a state of
+    disrepair; or lacks adequate supply of potable water, sanitary facilities,
+    or stormwater/sewage drainage.
+  </p>
+
+  <table class="assessment-table">
+    <thead>
+      <tr>
+        <th>Items</th>
+        <th>Photographic Reference</th>
+        <th>Observations</th>
+        <th>Compliance Requirement (s.64)</th>
+        <th>Remedial Works</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each assessmentItems}}
+      {{#if (eq assessmentType "sanitary")}}
+      <tr>
+        <td class="item-name">
+          <strong>{{items}}</strong>
+          {{#if details}}<br><span class="item-details">{{details}}</span>{{/if}}
+        </td>
+        <td class="photo-refs">{{photoRefs}}</td>
+        <td class="observations">{{observations}}</td>
+        <td class="compliance">{{complianceRequirement}}</td>
+        <td class="remedial">{{remedialWorks}}</td>
+      </tr>
+      {{/if}}
+      {{/each}}
+    </tbody>
+  </table>
+  {{else}}
+  <p class="no-data">No assessment items have been recorded.</p>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/06-remedial-works.hbs
+++ b/api/templates/ss/sections/06-remedial-works.hbs
@@ -1,0 +1,26 @@
+<section class="report-section" id="section-6">
+  <h2>6. Remedial Works</h2>
+
+  {{#if remedialItems}}
+  <table class="remedial-table">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Item</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each remedialItems}}
+      <tr>
+        <td>{{inc @index}}</td>
+        <td>{{item}}</td>
+        <td>{{description}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{else}}
+  <p>No remedial works are required. The building is in safe and sanitary condition.</p>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/07-summary.hbs
+++ b/api/templates/ss/sections/07-summary.hbs
@@ -1,0 +1,36 @@
+<section class="report-section" id="section-7">
+  <h2>7. Summary</h2>
+
+  {{#if summaryText}}
+  <p>{{summaryText}}</p>
+  {{else}}
+    {{#if isSafe}}
+      {{#if isSanitary}}
+      <p>
+        Following review of site works and comparing with compliance requirement,
+        it is concluded that the building of <strong>{{project.address}}</strong>
+        is in <strong>Safe and Sanitary condition</strong>.
+      </p>
+      {{else}}
+      <p>
+        Following review of site works, it is concluded that the building of
+        <strong>{{project.address}}</strong> is in <strong>safe condition</strong>
+        but remedial works are required to bring the building into sanitary condition
+        as outlined in Section 6.
+      </p>
+      {{/if}}
+    {{else}}
+      <p>
+        Following review of site works, remedial works are required to bring the
+        building of <strong>{{project.address}}</strong> into safe and sanitary
+        condition as outlined in Section 6.
+      </p>
+    {{/if}}
+  {{/if}}
+
+  {{#if remedialWorksNeeded}}
+  <p>
+    <strong>Remedial works summary:</strong> {{remedialWorksSummary}}
+  </p>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/08-limitations.hbs
+++ b/api/templates/ss/sections/08-limitations.hbs
@@ -1,0 +1,20 @@
+<section class="report-section" id="section-8">
+  <h2>8. Limitations</h2>
+
+  {{#if limitations}}
+  <ul>
+    {{#each limitations}}
+    <li>{{this}}</li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <ul>
+    <li>This report is based on a visual, non-invasive inspection only. No destructive testing was undertaken.</li>
+    <li>Areas concealed by wall linings, floor coverings, ceiling linings, stored items, or vegetation were not inspected.</li>
+    <li>This report does not cover compliance with the current Building Code (NZBC) — it assesses only against Building Act 1991, Section 64.</li>
+    <li>The inspection was limited to areas that were safely accessible at the time of inspection.</li>
+    <li>No comment is made on the structural adequacy of the building unless specifically noted.</li>
+    <li>This report is prepared for the exclusive use of the client named above and the relevant territorial authority.</li>
+  </ul>
+  {{/if}}
+</section>

--- a/api/templates/ss/sections/09-signatures.hbs
+++ b/api/templates/ss/sections/09-signatures.hbs
@@ -1,0 +1,35 @@
+<section class="report-section signatures-section" id="section-9">
+  <h2>9. Declaration &amp; Signatures</h2>
+
+  <p>
+    I/We declare that the information contained in this report is true and correct
+    to the best of my/our knowledge and belief, based on the inspection carried out
+    on {{formatDate inspection.date}}.
+  </p>
+
+  <div class="signature-block">
+    <div class="signature-row">
+      <div class="signature-field">
+        <div class="signature-line"></div>
+        <p class="signature-name">{{personnel.author.name}}</p>
+        {{#if personnel.author.credentials}}
+        <p class="signature-credentials">{{personnel.author.credentials}}</p>
+        {{/if}}
+        <p class="signature-role">Prepared By</p>
+        <p class="signature-date">Date: {{formatDate generatedAt}}</p>
+      </div>
+
+      {{#if personnel.reviewer}}
+      <div class="signature-field">
+        <div class="signature-line"></div>
+        <p class="signature-name">{{personnel.reviewer.name}}</p>
+        {{#if personnel.reviewer.credentials}}
+        <p class="signature-credentials">{{personnel.reviewer.credentials}}</p>
+        {{/if}}
+        <p class="signature-role">Reviewed By</p>
+        <p class="signature-date">Date: {{formatDate generatedAt}}</p>
+      </div>
+      {{/if}}
+    </div>
+  </div>
+</section>

--- a/api/templates/ss/styles/report.css
+++ b/api/templates/ss/styles/report.css
@@ -1,0 +1,77 @@
+/* Safe & Sanitary Report Styles — Issue #553 */
+
+@page {
+  size: A4;
+  margin: 20mm 15mm 25mm 15mm;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #333;
+}
+
+/* ─── Cover Page ─── */
+.cover-page { page-break-after: always; text-align: center; padding-top: 60mm; }
+.cover-title h1 { font-size: 24pt; margin: 20mm 0 5mm; }
+.cover-subtitle { font-size: 14pt; color: #666; margin-bottom: 20mm; }
+.cover-details { margin: 10mm auto; text-align: left; max-width: 300px; }
+.cover-details .label { font-weight: bold; }
+.cover-logo { max-height: 40mm; }
+
+/* ─── Table of Contents ─── */
+.table-of-contents { page-break-after: always; }
+.table-of-contents h2 { border-bottom: 2px solid #333; padding-bottom: 3mm; }
+
+/* ─── Sections ─── */
+.report-section { margin-bottom: 10mm; }
+.report-section h2 { color: #1a365d; border-bottom: 1px solid #ccc; padding-bottom: 2mm; margin-top: 8mm; }
+.report-section h3 { color: #2d4a7a; margin-top: 5mm; }
+
+/* ─── Tables ─── */
+table { width: 100%; border-collapse: collapse; margin: 5mm 0; }
+th, td { border: 1px solid #ccc; padding: 3mm 4mm; text-align: left; vertical-align: top; }
+th { background-color: #f0f4f8; font-weight: bold; color: #1a365d; }
+
+.summary-table th { width: 30%; }
+.personnel-table th { width: 30%; }
+.building-info-table th { width: 30%; }
+
+/* ─── Assessment Framework Table ─── */
+.assessment-table th { font-size: 10pt; }
+.assessment-table .item-name { width: 15%; font-weight: bold; }
+.assessment-table .item-details { font-weight: normal; font-size: 10pt; color: #555; }
+.assessment-table .photo-refs { width: 12%; font-size: 10pt; }
+.assessment-table .observations { width: 30%; }
+.assessment-table .compliance { width: 20%; font-size: 10pt; }
+.assessment-table .remedial { width: 15%; }
+
+/* ─── Remedial Table ─── */
+.remedial-table th:first-child { width: 8%; }
+.remedial-table th:nth-child(2) { width: 25%; }
+
+/* ─── Signatures ─── */
+.signatures-section { page-break-before: always; }
+.signature-block { margin-top: 10mm; }
+.signature-row { display: flex; gap: 20mm; }
+.signature-field { flex: 1; }
+.signature-line { border-bottom: 1px solid #333; height: 15mm; margin-bottom: 3mm; }
+.signature-name { font-weight: bold; margin: 0; }
+.signature-credentials { font-size: 10pt; color: #555; margin: 1mm 0; }
+.signature-role { font-size: 10pt; margin: 1mm 0; }
+.signature-date { font-size: 10pt; color: #555; margin: 1mm 0; }
+
+/* ─── Photos ─── */
+.photo-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 5mm; }
+.photo-item { break-inside: avoid; margin-bottom: 5mm; }
+.photo-item img { max-width: 100%; border: 1px solid #ddd; }
+.photo-item figcaption { font-size: 10pt; margin-top: 2mm; }
+.photo-location { color: #666; }
+
+/* ─── Document Control ─── */
+.document-control-page { page-break-after: always; }
+
+/* ─── Utilities ─── */
+.page-break-before { page-break-before: always; }
+.no-data { font-style: italic; color: #666; }


### PR DESCRIPTION
## Summary

Creates Safe & Sanitary report templates with 9 sections + photo appendix, assessing buildings against Building Act 1991 s.64.

### Changes
- **New:** `api/templates/ss/` — complete template set (base, cover, 9 sections, photo appendix, CSS)
- **Core:** Assessment framework (section 5) splits into safety (s.64(1)) and sanitary (s.64(4)) tables
- **Updated:** report-type-routing tests to reflect SS availability
- **13 new tests** + updated routing tests (667 total passing)

### Key Templates
| Section | File | Purpose |
|---------|------|---------|
| 5 | `05-assessment-framework.hbs` | Safety + sanitary tables with photo refs, observations, compliance, remedial |
| 7 | `07-summary.hbs` | Auto-selects conclusion based on isSafe/isSanitary flags |
| 8 | `08-limitations.hbs` | Default boilerplate for s.64 assessment scope |

### Acceptance Criteria
- [x] 9 sections: Report Info → Introduction → Building Description → Methodology → Assessment Framework → Remedial → Summary → Limitations → Signatures
- [x] Assessment table columns: Items, Photo Ref, Observations, Compliance (s.64), Remedial Works
- [x] Safety items reference s.64(1), sanitary items reference s.64(4)
- [x] Summary states "Safe and Sanitary condition" when both pass
- [x] COA/CCC/PPI reports unaffected

Closes #553