### PR TITLE
feat(api): add semantic versioning to health endpoint

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-inspection/api",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Backend API service (Express + Prisma)",
   "type": "module",

--- a/api/src/__tests__/health.test.ts
+++ b/api/src/__tests__/health.test.ts
@@ -4,10 +4,15 @@ import { version } from '../config/version.js';
 describe('Health Endpoint', () => {
   describe('Version info', () => {
     it('should have required version fields', () => {
+      expect(version).toHaveProperty('semver');
       expect(version).toHaveProperty('sha');
       expect(version).toHaveProperty('shortSha');
       expect(version).toHaveProperty('branch');
       expect(version).toHaveProperty('buildTime');
+    });
+
+    it('should have valid semver from package.json', () => {
+      expect(version.semver).toMatch(/^\d+\.\d+\.\d+/);
     });
 
     it('should have shortSha as 7 characters or "unknown"', () => {
@@ -19,13 +24,11 @@ describe('Health Endpoint', () => {
     });
 
     it('should have valid buildTime format', () => {
-      // Should be ISO 8601 format
       expect(() => new Date(version.buildTime)).not.toThrow();
       expect(new Date(version.buildTime).toISOString()).toBeTruthy();
     });
 
     it('should default to unknown for missing env vars', () => {
-      // In test environment, env vars are typically not set
       expect(['unknown', version.sha]).toContain(version.sha);
       expect(['unknown', version.branch]).toContain(version.branch);
     });

--- a/api/src/config/version.ts
+++ b/api/src/config/version.ts
@@ -1,13 +1,19 @@
 /**
- * Version information for health endpoint
- * 
- * Railway auto-injects RAILWAY_GIT_COMMIT_SHA and RAILWAY_GIT_BRANCH
- * For local dev, falls back to 'unknown'
+ * Version information for health endpoint — Issue #591
+ *
+ * Exposes semantic version from package.json alongside git metadata.
+ * Railway auto-injects RAILWAY_GIT_COMMIT_SHA and RAILWAY_GIT_BRANCH.
  */
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json') as { version: string };
 
 const sha = process.env.GIT_SHA || process.env.RAILWAY_GIT_COMMIT_SHA || 'unknown';
 
 export const version = {
+  semver: pkg.version,
   sha,
   shortSha: sha.slice(0, 7),
   branch: process.env.GIT_BRANCH || process.env.RAILWAY_GIT_BRANCH || 'unknown',


### PR DESCRIPTION
## Summary

Adds `version.semver` to the `GET /health` response, read from `api/package.json`.

### Changes
- `api/package.json` — bumped to `1.1.0`
- `api/src/config/version.ts` — reads semver from package.json via `createRequire`
- `api/src/__tests__/health.test.ts` — added semver validation test

### Response Example
```json
{"status":"ok","version":{"semver":"1.1.0","sha":"abc1234","shortSha":"abc1234","branch":"develop","buildTime":"..."}}
```

Closes #591