### PR TITLE
feat(server): add pino structured logger to MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14505,6 +14505,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "handlebars": "^4.7.8",
+        "pino": "^10.3.1",
         "puppeteer": "^24.37.3",
         "yaml": "^2.4.0",
         "zod": "^3.24.0"
@@ -14514,6 +14515,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
+        "pino-pretty": "^13.1.3",
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.56.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "handlebars": "^4.7.8",
+    "pino": "^10.3.1",
     "puppeteer": "^24.37.3",
     "yaml": "^2.4.0",
     "zod": "^3.24.0"
@@ -31,6 +32,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
+    "pino-pretty": "^13.1.3",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.56.0",

--- a/server/src/__tests__/logger.test.ts
+++ b/server/src/__tests__/logger.test.ts
@@ -1,0 +1,31 @@
+/**
+ * MCP Server Logger Tests — Issue #574
+ */
+
+import { describe, it, expect } from 'vitest';
+import { logger } from '../lib/logger.js';
+
+describe('MCP Server Logger — #574', () => {
+  it('has service binding set to mcp-server', () => {
+    const bindings = logger.bindings();
+    expect(bindings.service).toBe('mcp-server');
+  });
+
+  it('has default level of info', () => {
+    expect(logger.level).toBe('info');
+  });
+
+  it('creates child loggers with additional context', () => {
+    const child = logger.child({ tool: 'create_finding' });
+    const bindings = child.bindings();
+    expect(bindings.tool).toBe('create_finding');
+    expect(bindings.service).toBe('mcp-server');
+  });
+
+  it('is a pino logger instance', () => {
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.error).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.child).toBe('function');
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,4 @@
+import { logger } from "./lib/logger.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerTools } from "./tools/index.js";
@@ -14,10 +15,10 @@ registerTools(server);
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("AI Inspection MCP server running on stdio");
+  logger.info("AI Inspection MCP server running on stdio");
 }
 
 main().catch((error) => {
-  console.error("Failed to start server:", error);
+  logger.fatal({ err: error }, "Failed to start MCP server");
   process.exit(1);
 });

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -1,0 +1,55 @@
+/**
+ * Structured Logger — Issue #574
+ *
+ * Shared pino logger instance for the MCP server.
+ * Outputs newline-delimited JSON for Grafana Loki ingestion.
+ *
+ * Note: MCP server communicates via stdio, so logs MUST go to stderr
+ * (stdout is reserved for MCP JSON-RPC protocol messages).
+ */
+
+import pino from 'pino';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+
+  base: {
+    service: 'mcp-server',
+    env: process.env.NODE_ENV || 'development',
+  },
+
+  redact: {
+    paths: [
+      'password',
+      'token',
+      'secret',
+      'apiKey',
+    ],
+    censor: '[REDACTED]',
+  },
+
+  // Human-readable in dev, always to stderr
+  ...(isDev
+    ? {
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss',
+            ignore: 'pid,hostname,service,env',
+            destination: 2, // stderr
+          },
+        },
+      }
+    : {
+        // Production: JSON to stderr
+        transport: {
+          target: 'pino/file',
+          options: { destination: 2 },
+        },
+      }),
+});
+
+export type Logger = pino.Logger;

--- a/server/src/services/checklist.ts
+++ b/server/src/services/checklist.ts
@@ -1,3 +1,4 @@
+import { logger } from "../lib/logger.js";
 /**
  * Checklist Service - Issue #3
  * 
@@ -64,7 +65,7 @@ class ChecklistService {
     if (this.loaded) return;
 
     if (!existsSync(this.configPath)) {
-      console.warn(`Checklist config path not found: ${this.configPath}`);
+      logger.warn({ configPath: this.configPath }, "Checklist config path not found");
       return;
     }
 
@@ -92,9 +93,9 @@ class ChecklistService {
         };
 
         this.checklists.set(id, checklist);
-        console.error(`Loaded checklist: ${id} (${checklist.sections.length} sections)`);
+        logger.debug({ id, sections: checklist.sections.length }, "Loaded checklist");
       } catch (error) {
-        console.error(`Failed to load checklist ${file}:`, error);
+        logger.error({ err: error, file }, "Failed to load checklist");
       }
     }
 

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -1,3 +1,4 @@
+import { logger } from "../lib/logger.js";
 /**
  * Comment Library Service - Issue #4
  * 
@@ -72,7 +73,7 @@ class CommentLibraryService {
         const content = readFileSync(defaultsPath, 'utf-8');
         this.library = parseYaml(content) || {};
       } catch (error) {
-        console.error('Failed to load defaults.yaml:', error);
+        logger.error({ err: error }, 'Failed to load defaults.yaml');
         this.library = {};
       }
     }
@@ -84,7 +85,7 @@ class CommentLibraryService {
         const custom = parseYaml(content) || {};
         this.library = this.deepMerge(this.library, custom);
       } catch (error) {
-        console.error('Failed to load custom.yaml:', error);
+        logger.error({ err: error }, 'Failed to load custom.yaml');
       }
     }
 

--- a/server/src/services/interaction-logger.ts
+++ b/server/src/services/interaction-logger.ts
@@ -1,3 +1,4 @@
+import { logger } from "../lib/logger.js";
 /**
  * Interaction Logger Service
  * Issue #512 - Interaction Observability
@@ -26,7 +27,7 @@ async function flushLogs(): Promise<void> {
     await interactionLogsApi.createBatch(logsToSend);
   } catch (error) {
     // Log failure but don't throw - logging should not break tools
-    console.error('[InteractionLogger] Failed to flush logs:', error);
+    logger.error({ err: error }, 'Failed to flush interaction logs');
   }
 }
 


### PR DESCRIPTION
## Summary

Adds pino structured JSON logging to the MCP server, replacing all console.error/warn calls.

### Changes
- **New:** `server/src/lib/logger.ts` — shared pino instance with `service: 'mcp-server'`, stderr output (stdout reserved for MCP JSON-RPC)
- **Replaced** console calls in: index.ts, comments.ts, interaction-logger.ts, checklist.ts
- **4 tests** for logger instance, bindings, level, child loggers

### Key Design Decision
MCP server communicates via stdio — all logs go to **stderr** so they don't interfere with the JSON-RPC protocol on stdout.

### Acceptance Criteria
- [x] Structured JSON with `service: 'mcp-server'`
- [x] All console.error/warn replaced with pino
- [x] Zero console.* remaining in src/ (excluding tests)

Closes #574