### PR TITLE
feat(api): add BRANZ zone data fields to Property schema

### DIFF
--- a/api/prisma/migrations/20260301_add_branz_zone_fields/migration.sql
+++ b/api/prisma/migrations/20260301_add_branz_zone_fields/migration.sql
@@ -1,0 +1,9 @@
+-- Add BRANZ zone data fields to Property — Issue #543
+
+ALTER TABLE "Property" ADD COLUMN "climateZone" TEXT;
+ALTER TABLE "Property" ADD COLUMN "earthquakeZone" TEXT;
+ALTER TABLE "Property" ADD COLUMN "exposureZone" TEXT;
+ALTER TABLE "Property" ADD COLUMN "leeZone" TEXT;
+ALTER TABLE "Property" ADD COLUMN "rainfallRange" TEXT;
+ALTER TABLE "Property" ADD COLUMN "windRegion" TEXT;
+ALTER TABLE "Property" ADD COLUMN "windZone" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -348,6 +348,15 @@ model Property {
   yearBuilt            Int?
   siteData             Json?
   construction         Json?
+  
+  // BRANZ Zone Data — Issue #543
+  climateZone          String?
+  earthquakeZone       String?
+  exposureZone         String?
+  leeZone              String?
+  rainfallRange        String?
+  windRegion           String?
+  windZone             String?
   createdAt            DateTime             @default(now())
   updatedAt            DateTime             @updatedAt
   

--- a/api/src/__tests__/project.test.ts
+++ b/api/src/__tests__/project.test.ts
@@ -52,6 +52,13 @@ const mockProperty: Property = {
   yearBuilt: 2000,
   siteData: null,
   construction: null,
+  climateZone: null,
+  earthquakeZone: null,
+  exposureZone: null,
+  leeZone: null,
+  rainfallRange: null,
+  windRegion: null,
+  windZone: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -372,5 +379,103 @@ describe('ClientService', () => {
         service.update('non-existent', { phone: '09 987 6543' })
       ).rejects.toThrow(ClientNotFoundError);
     });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// BRANZ Zone Data Tests — Issue #543
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('Property BRANZ Zone Fields — #543', () => {
+  let repository: IPropertyRepository;
+  let service: PropertyService;
+
+  beforeEach(() => {
+    repository = createMockPropertyRepository();
+    service = new PropertyService(repository);
+  });
+
+  const mockPropertyWithZones = {
+    id: 'prop-1',
+    streetAddress: '123 Test St',
+    suburb: 'Ponsonby',
+    city: 'Auckland',
+    postcode: '1011',
+    lotDp: 'Lot 1 DP 12345',
+    councilPropertyId: null,
+    territorialAuthority: 'AKL' as const,
+    bcNumber: null,
+    yearBuilt: 2005,
+    siteData: null,
+    construction: null,
+    climateZone: '1',
+    earthquakeZone: 'Zone 1',
+    exposureZone: 'Zone B',
+    leeZone: 'No',
+    rainfallRange: '80-90',
+    windRegion: 'A',
+    windZone: 'Medium',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it('should create property with BRANZ zone data', async () => {
+    vi.mocked(repository.create).mockResolvedValue(mockPropertyWithZones as never);
+
+    const result = await service.create({
+      streetAddress: '123 Test St',
+      territorialAuthority: 'AKL',
+      climateZone: '1',
+      earthquakeZone: 'Zone 1',
+      exposureZone: 'Zone B',
+      leeZone: 'No',
+      rainfallRange: '80-90',
+      windRegion: 'A',
+      windZone: 'Medium',
+    });
+
+    expect(result.climateZone).toBe('1');
+    expect(result.earthquakeZone).toBe('Zone 1');
+    expect(result.windZone).toBe('Medium');
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        climateZone: '1',
+        earthquakeZone: 'Zone 1',
+        windZone: 'Medium',
+      }),
+    );
+  });
+
+  it('should update property BRANZ zone data', async () => {
+    vi.mocked(repository.findById).mockResolvedValue(mockPropertyWithZones as never);
+    vi.mocked(repository.update).mockResolvedValue({
+      ...mockPropertyWithZones,
+      windZone: 'High',
+    } as never);
+
+    const result = await service.update('prop-1', { windZone: 'High' });
+    expect(result.windZone).toBe('High');
+  });
+
+  it('should accept property without BRANZ fields', async () => {
+    const noZones = {
+      ...mockPropertyWithZones,
+      climateZone: null,
+      earthquakeZone: null,
+      exposureZone: null,
+      leeZone: null,
+      rainfallRange: null,
+      windRegion: null,
+      windZone: null,
+    };
+    vi.mocked(repository.create).mockResolvedValue(noZones as never);
+
+    const result = await service.create({
+      streetAddress: '456 Other St',
+      territorialAuthority: 'WCC',
+    });
+
+    expect(result.climateZone).toBeNull();
+    expect(result.windZone).toBeNull();
   });
 });

