### PR TITLE
feat(api): add ServiceKey model and seed for scoped auth

### DIFF
--- a/api/prisma/migrations/20260301_add_service_key/migration.sql
+++ b/api/prisma/migrations/20260301_add_service_key/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable: ServiceKey — Issue #594
+CREATE TABLE "ServiceKey" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "keyPrefix" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "actor" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "expiresAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ServiceKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ServiceKey_name_key" ON "ServiceKey"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ServiceKey_keyHash_key" ON "ServiceKey"("keyHash");
+
+-- CreateIndex
+CREATE INDEX "ServiceKey_keyPrefix_idx" ON "ServiceKey"("keyPrefix");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1072,3 +1072,23 @@ enum InteractionEventType {
   TOOL_RESULT
   AI_RESPONSE
 }
+
+// ============================================
+// Service Key Management — Issue #594
+// ============================================
+
+model ServiceKey {
+  id          String    @id @default(uuid())
+  name        String    @unique          // e.g. "kai-agent"
+  keyHash     String    @unique          // bcrypt hash of the key
+  keyPrefix   String                     // first 8 chars for identification
+  scopes      String[]                   // e.g. ["inspections:read", "inspections:write"]
+  actor       String                     // e.g. "agent:kai"
+  active      Boolean   @default(true)
+  expiresAt   DateTime?
+  lastUsedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([keyPrefix])
+}

