### PR TITLE
docs(infra): add Grafana Cloud setup guide and dashboard

### DIFF
--- a/docs/developer/deployment/grafana-loki-setup.md
+++ b/docs/developer/deployment/grafana-loki-setup.md
@@ -1,0 +1,119 @@
+# Grafana Cloud + Loki Setup Guide
+
+**Issue:** #575
+**Author:** Alex
+**Date:** 2026-03-01
+
+## Overview
+
+Ships structured JSON logs from Railway (API) and OpenClaw (MCP server) to Grafana Cloud Loki for centralized log search and dashboards.
+
+**Cost:** Free tier — 50GB logs/month, 14-day retention.
+
+---
+
+## Step 1: Create Grafana Cloud Account
+
+1. Go to [grafana.com/auth/sign-up/create-user](https://grafana.com/auth/sign-up/create-user)
+2. Create a free account (no credit card required)
+3. Note your **Grafana Cloud stack URL** (e.g. `https://yourorg.grafana.net`)
+
+## Step 2: Get Loki Push Credentials
+
+1. In Grafana Cloud → **Connections** → **Hosted Logs (Loki)**
+2. Note these values:
+   - **Loki push URL:** `https://logs-prod-XXX.grafana.net/loki/api/v1/push`
+   - **User ID:** (numeric, e.g. `123456`)
+   - **API Key:** Generate one via **Security** → **API Keys** → **Add API Key** (role: `MetricsPublisher`)
+3. The HTTP basic auth is: `user:apiKey`
+
+## Step 3: Configure Railway Log Drain
+
+Railway supports HTTP log drains that POST JSON logs to an endpoint.
+
+1. In Railway dashboard → **Project Settings** → **Log Drains**
+2. Add a new log drain:
+   - **Type:** HTTP
+   - **Endpoint:** `https://<USER_ID>:<API_KEY>@logs-prod-XXX.grafana.net/loki/api/v1/push`
+   - **Format:** JSON (ndjson)
+3. Railway will ship all stdout/stderr from the API service to Loki
+
+### Alternative: Grafana Alloy (Agent)
+
+If Railway's built-in log drain doesn't support Loki's push format directly, deploy Grafana Alloy as a sidecar or separate service:
+
+```yaml
+# alloy-config.yaml
+loki.write "default" {
+  endpoint {
+    url = "https://logs-prod-XXX.grafana.net/loki/api/v1/push"
+    basic_auth {
+      username = env("LOKI_USER")
+      password = env("LOKI_API_KEY")
+    }
+  }
+}
+```
+
+## Step 4: Verify Logs in Grafana
+
+1. Go to Grafana Cloud → **Explore**
+2. Select **Loki** data source
+3. Run query: `{service="api"}`
+4. You should see structured JSON log lines from the API
+5. Try filtering: `{service="api"} | json | level="error"`
+
+## Step 5: Environment Variables
+
+Add to Railway environment (NOT in repo):
+
+| Variable | Description |
+|----------|-------------|
+| `LOG_LEVEL` | `info` (production default) |
+| `LOKI_USER` | Grafana Cloud user ID (if using Alloy) |
+| `LOKI_API_KEY` | Grafana Cloud API key (if using Alloy) |
+
+## Log Format Reference
+
+All services emit newline-delimited JSON:
+
+```json
+{"level":30,"time":1709312400000,"service":"api","msg":"GET /api/projects 200","req":{"id":"abc123","method":"GET","url":"/api/projects"},"res":{"statusCode":200},"responseTime":42}
+```
+
+### Labels for Loki Queries
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `service` | `api`, `mcp-server` | Which service emitted the log |
+| `level` | `10-60` | pino log level (30=info, 40=warn, 50=error) |
+
+### Useful LogQL Queries
+
+```logql
+# All API errors
+{service="api"} | json | level >= 50
+
+# Request latency > 1 second
+{service="api"} | json | responseTime > 1000
+
+# Auth failures
+{service="api"} |= "401"
+
+# MCP server tool calls
+{service="mcp-server"} | json | tool != ""
+
+# Errors in last hour
+{service=~"api|mcp-server"} | json | level >= 50
+```
+
+## Troubleshooting
+
+**No logs appearing:**
+- Check Railway log drain is active and endpoint is correct
+- Verify API key has `MetricsPublisher` role
+- Check Loki data source is selected in Grafana Explore
+
+**Logs appear but not structured:**
+- Ensure pino logger is used (not console.log)
+- Check `NODE_ENV=production` (disables pino-pretty)

--- a/infra/grafana/service-health-dashboard.json
+++ b/infra/grafana/service-health-dashboard.json
@@ -1,0 +1,167 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "Grafana Cloud Loki data source",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "title": "Service Health & Error Logs",
+  "description": "Monitors API and MCP server health — Issue #576",
+  "tags": ["ai-inspection", "logging"],
+  "editable": true,
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "custom",
+        "label": "Service",
+        "current": { "text": "All", "value": "$__all" },
+        "options": [
+          { "text": "All", "value": "$__all", "selected": true },
+          { "text": "api", "value": "api", "selected": false },
+          { "text": "mcp-server", "value": "mcp-server", "selected": false }
+        ],
+        "includeAll": true,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Error Rate Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum(count_over_time({service=~\"$service\"} | json | level >= 50 [$__interval])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "pointSize": 5
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Logs by Level",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum(count_over_time({service=~\"$service\"} | json | level = 30 [$__range])) ",
+          "legendFormat": "info",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum(count_over_time({service=~\"$service\"} | json | level = 40 [$__range]))",
+          "legendFormat": "warn",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum(count_over_time({service=~\"$service\"} | json | level >= 50 [$__range]))",
+          "legendFormat": "error",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "info" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "warn" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "title": "Recent Errors",
+      "type": "logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "{service=~\"$service\"} | json | level >= 50",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Request Latency (p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "quantile_over_time(0.95, {service=\"api\"} | json | unwrap responseTime [$__interval]) by (service)",
+          "legendFormat": "p95 response time",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request Volume",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "sum(count_over_time({service=\"api\"} | json | responseTime > 0 [$__interval]))",
+          "legendFormat": "requests/interval",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 50 }
+        }
+      }
+    }
+  ],
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Adds deployment documentation and dashboard config for Grafana Cloud Loki log aggregation.

### Changes
- **New:** `docs/developer/deployment/grafana-loki-setup.md` — step-by-step setup guide
  - Grafana Cloud account creation
  - Loki push credentials
  - Railway log drain configuration
  - LogQL query reference for debugging
  - Environment variable documentation
- **New:** `infra/grafana/service-health-dashboard.json` — importable Grafana dashboard
  - Error rate over time (per service)
  - Logs by level (pie chart: info/warn/error)
  - Recent errors log panel
  - Request latency p95 + request volume
  - Service selector dropdown

### ⚠️ Manual Steps Required
After merging, someone with Railway + Grafana access needs to:
1. Create Grafana Cloud account (free tier)
2. Configure Railway log drain → Loki endpoint
3. Import dashboard JSON in Grafana

Closes #575
Closes #576