--- a/api/src/repositories/interfaces/project.ts
+++ b/api/src/repositories/interfaces/project.ts
@@ -39,6 +39,14 @@ export interface CreatePropertyInput {
   yearBuilt?: number;
   siteData?: Prisma.InputJsonValue;
   construction?: Prisma.InputJsonValue;
+  // BRANZ Zone Data — Issue #543
+  climateZone?: string;
+  earthquakeZone?: string;
+  exposureZone?: string;
+  leeZone?: string;
+  rainfallRange?: string;
+  windRegion?: string;
+  windZone?: string;
 }
 
 export interface UpdatePropertyInput {
@@ -53,6 +61,14 @@ export interface UpdatePropertyInput {
   yearBuilt?: number;
   siteData?: Prisma.InputJsonValue;
   construction?: Prisma.InputJsonValue;
+  // BRANZ Zone Data — Issue #543
+  climateZone?: string;
+  earthquakeZone?: string;
+  exposureZone?: string;
+  leeZone?: string;
+  rainfallRange?: string;
+  windRegion?: string;
+  windZone?: string;
 }
 
 export interface PropertySearchParams {

--- a/api/src/routes/properties.ts
+++ b/api/src/routes/properties.ts
@@ -28,6 +28,14 @@ const CreatePropertySchema = z.object({
   yearBuilt: z.number().int().min(1800).max(2100).optional(),
   siteData: z.any().optional(),
   construction: z.any().optional(),
+  // BRANZ Zone Data — Issue #543
+  climateZone: z.string().optional(),
+  earthquakeZone: z.string().optional(),
+  exposureZone: z.string().optional(),
+  leeZone: z.string().optional(),
+  rainfallRange: z.string().optional(),
+  windRegion: z.string().optional(),
+  windZone: z.string().optional(),
 });
 
 const UpdatePropertySchema = z.object({
@@ -42,6 +50,14 @@ const UpdatePropertySchema = z.object({
   yearBuilt: z.number().int().min(1800).max(2100).optional(),
   siteData: z.any().optional(),
   construction: z.any().optional(),
+  // BRANZ Zone Data — Issue #543
+  climateZone: z.string().optional(),
+  earthquakeZone: z.string().optional(),
+  exposureZone: z.string().optional(),
+  leeZone: z.string().optional(),
+  rainfallRange: z.string().optional(),
+  windRegion: z.string().optional(),
+  windZone: z.string().optional(),
 });
 
 // POST /api/properties - Create property


### PR DESCRIPTION
## Summary

Adds 7 BRANZ zone data fields to the Property model for site-specific environmental data used in inspection reports.

### Changes
- **Schema:** Added `climateZone`, `earthquakeZone`, `exposureZone`, `leeZone`, `rainfallRange`, `windRegion`, `windZone` to Property model
- **Migration:** `20260301_add_branz_zone_fields` — nullable text columns
- **Interfaces:** Updated `CreatePropertyInput` and `UpdatePropertyInput`
- **Routes:** Updated Zod schemas in property routes
- **Tests:** 3 new tests for BRANZ zone CRUD

### Acceptance Criteria
- [x] Property can store BRANZ zone data fields
- [x] Fields are optional/nullable (existing properties unaffected)
- [x] Create and update APIs accept zone data

Closes #543