### PR TITLE
[Sam] feat(web): add BRANZ zone data fields to property page

### DIFF
--- a/docs/design/ui/branz-zone-fields.spec.yaml
+++ b/docs/design/ui/branz-zone-fields.spec.yaml
@@ -1,0 +1,51 @@
+name: branz-zone-fields
+issue: 556
+description: BRANZ zone data fields on property page
+
+section:
+  title: "Site Data (BRANZ Maps)"
+  placement: after Property section, as a new CollapsibleSection
+  pattern: inline-editable fields with auto-save
+
+fields:
+  - name: climateZone
+    label: Climate Zone
+    type: select
+    options: ["1", "2", "3"]
+  - name: earthquakeZone
+    label: Earthquake Zone
+    type: select
+    options: ["Zone 1", "Zone 2"]
+  - name: exposureZone
+    label: Exposure Zone
+    type: select
+    options: ["Zone A", "Zone B", "Zone C", "Zone D"]
+  - name: leeZone
+    label: Lee Zone
+    type: select
+    options: ["Yes", "No"]
+  - name: rainfallRange
+    label: Rainfall Range
+    type: text
+    placeholder: "e.g. 90-100"
+  - name: windRegion
+    label: Wind Region
+    type: select
+    options: ["A", "W"]
+  - name: windZone
+    label: Wind Zone
+    type: select
+    options: ["Low", "Medium", "High", "Very High", "Extra High"]
+
+layout:
+  type: two-column-grid
+  responsive: single-column on mobile
+
+api:
+  endpoint: "PUT /api/properties/:id"
+  payload: individual field values
+
+tokens:
+  spacing: space-y-4 for form, gap-4 for grid
+  labels: text-sm font-medium text-gray-700
+  inputs: standard form controls matching existing UI

--- a/web/app/projects/[id]/branz-zone-section.tsx
+++ b/web/app/projects/[id]/branz-zone-section.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { CollapsibleSection } from '@/components/collapsible-section';
+import { SaveIndicator } from '@/components/save-indicator';
+import { useAutoSave } from '@/hooks/use-auto-save';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+interface BranzZoneData {
+  climateZone: string;
+  earthquakeZone: string;
+  exposureZone: string;
+  leeZone: string;
+  rainfallRange: string;
+  windRegion: string;
+  windZone: string;
+}
+
+interface BranzZoneSectionProps {
+  propertyId: string;
+  initialData: BranzZoneData;
+}
+
+const CLIMATE_ZONE_OPTIONS = ['1', '2', '3'];
+const EARTHQUAKE_ZONE_OPTIONS = ['Zone 1', 'Zone 2'];
+const EXPOSURE_ZONE_OPTIONS = ['Zone A', 'Zone B', 'Zone C', 'Zone D'];
+const LEE_ZONE_OPTIONS = ['Yes', 'No'];
+const WIND_REGION_OPTIONS = ['A', 'W'];
+const WIND_ZONE_OPTIONS = ['Low', 'Medium', 'High', 'Very High', 'Extra High'];
+
+function SelectField({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        <option value="">— Select —</option>
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">
+        {label}
+      </label>
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+    </div>
+  );
+}
+
+export function BranzZoneSection({
+  propertyId,
+  initialData,
+}: BranzZoneSectionProps): React.ReactElement {
+  const [data, setData] = useState<BranzZoneData>(initialData);
+
+  const handleSave = useCallback(
+    async (dataToSave: BranzZoneData): Promise<void> => {
+      const response = await fetch(`${API_URL}/api/properties/${propertyId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(dataToSave),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to save: ${response.status}`);
+      }
+    },
+    [propertyId]
+  );
+
+  const { status, error, retry } = useAutoSave({
+    data,
+    onSave: handleSave,
+    debounceMs: 800,
+  });
+
+  const updateField = useCallback(
+    (field: keyof BranzZoneData) => (value: string) => {
+      setData((prev) => ({ ...prev, [field]: value }));
+    },
+    []
+  );
+
+  const filledCount = Object.values(data).filter(Boolean).length;
+
+  return (
+    <>
+      <CollapsibleSection
+        id="branz-zone-data"
+        title="Site Data (BRANZ Maps)"
+        completionStatus={filledCount > 0 ? `${filledCount}/7 fields` : undefined}
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <SelectField
+            label="Climate Zone"
+            value={data.climateZone}
+            options={CLIMATE_ZONE_OPTIONS}
+            onChange={updateField('climateZone')}
+          />
+          <SelectField
+            label="Earthquake Zone"
+            value={data.earthquakeZone}
+            options={EARTHQUAKE_ZONE_OPTIONS}
+            onChange={updateField('earthquakeZone')}
+          />
+          <SelectField
+            label="Exposure Zone"
+            value={data.exposureZone}
+            options={EXPOSURE_ZONE_OPTIONS}
+            onChange={updateField('exposureZone')}
+          />
+          <SelectField
+            label="Lee Zone"
+            value={data.leeZone}
+            options={LEE_ZONE_OPTIONS}
+            onChange={updateField('leeZone')}
+          />
+          <TextField
+            label="Rainfall Range"
+            value={data.rainfallRange}
+            placeholder="e.g. 90-100"
+            onChange={updateField('rainfallRange')}
+          />
+          <SelectField
+            label="Wind Region"
+            value={data.windRegion}
+            options={WIND_REGION_OPTIONS}
+            onChange={updateField('windRegion')}
+          />
+          <SelectField
+            label="Wind Zone"
+            value={data.windZone}
+            options={WIND_ZONE_OPTIONS}
+            onChange={updateField('windZone')}
+          />
+        </div>
+      </CollapsibleSection>
+      <SaveIndicator status={status} error={error} onRetry={retry} />
+    </>
+  );
+}

