### PR TITLE
feat(api): add pino-http request logging middleware

### DIFF
--- a/api/src/__tests__/pino-http.test.ts
+++ b/api/src/__tests__/pino-http.test.ts
@@ -1,0 +1,93 @@
+/**
+ * pino-http Request Logging Tests — Issue #573
+ */
+
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { pinoHttp } from 'pino-http';
+import pino from 'pino';
+
+function createTestApp() {
+  const logs: Record<string, unknown>[] = [];
+  const stream = {
+    write(msg: string) {
+      logs.push(JSON.parse(msg));
+    },
+  };
+
+  const logger = pino({ level: 'info' }, stream);
+  const app = express();
+
+  app.use(pinoHttp({
+    logger,
+    autoLogging: {
+      ignore: (req: any) => req.url === '/health' || req.url === '/health/ready',
+    },
+    customSuccessMessage: (req: any, res: any) => `${req.method} ${req.url} ${res.statusCode}`,
+    customErrorMessage: (req: any, res: any) => `${req.method} ${req.url} ${res.statusCode}`,
+  }));
+
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  app.get('/api/test', (_req, res) => res.json({ ok: true }));
+  app.post('/api/data', (_req, res) => res.status(201).json({ created: true }));
+  app.get('/api/error', (_req, _res, next) => next(new Error('test error')));
+
+  // Error handler using req.log
+  app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    const log = req.log || logger;
+    log.error({ err, statusCode: 500 }, 'Unhandled API error');
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
+  return { app, logs };
+}
+
+describe('pino-http Request Logging — #573', () => {
+  it('logs request with method, url, statusCode, responseTime', async () => {
+    const { app, logs } = createTestApp();
+    await request(app).get('/api/test');
+
+    const reqLog = logs.find((l) => l.msg && (l.msg as string).includes('GET /api/test'));
+    expect(reqLog).toBeDefined();
+    expect(reqLog!.req).toBeDefined();
+    expect(reqLog!.res).toBeDefined();
+    expect(reqLog!.responseTime).toBeDefined();
+    expect(typeof reqLog!.responseTime).toBe('number');
+  });
+
+  it('includes unique request ID (req.id)', async () => {
+    const { app, logs } = createTestApp();
+    await request(app).get('/api/test');
+
+    const reqLog = logs.find((l) => l.msg && (l.msg as string).includes('GET /api/test'));
+    expect(reqLog).toBeDefined();
+    expect((reqLog!.req as Record<string, unknown>).id).toBeDefined();
+  });
+
+  it('does NOT log health check requests', async () => {
+    const { app, logs } = createTestApp();
+    await request(app).get('/health');
+
+    const healthLog = logs.find((l) => l.msg && (l.msg as string).includes('/health'));
+    expect(healthLog).toBeUndefined();
+  });
+
+  it('logs errors via pino on unhandled errors', async () => {
+    const { app, logs } = createTestApp();
+    await request(app).get('/api/error');
+
+    const errorLog = logs.find((l) => l.msg === 'Unhandled API error');
+    expect(errorLog).toBeDefined();
+    expect(errorLog!.level).toBe(50); // pino error level
+    expect((errorLog!.err as Record<string, unknown>).message).toBe('test error');
+  });
+
+  it('logs POST requests with correct method', async () => {
+    const { app, logs } = createTestApp();
+    await request(app).post('/api/data').send({ foo: 'bar' });
+
+    const reqLog = logs.find((l) => l.msg && (l.msg as string).includes('POST /api/data'));
+    expect(reqLog).toBeDefined();
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,4 +1,5 @@
 import { logger } from './lib/logger.js';
+import { pinoHttp as PinoHttp, type Options as PinoHttpOptions } from 'pino-http';
 import express, { type Application } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -77,6 +78,16 @@ app.use(cors({
 app.use(cookieParser());
 app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 
+// Structured request logging — Issue #573
+app.use(PinoHttp({
+  logger,
+  autoLogging: {
+    ignore: (req) => req.url === '/health' || req.url === '/health/ready',
+  },
+  customSuccessMessage: (req, res) => `${req.method} ${req.url} ${res.statusCode}`,
+  customErrorMessage: (req, res) => `${req.method} ${req.url} ${res.statusCode}`,
+}));
+
 // Public routes (no auth required)
 app.use('/health', healthRouter);
 app.use('/api', openApiRouter);  // OpenAPI docs (no auth required)
@@ -121,20 +132,21 @@ app.use('/api', serviceAuthMiddleware, credentialsRouter);
 
 // Error handling with detailed logging
 app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  // Log with context
-  logger.error({
+  // Use pino-http request logger if available, fall back to shared logger
+  const log = req.log || logger;
+  log.error({
     method: req.method,
     path: req.path,
+    statusCode: 500,
     err,
   }, 'Unhandled API error');
 
-  
   // Check for common issues and provide hints
   const message = err.message.toLowerCase();
   if (message.includes('prisma') || message.includes('database') || message.includes('connect')) {
-    logger.error('Hint: Check DATABASE_URL is set correctly');
+    log.error('Hint: Check DATABASE_URL is set correctly');
   }
-  
+
   res.status(500).json({ error: 'Internal server error' });
 });
 


### PR DESCRIPTION
## Summary

Adds pino-http middleware for automatic structured request/response logging on every API call.

### Changes
- **Updated:** `api/src/index.ts` — added pino-http middleware before routes
- **New:** `api/src/__tests__/pino-http.test.ts` — 5 tests

### Features
- Every request logged with method, url, statusCode, responseTime, unique req.id
- Health check endpoints (`/health`, `/health/ready`) excluded from auto-logging
- Error handler uses `req.log` (pino-http child logger) for per-request context

### Dependencies
- Depends on #572 (pino logger) — PR #578

### Acceptance Criteria
- [x] Request logged with method, url, statusCode, responseTime
- [x] Unique request ID (req.id) included
- [x] Error handler logs via pino (not console.error)

Closes #573