### PR TITLE
feat(api): add admin endpoints for service key management

### DIFF
--- a/api/src/__tests__/service-keys-admin.test.ts
+++ b/api/src/__tests__/service-keys-admin.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Service Keys Admin Routes — Issue #597
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Response, type NextFunction } from 'express';
+import type { ServiceKey } from '@prisma/client';
+import { requireAdmin, type AuthRequest } from '../middleware/auth.js';
+import { createServiceKeysAdminRouter } from '../routes/admin/service-keys.js';
+
+function createTestApp(serviceMock: {
+  create: (input: any) => Promise<ServiceKey>;
+  list: () => Promise<Omit<ServiceKey, 'keyHash'>[]>;
+  deactivate: (id: string) => Promise<ServiceKey>;
+}) {
+  const app = express();
+  app.use(express.json());
+
+  // Fake auth: set userId from header
+  app.use((req: AuthRequest, _res: Response, next: NextFunction) => {
+    req.userId = req.headers['x-user-id'] as string | undefined;
+    next();
+  });
+
+  app.use(requireAdmin);
+  app.use('/api/admin/service-keys', createServiceKeysAdminRouter(serviceMock as any));
+  return app;
+}
+
+describe('Service Keys Admin Routes — #597', () => {
+  const adminId = 'admin-1';
+  const nonAdminId = 'user-2';
+
+  beforeEach(() => {
+    process.env.ADMIN_USER_IDS = adminId;
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_USER_IDS;
+  });
+
+  it('rejects non-admin users', async () => {
+    const serviceMock = {
+      create: vi.fn(),
+      list: vi.fn(),
+      deactivate: vi.fn(),
+    };
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .post('/api/admin/service-keys')
+      .set('x-user-id', nonAdminId)
+      .send({ name: 'kai', actor: 'agent:kai', scopes: ['projects:read'] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Admin access required');
+  });
+
+  it('creates a service key and returns plaintext once', async () => {
+    const created: ServiceKey = {
+      id: 'key-1',
+      name: 'kai',
+      keyHash: 'hash',
+      keyPrefix: 'sk_abc12',
+      scopes: ['projects:read'],
+      actor: 'agent:kai',
+      active: true,
+      expiresAt: null,
+      lastUsedAt: null,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+    };
+
+    const serviceMock = {
+      create: vi.fn().mockResolvedValue(created),
+      list: vi.fn(),
+      deactivate: vi.fn(),
+    };
+
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .post('/api/admin/service-keys')
+      .set('x-user-id', adminId)
+      .send({ name: 'kai', actor: 'agent:kai', scopes: ['projects:read'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('key');
+    expect(res.body.key).toMatch(/^sk_/);
+    expect(res.body.keyPrefix).toHaveLength(8);
+    expect(res.body.name).toBe('kai');
+
+  });
+
+  it('lists service keys without keyHash', async () => {
+    const listData = [
+      {
+        id: 'key-1',
+        name: 'kai',
+        keyPrefix: 'sk_abc12',
+        scopes: ['projects:read'],
+        actor: 'agent:kai',
+        active: true,
+        expiresAt: null,
+        lastUsedAt: null,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+      },
+    ];
+
+    const serviceMock = {
+      create: vi.fn(),
+      list: vi.fn().mockResolvedValue(listData as any),
+      deactivate: vi.fn(),
+    };
+
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .get('/api/admin/service-keys')
+      .set('x-user-id', adminId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).not.toHaveProperty('keyHash');
+  });
+
+  it('deactivates a service key', async () => {
+    const updated: ServiceKey = {
+      id: 'key-1',
+      name: 'kai',
+      keyHash: 'hash',
+      keyPrefix: 'sk_abc12',
+      scopes: ['projects:read'],
+      actor: 'agent:kai',
+      active: false,
+      expiresAt: null,
+      lastUsedAt: null,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+    };
+
+    const serviceMock = {
+      create: vi.fn(),
+      list: vi.fn(),
+      deactivate: vi.fn().mockResolvedValue(updated),
+    };
+
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .delete('/api/admin/service-keys/key-1')
+      .set('x-user-id', adminId);
+
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(false);
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -40,8 +40,9 @@ import { generatedReportsRouter } from './routes/generated-reports.js';
 import { personnelRouter } from './routes/personnel.js';
 import { credentialsRouter } from './routes/credentials.js';
 import { interactionLogsRouter } from './routes/interaction-logs.js';
+import { serviceKeysAdminRouter } from './routes/admin/service-keys.js';
 import { openApiRouter } from './openapi/index.js';
-import { authMiddleware, serviceAuthMiddleware, requireScope } from './middleware/auth.js';
+import { authMiddleware, serviceAuthMiddleware, requireScope, requireAdmin } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
 import { logStartupDiagnostics } from './config/startup.js';
 
@@ -130,6 +131,10 @@ app.use('/api/na-reason-templates', serviceAuthMiddleware, naReasonTemplatesRout
 app.use('/api', serviceAuthMiddleware, costEstimatesRouter);
 app.use('/api', serviceAuthMiddleware, reportGenerationRouter);
 app.use('/api', serviceAuthMiddleware, reportTemplatesRouter);
+
+// Admin routes — JWT + admin only
+app.use("/api/admin/service-keys", authMiddleware, requireAdmin, serviceKeysAdminRouter);
+
 app.use('/api/reports', serviceAuthMiddleware, generatedReportsRouter);
 
 // Error handling with detailed logging

--- a/api/src/routes/admin/service-keys.ts
+++ b/api/src/routes/admin/service-keys.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin Service Key Routes — Issue #597
+ */
+
+import { Router, type Router as RouterType, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '@prisma/client';
+import crypto from 'crypto';
+import {
+  ServiceKeyService,
+  DuplicateKeyNameError,
+  ServiceKeyNotFoundError,
+} from '../../services/service-key.js';
+
+const prisma = new PrismaClient();
+const service = new ServiceKeyService(prisma);
+
+const CreateServiceKeySchema = z.object({
+  name: z.string().min(1),
+  actor: z.string().min(1),
+  scopes: z.array(z.string()).min(1),
+  expiresAt: z.string().datetime().optional(),
+});
+
+type CreateServiceKeyInput = z.infer<typeof CreateServiceKeySchema>;
+
+function generateRawKey(): string {
+  return `sk_${crypto.randomBytes(24).toString('hex')}`;
+}
+
+export function createServiceKeysAdminRouter(
+  svc: ServiceKeyService = service,
+): RouterType {
+  const router: RouterType = Router();
+
+  // POST /api/admin/service-keys
+  router.post('/', async (req: Request, res: Response) => {
+    const parsed = CreateServiceKeySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Validation failed',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const { name, actor, scopes, expiresAt } = parsed.data as CreateServiceKeyInput;
+    const rawKey = generateRawKey();
+
+    try {
+      const created = await svc.create({
+        name,
+        actor,
+        scopes,
+        rawKey,
+        expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+      });
+
+      res.status(201).json({
+        id: created.id,
+        name: created.name,
+        actor: created.actor,
+        scopes: created.scopes,
+        keyPrefix: created.keyPrefix,
+        active: created.active,
+        expiresAt: created.expiresAt,
+        createdAt: created.createdAt,
+        key: rawKey, // returned only once
+      });
+    } catch (err) {
+      if (err instanceof DuplicateKeyNameError) {
+        res.status(409).json({ error: err.message });
+        return;
+      }
+      res.status(500).json({ error: 'Failed to create service key' });
+    }
+  });
+
+  // GET /api/admin/service-keys
+  router.get('/', async (_req: Request, res: Response) => {
+    const keys = await svc.list();
+    res.json(keys);
+  });
+
+  // DELETE /api/admin/service-keys/:id
+  router.delete('/:id', async (req: Request, res: Response) => {
+    try {
+      const updated = await svc.deactivate(req.params.id as string);
+      res.json({
+        id: updated.id,
+        name: updated.name,
+        active: updated.active,
+        updatedAt: updated.updatedAt,
+      });
+    } catch (err) {
+      if (err instanceof ServiceKeyNotFoundError) {
+        res.status(404).json({ error: err.message });
+        return;
+      }
+      res.status(500).json({ error: 'Failed to deactivate service key' });
+    }
+  });
+
+  return router;
+}
+
+export const serviceKeysAdminRouter = createServiceKeysAdminRouter();


### PR DESCRIPTION
## Summary

Adds admin-only API endpoints to create, list, and deactivate service keys.

### Endpoints
- **POST** /api/admin/service-keys — create key (returns plaintext once)
- **GET** /api/admin/service-keys — list keys (no keyHash)
- **DELETE** /api/admin/service-keys/:id — deactivate key (active=false)

### Access Control
- **JWT + requireAdmin** only (non-admin → 403)

### Tests
4 tests covering: admin create, list, deactivate, non-admin 403

Closes #597