--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -28,6 +28,13 @@ interface Project {
     yearBuilt: number | null;
     siteData: Record<string, unknown> | null;
     construction: Record<string, unknown> | null;
+    climateZone: string | null;
+    earthquakeZone: string | null;
+    exposureZone: string | null;
+    leeZone: string | null;
+    rainfallRange: string | null;
+    windRegion: string | null;
+    windZone: string | null;
   };
   client: {
     id: string;

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -6,6 +6,7 @@ import { PhotoGrid, Photo } from '@/components/photo-grid';
 import { ClauseReviewSection } from './clause-review-section';
 import { DocumentUpload } from '@/components/document-upload';
 import { DocumentList, Document } from '@/components/document-list';
+import { BranzZoneSection } from './branz-zone-section';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
@@ -29,6 +30,13 @@ interface Project {
     yearBuilt: number | null;
     siteData: Record<string, unknown> | null;
     construction: Record<string, unknown> | null;
+    climateZone: string | null;
+    earthquakeZone: string | null;
+    exposureZone: string | null;
+    leeZone: string | null;
+    rainfallRange: string | null;
+    windRegion: string | null;
+    windZone: string | null;
   };
   client: {
     id: string;
@@ -184,6 +192,20 @@ export function ProjectSections({ project }: ProjectSectionsProps): React.ReactE
           />
         </dl>
       </CollapsibleSection>
+
+      {/* BRANZ Zone Data Section — Issue #556 */}
+      <BranzZoneSection
+        propertyId={project.property.id}
+        initialData={{
+          climateZone: project.property.climateZone || '',
+          earthquakeZone: project.property.earthquakeZone || '',
+          exposureZone: project.property.exposureZone || '',
+          leeZone: project.property.leeZone || '',
+          rainfallRange: project.property.rainfallRange || '',
+          windRegion: project.property.windRegion || '',
+          windZone: project.property.windZone || '',
+        }}
+      />
 
       {/* Inspections Section */}
       <CollapsibleSection


### PR DESCRIPTION
## Summary
Add **Site Data (BRANZ Maps)** section to the property page with 7 editable fields.

## Changes
- New `BranzZoneSection` component with auto-save
- 6 dropdown selects + 1 free text field (Rainfall Range)
- Responsive 2-column grid layout
- Uses existing `useAutoSave` hook + `SaveIndicator`
- Design spec: `docs/design/ui/branz-zone-fields.spec.yaml`

## Fields
| Field | Type | Options |
|-------|------|---------|
| Climate Zone | Select | 1, 2, 3 |
| Earthquake Zone | Select | Zone 1, Zone 2 |
| Exposure Zone | Select | Zone A, Zone B, Zone C, Zone D |
| Lee Zone | Select | Yes, No |
| Rainfall Range | Text | Free text (e.g. 90-100) |
| Wind Region | Select | A, W |
| Wind Zone | Select | Low, Medium, High, Very High, Extra High |

## Dependencies
- Backend #543 (merged, `tested-pass`)

Closes #556