--- a/api/prisma/seed-service-keys.ts
+++ b/api/prisma/seed-service-keys.ts
@@ -1,0 +1,58 @@
+/**
+ * Seed Service Keys — Issue #594
+ *
+ * Seeds Kai's service key using the current SERVICE_API_KEY value.
+ * Run: npx tsx prisma/seed-service-keys.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { ServiceKeyService } from '../src/services/service-key.js';
+
+const prisma = new PrismaClient();
+const svc = new ServiceKeyService(prisma);
+
+const KAI_SCOPES = [
+  'inspections:*',
+  'projects:*',
+  'properties:*',
+  'clients:*',
+  'checklist:*',
+  'clause-reviews:*',
+  'building-code:read',
+  'photos:*',
+];
+
+async function main() {
+  const rawKey = process.env.SERVICE_API_KEY;
+  if (!rawKey) {
+    console.error('SERVICE_API_KEY env var is required');
+    process.exit(1);
+  }
+
+  // Check if already seeded
+  const existing = await prisma.serviceKey.findUnique({
+    where: { name: 'kai-agent' },
+  });
+
+  if (existing) {
+    console.log('Kai service key already exists, skipping.');
+    return;
+  }
+
+  const key = await svc.create({
+    name: 'kai-agent',
+    rawKey,
+    scopes: KAI_SCOPES,
+    actor: 'agent:kai',
+  });
+
+  console.log(`Created service key: ${key.name} (prefix: ${key.keyPrefix})`);
+  console.log(`Scopes: ${key.scopes.join(', ')}`);
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/api/src/__tests__/service-key.test.ts
+++ b/api/src/__tests__/service-key.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Service Key Tests — Issue #594
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import bcrypt from 'bcrypt';
+import {
+  ServiceKeyService,
+  DuplicateKeyNameError,
+} from '../services/service-key.js';
+
+// Mock Prisma client
+function createMockPrisma() {
+  const keys: Record<string, any> = {};
+
+  return {
+    serviceKey: {
+      findUnique: vi.fn(async ({ where }: any) => {
+        if (where.name) return keys[where.name] ?? null;
+        return null;
+      }),
+      findFirst: vi.fn(async ({ where }: any) => {
+        return Object.values(keys).find(
+          (k: any) => k.keyPrefix === where.keyPrefix && k.active
+        ) ?? null;
+      }),
+      findMany: vi.fn(async () => Object.values(keys)),
+      create: vi.fn(async ({ data }: any) => {
+        const key = { id: `id-${data.name}`, active: true, expiresAt: null, lastUsedAt: null, ...data, createdAt: new Date(), updatedAt: new Date() };
+        keys[data.name] = key;
+        return key;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const key = Object.values(keys).find((k: any) => k.id === where.id) as any;
+        if (key) Object.assign(key, data, { updatedAt: new Date() });
+        return key;
+      }),
+    },
+    _keys: keys,
+  };
+}
+
+describe('ServiceKeyService — #594', () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+  let svc: ServiceKeyService;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    svc = new ServiceKeyService(prisma as any);
+  });
+
+  describe('create', () => {
+    it('creates a key with hashed value and prefix', async () => {
+      const key = await svc.create({
+        name: 'kai-agent',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:*', 'photos:*'],
+        actor: 'agent:kai',
+      });
+
+      expect(key.name).toBe('kai-agent');
+      expect(key.keyPrefix).toBe('sk_test_');
+      expect(key.scopes).toEqual(['inspections:*', 'photos:*']);
+      expect(key.actor).toBe('agent:kai');
+      expect(key.active).toBe(true);
+      // Hash should be bcrypt format
+      expect(key.keyHash).toMatch(/^\$2[aby]\$/);
+    });
+
+    it('throws DuplicateKeyNameError for duplicate names', async () => {
+      await svc.create({
+        name: 'kai-agent',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:*'],
+        actor: 'agent:kai',
+      });
+
+      await expect(
+        svc.create({
+          name: 'kai-agent',
+          rawKey: 'sk_test_different',
+          scopes: ['inspections:*'],
+          actor: 'agent:kai',
+        })
+      ).rejects.toThrow(DuplicateKeyNameError);
+    });
+  });
+
+  describe('verify', () => {
+    it('returns true for matching key', async () => {
+      const rawKey = 'sk_test_abcdefghijklmnop';
+      const key = await svc.create({
+        name: 'test-key',
+        rawKey,
+        scopes: ['inspections:read'],
+        actor: 'test',
+      });
+
+      const result = await svc.verify(rawKey, key.keyHash);
+      expect(result).toBe(true);
+    });
+
+    it('returns false for wrong key', async () => {
+      const key = await svc.create({
+        name: 'test-key',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:read'],
+        actor: 'test',
+      });
+
+      const result = await svc.verify('sk_test_wrongkey', key.keyHash);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('findByPrefix', () => {
+    it('finds active key by prefix', async () => {
+      await svc.create({
+        name: 'kai-agent',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:*'],
+        actor: 'agent:kai',
+      });
+
+      const found = await svc.findByPrefix('sk_test_');
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe('kai-agent');
+    });
+  });
+
+  describe('list', () => {
+    it('returns keys without keyHash', async () => {
+      await svc.create({
+        name: 'kai-agent',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:*'],
+        actor: 'agent:kai',
+      });
+
+      const keys = await svc.list();
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).not.toHaveProperty('keyHash');
+      expect(keys[0].name).toBe('kai-agent');
+    });
+  });
+
+  describe('deactivate', () => {
+    it('sets active to false', async () => {
+      const key = await svc.create({
+        name: 'kai-agent',
+        rawKey: 'sk_test_abcdefghijklmnop',
+        scopes: ['inspections:*'],
+        actor: 'agent:kai',
+      });
+
+      await svc.deactivate(key.id);
+      expect(prisma.serviceKey.update).toHaveBeenCalledWith({
+        where: { id: key.id },
+        data: { active: false },
+      });
+    });
+  });
+});

--- a/api/src/services/service-key.ts
+++ b/api/src/services/service-key.ts
@@ -1,0 +1,110 @@
+/**
+ * Service Key Management — Issue #594
+ *
+ * Manages DB-backed API keys with scopes and actor identity.
+ */
+
+import type { PrismaClient, ServiceKey } from '@prisma/client';
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 10;
+const PREFIX_LENGTH = 8;
+
+export class ServiceKeyNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Service key not found: ${id}`);
+    this.name = 'ServiceKeyNotFoundError';
+  }
+}
+
+export class DuplicateKeyNameError extends Error {
+  constructor(name: string) {
+    super(`Service key with name "${name}" already exists`);
+    this.name = 'DuplicateKeyNameError';
+  }
+}
+
+export interface CreateServiceKeyInput {
+  name: string;
+  rawKey: string;
+  scopes: string[];
+  actor: string;
+  expiresAt?: Date;
+}
+
+export class ServiceKeyService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Create a new service key (hashes the raw key).
+   */
+  async create(input: CreateServiceKeyInput): Promise<ServiceKey> {
+    const { name, rawKey, scopes, actor, expiresAt } = input;
+
+    const existing = await this.prisma.serviceKey.findUnique({ where: { name } });
+    if (existing) {
+      throw new DuplicateKeyNameError(name);
+    }
+
+    const keyHash = await bcrypt.hash(rawKey, SALT_ROUNDS);
+    const keyPrefix = rawKey.slice(0, PREFIX_LENGTH);
+
+    return this.prisma.serviceKey.create({
+      data: {
+        name,
+        keyHash,
+        keyPrefix,
+        scopes,
+        actor,
+        expiresAt: expiresAt ?? null,
+      },
+    });
+  }
+
+  /**
+   * Find a service key by its prefix (first 8 chars).
+   * Returns null if not found.
+   */
+  async findByPrefix(prefix: string): Promise<ServiceKey | null> {
+    return this.prisma.serviceKey.findFirst({
+      where: { keyPrefix: prefix, active: true },
+    });
+  }
+
+  /**
+   * Verify a raw key against a stored key hash.
+   */
+  async verify(rawKey: string, keyHash: string): Promise<boolean> {
+    return bcrypt.compare(rawKey, keyHash);
+  }
+
+  /**
+   * Update lastUsedAt timestamp (fire-and-forget).
+   */
+  async touchLastUsed(id: string): Promise<void> {
+    await this.prisma.serviceKey.update({
+      where: { id },
+      data: { lastUsedAt: new Date() },
+    });
+  }
+
+  /**
+   * List all service keys (without hashes).
+   */
+  async list(): Promise<Omit<ServiceKey, 'keyHash'>[]> {
+    const keys = await this.prisma.serviceKey.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+    return keys.map(({ keyHash: _, ...rest }) => rest);
+  }
+
+  /**
+   * Deactivate a key.
+   */
+  async deactivate(id: string): Promise<ServiceKey> {
+    return this.prisma.serviceKey.update({
+      where: { id },
+      data: { active: false },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Foundation for scoped service authentication. Adds the ServiceKey Prisma model and service layer for DB-backed API keys with scopes and actor identity.

### Changes
- **Schema:** `ServiceKey` model — id, name, keyHash, keyPrefix, scopes[], actor, active, expiresAt, lastUsedAt
- **Migration:** `20260301_add_service_key`
- **Service:** `ServiceKeyService` — create (bcrypt hash), verify, findByPrefix, list, deactivate
- **Seed:** `prisma/seed-service-keys.ts` — seeds Kai's key with current `SERVICE_API_KEY` value
- **7 tests** — creation, hashing, duplicate detection, verification, prefix lookup, listing, deactivation

### Kai's Scopes
`inspections:*`, `projects:*`, `properties:*`, `clients:*`, `checklist:*`, `clause-reviews:*`, `building-code:read`, `photos:*`

### Next Steps
- #595: Update `serviceAuthMiddleware` to use DB-backed keys
- #596: Wire `requireScope` to routes
- #597: Admin key management endpoint

Closes #594