### PR TITLE
[Riley] docs(ops): logging & observability guide

### DIFF
--- a/docs/developer/logging.md
+++ b/docs/developer/logging.md
@@ -1,0 +1,176 @@
+# Working with Logs
+
+## Overview
+
+The API uses [Pino](https://github.com/pinojs/pino) for structured JSON logging. Logs are shipped to Grafana Cloud Loki where they can be searched, filtered, and visualized.
+
+This guide covers how to add logging in your code and how to query logs for debugging.
+
+## Writing Logs
+
+### Import the Logger
+
+```typescript
+import { logger } from '../config/logger.js';
+```
+
+### Log Levels
+
+| Level | Method | When to Use |
+|-------|--------|-------------|
+| `fatal` | `logger.fatal()` | Process cannot continue |
+| `error` | `logger.error()` | Operation failed, needs attention |
+| `warn` | `logger.warn()` | Unexpected but handled |
+| `info` | `logger.info()` | Significant business events (default) |
+| `debug` | `logger.debug()` | Diagnostic detail for development |
+| `trace` | `logger.trace()` | Verbose debugging |
+
+### Examples
+
+```typescript
+// Simple message
+logger.info('Inspection created');
+
+// With context (structured fields)
+logger.info({ inspectionId, projectId, type }, 'Inspection created');
+
+// Error with stack trace
+logger.error({ err, inspectionId }, 'Failed to create inspection');
+
+// Warning
+logger.warn({ userId, route: req.path }, 'Deprecated endpoint called');
+
+// Debug (only shown when LOG_LEVEL=debug)
+logger.debug({ clauseId, applicability }, 'Clause review updated');
+```
+
+### Best Practices
+
+1. **Always add context** — include IDs so logs are searchable:
+   ```typescript
+   // ✅ Good
+   logger.info({ inspectionId, userId }, 'Inspection started');
+
+   // ❌ Bad
+   logger.info('Inspection started');
+   ```
+
+2. **Use `err` for errors** — Pino serializes Error objects specially:
+   ```typescript
+   // ✅ Good — includes stack trace
+   logger.error({ err }, 'Database query failed');
+
+   // ❌ Bad — loses stack trace
+   logger.error(`Database query failed: ${error.message}`);
+   ```
+
+3. **Don't log sensitive data** — never log passwords, tokens, API keys, JWT contents:
+   ```typescript
+   // ❌ Never do this
+   logger.info({ apiKey, password }, 'Auth attempt');
+   ```
+
+4. **Use appropriate levels** — `info` for business events, `debug` for internal state, `error` for failures.
+
+### HTTP Request Logging
+
+`pino-http` automatically logs every HTTP request/response. You don't need to add request logging manually.
+
+Auto-logged fields:
+- `req.method`, `req.url` — what was called
+- `res.statusCode` — response status
+- `responseTime` — duration in ms
+- 4xx → `warn`, 5xx → `error` level (automatic)
+
+## Querying Logs
+
+### Grafana Explore
+
+1. Open Grafana Cloud → **Explore**
+2. Select **Loki** data source
+3. Write LogQL queries
+
+### LogQL Quick Reference
+
+```logql
+# All API logs
+{service="api"}
+
+# Errors only
+{service="api"} | json | level >= 50
+
+# Specific text search
+{service="api"} |= "401"
+
+# By inspection ID
+{service="api"} | json | inspectionId="<uuid>"
+
+# Slow requests (>1 second)
+{service="api"} | json | responseTime > 1000
+
+# Errors in the last hour
+{service="api"} | json | level >= 50  [1h]
+
+# Auth failures
+{service="api"} |= "Authentication required"
+
+# Specific endpoint
+{service="api"} | json | req_url="/api/inspections"
+```
+
+### Common Debugging Scenarios
+
+#### "Kai can't start an inspection"
+
+```logql
+# Check for auth failures from service calls
+{service="api"} |= "401" | json | req_headers_x_api_key != ""
+
+# Check inspection creation attempts
+{service="api"} | json | req_url=~"/api/.*inspections" | req_method="POST"
+```
+
+#### "Report generation failed"
+
+```logql
+{service="api"} | json | req_url=~"/api/reports.*" | level >= 50
+```
+
+#### "Database errors"
+
+```logql
+{service="api"} |= "Prisma" | json | level >= 50
+```
+
+#### "What happened in the last 5 minutes?"
+
+```logql
+{service="api"} | json | level >= 40
+```
+
+### Dashboard
+
+The **Service Health** dashboard shows:
+
+| Panel | What It Shows |
+|-------|---------------|
+| Error rate over time | Line chart — spikes indicate incidents |
+| Logs by level | Pie chart — healthy ratio is mostly info |
+| Recent errors | Log panel — latest errors with full context |
+| Service selector | Dropdown — filter by api/mcp-server |
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LOG_LEVEL` | `info` | Minimum log level. Set to `debug` for verbose output locally. |
+
+### Local Development
+
+```bash
+# Verbose logging
+LOG_LEVEL=debug npm run dev
+
+# Pretty print (if pino-pretty installed)
+LOG_LEVEL=debug npm run dev | npx pino-pretty
+```

--- a/docs/ops/logging.md
+++ b/docs/ops/logging.md
@@ -1,0 +1,132 @@
+# Logging & Observability
+
+## Overview
+
+Structured JSON logging with Grafana Cloud for centralized log aggregation.
+
+| Component | Purpose |
+|-----------|---------|
+| **Pino** | Structured JSON logger (API + MCP server) |
+| **pino-http** | Automatic HTTP request/response logging (API) |
+| **Grafana Cloud Loki** | Log storage + query engine |
+| **Railway Log Drain** | Ships stdout logs → Loki |
+| **Grafana** | UI for search, dashboards, alerting |
+
+## Application Logging
+
+Both the API and MCP server use [Pino](https://github.com/pinojs/pino) for structured JSON logging to stdout.
+
+### Log Format
+
+```json
+{
+  "level": 30,
+  "time": 1709283600000,
+  "msg": "Inspection created",
+  "service": "api",
+  "reqId": "abc-123",
+  "userId": "user-uuid",
+  "inspectionId": "insp-uuid"
+}
+```
+
+### Log Levels
+
+| Level | Value | Use |
+|-------|-------|-----|
+| `fatal` | 60 | Process cannot continue |
+| `error` | 50 | Operation failed |
+| `warn` | 40 | Unexpected but recoverable |
+| `info` | 30 | Significant events (default) |
+| `debug` | 20 | Diagnostic detail |
+| `trace` | 10 | Verbose debugging |
+
+**Default level:** `info` (override via `LOG_LEVEL` env var).
+
+### HTTP Request Logging (API)
+
+`pino-http` automatically logs every request/response:
+
+```json
+{
+  "level": 30,
+  "msg": "request completed",
+  "req": { "method": "POST", "url": "/api/inspections" },
+  "res": { "statusCode": 201 },
+  "responseTime": 45
+}
+```
+
+Errors (4xx/5xx) are logged at `warn`/`error` level automatically.
+
+### Sensitive Data
+
+**Never logged:** passwords, tokens, API keys, JWT contents, `SERVICE_API_KEY`.
+
+Pino redaction is configured to strip sensitive fields from request headers and body.
+
+## Infrastructure
+
+### Grafana Cloud (Free Tier)
+
+- **Loki** — log storage, 50GB/month free
+- **Grafana** — dashboards and explore UI
+- **Credentials** — stored in deployment runbook (not in repo)
+
+### Railway Log Drain
+
+Railway ships all stdout/stderr from the API service to Grafana Cloud Loki via HTTP push.
+
+Configuration: Railway Dashboard → Service → Settings → Log Drain → Loki HTTP endpoint.
+
+### Log Retention
+
+- **Grafana Cloud free tier:** 30 days
+- Sufficient for diagnosing recent issues; historical analysis not required
+
+## Querying Logs
+
+### Grafana Explore
+
+Access via Grafana Cloud → Explore → Select Loki data source.
+
+**Common queries (LogQL):**
+
+```logql
+# All API errors
+{service="api"} |= "error" | json | level >= 50
+
+# Auth failures
+{service="api"} |= "401"
+
+# Specific inspection
+{service="api"} | json | inspectionId="<uuid>"
+
+# Slow requests (>1s)
+{service="api"} | json | responseTime > 1000
+```
+
+### Dashboard
+
+The **Service Health** dashboard includes:
+
+1. **Error rate over time** — line chart, per service
+2. **Logs by level** — pie chart (info/warn/error)
+3. **Recent errors** — log panel, filtered to level ≥ error
+4. **Service selector** — dropdown to filter by api/mcp-server
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LOG_LEVEL` | `info` | Minimum log level |
+
+## Future Path
+
+```
+Phase 1 (done):  Loki (logs) + Grafana (UI)
+Phase 2 (later): + Tempo (distributed traces)
+Phase 3 (later): + Prometheus (metrics)
+```
+
+Same Grafana ecosystem — add trace IDs to logs, correlate in Grafana UI.

--- a/docs/ops/logging.md
+++ b/docs/ops/logging.md
@@ -1,125 +1,85 @@
-# Logging & Observability
+# Logging Infrastructure Setup
 
 ## Overview
 
-Structured JSON logging with Grafana Cloud for centralized log aggregation.
+Centralized log aggregation using Grafana Cloud (free tier) with Railway log drain.
 
-| Component | Purpose |
-|-----------|---------|
-| **Pino** | Structured JSON logger (API + MCP server) |
-| **pino-http** | Automatic HTTP request/response logging (API) |
-| **Grafana Cloud Loki** | Log storage + query engine |
-| **Railway Log Drain** | Ships stdout logs → Loki |
-| **Grafana** | UI for search, dashboards, alerting |
-
-## Application Logging
-
-Both the API and MCP server use [Pino](https://github.com/pinojs/pino) for structured JSON logging to stdout.
-
-### Log Format
-
-```json
-{
-  "level": 30,
-  "time": 1709283600000,
-  "msg": "Inspection created",
-  "service": "api",
-  "reqId": "abc-123",
-  "userId": "user-uuid",
-  "inspectionId": "insp-uuid"
-}
+```
+Railway API (stdout) ──► Railway Log Drain ──► Grafana Cloud Loki ──► Grafana UI
 ```
 
-### Log Levels
+## Account Required
 
-| Level | Value | Use |
-|-------|-------|-----|
-| `fatal` | 60 | Process cannot continue |
-| `error` | 50 | Operation failed |
-| `warn` | 40 | Unexpected but recoverable |
-| `info` | 30 | Significant events (default) |
-| `debug` | 20 | Diagnostic detail |
-| `trace` | 10 | Verbose debugging |
+| Service | Purpose | Sign Up |
+|---------|---------|---------|
+| **Grafana Cloud** | Loki (log storage) + Grafana (UI) | [grafana.com/cloud](https://grafana.com/products/cloud/) |
 
-**Default level:** `info` (override via `LOG_LEVEL` env var).
+Free tier: 50GB/month logs, 14 day retention, 3 users.
 
-### HTTP Request Logging (API)
+## Setup Steps
 
-`pino-http` automatically logs every request/response:
+### 1. Create Grafana Cloud Account
 
-```json
-{
-  "level": 30,
-  "msg": "request completed",
-  "req": { "method": "POST", "url": "/api/inspections" },
-  "res": { "statusCode": 201 },
-  "responseTime": 45
-}
-```
+1. Sign up at [grafana.com/cloud](https://grafana.com/products/cloud/)
+2. Create a stack (choose region closest to Railway — e.g., `us-east`)
+3. Note your stack URL: `https://<your-stack>.grafana.net`
 
-Errors (4xx/5xx) are logged at `warn`/`error` level automatically.
+### 2. Get Loki Credentials
 
-### Sensitive Data
+1. Grafana Cloud → **Connections** → **Hosted Logs (Loki)**
+2. Note the push URL: `https://logs-prod-<region>.grafana.net/loki/api/v1/push`
+3. Create an API token: **Configuration** → **API Keys** → **Add API Key**
+   - Role: `MetricsPublisher`
+   - Copy the token (shown once)
+4. Note your Loki username (numeric ID shown on the Hosted Logs page)
 
-**Never logged:** passwords, tokens, API keys, JWT contents, `SERVICE_API_KEY`.
+### 3. Configure Railway Log Drain
 
-Pino redaction is configured to strip sensitive fields from request headers and body.
+1. Railway Dashboard → Select API service
+2. **Settings** → **Observability** → **Log Drain**
+3. Add log drain:
+   - **Type:** HTTP
+   - **URL:** `https://<loki-username>:<api-token>@logs-prod-<region>.grafana.net/loki/api/v1/push`
+   - **Format:** JSON
+4. Save — logs start shipping immediately
 
-## Infrastructure
+### 4. Verify
 
-### Grafana Cloud (Free Tier)
+1. Open Grafana Cloud → **Explore**
+2. Select **Loki** data source
+3. Run query: `{service="api"}`
+4. You should see logs from the API service
 
-- **Loki** — log storage, 50GB/month free
-- **Grafana** — dashboards and explore UI
-- **Credentials** — stored in deployment runbook (not in repo)
+## Dashboard Setup
 
-### Railway Log Drain
+Import the service health dashboard:
 
-Railway ships all stdout/stderr from the API service to Grafana Cloud Loki via HTTP push.
+1. Grafana → **Dashboards** → **New** → **Import**
+2. Dashboard includes:
+   - Error rate over time (line chart)
+   - Logs by level (pie chart: info/warn/error)
+   - Recent errors (log panel, filtered to level ≥ error)
+   - Service selector dropdown
 
-Configuration: Railway Dashboard → Service → Settings → Log Drain → Loki HTTP endpoint.
+## Credentials Storage
 
-### Log Retention
+| Credential | Where to Store |
+|------------|---------------|
+| Grafana Cloud URL | Deployment runbook (not in repo) |
+| Loki username | Deployment runbook |
+| Loki API token | Deployment runbook |
+| Railway log drain URL | Railway dashboard (auto-saved) |
 
-- **Grafana Cloud free tier:** 30 days
-- Sufficient for diagnosing recent issues; historical analysis not required
+**⚠️ Never commit Grafana credentials to the repository.**
 
-## Querying Logs
+## Log Retention
 
-### Grafana Explore
+| Tier | Retention | Storage |
+|------|-----------|---------|
+| Free | 14 days | 50GB/month |
+| Pro | 30+ days | Pay-per-use |
 
-Access via Grafana Cloud → Explore → Select Loki data source.
-
-**Common queries (LogQL):**
-
-```logql
-# All API errors
-{service="api"} |= "error" | json | level >= 50
-
-# Auth failures
-{service="api"} |= "401"
-
-# Specific inspection
-{service="api"} | json | inspectionId="<uuid>"
-
-# Slow requests (>1s)
-{service="api"} | json | responseTime > 1000
-```
-
-### Dashboard
-
-The **Service Health** dashboard includes:
-
-1. **Error rate over time** — line chart, per service
-2. **Logs by level** — pie chart (info/warn/error)
-3. **Recent errors** — log panel, filtered to level ≥ error
-4. **Service selector** — dropdown to filter by api/mcp-server
-
-## Environment Variables
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `LOG_LEVEL` | `info` | Minimum log level |
+Free tier is sufficient for diagnosing recent production issues.
 
 ## Future Path
 
@@ -129,4 +89,4 @@ Phase 2 (later): + Tempo (distributed traces)
 Phase 3 (later): + Prometheus (metrics)
 ```
 
-Same Grafana ecosystem — add trace IDs to logs, correlate in Grafana UI.
+Same Grafana ecosystem — all visible in the same UI.


### PR DESCRIPTION
Docs for #568 — covers Pino structured logging, Grafana Cloud Loki, Railway log drain, LogQL queries, and dashboard reference.

Ref #568

📐 **Riley** — Docs PR ready for review