### PR TITLE
feat: add skill deployment script and changelog

### DIFF
--- a/scripts/deploy-skill.sh
+++ b/scripts/deploy-skill.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy building-inspection skill to Kai's OpenClaw workspace
+# Issue #590
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SOURCE_SKILL="$ROOT_DIR/skills/building-inspection/SKILL.md"
+TARGET_DIR="$HOME/.openclaw/agents/kai/workspace/skills/building-inspection"
+TARGET_SKILL="$TARGET_DIR/SKILL.md"
+
+if [[ ! -f "$SOURCE_SKILL" ]]; then
+  echo "❌ Source skill not found: $SOURCE_SKILL" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+cp "$SOURCE_SKILL" "$TARGET_SKILL"
+
+echo "✅ Deployed skill to: $TARGET_SKILL"

--- a/skills/building-inspection/CHANGELOG.md
+++ b/skills/building-inspection/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog — Building Inspection Skill
+
+All notable changes to the building-inspection skill.
+
+## [1.0.0] — 2026-02-23
+
+### Initial Release
+- COA inspection workflow via WhatsApp
+- Guided section-by-section inspection
+- Photo capture and finding creation
+- Report generation trigger


### PR DESCRIPTION
## Summary

Adds a deployment script to copy the building-inspection skill to Kai's OpenClaw workspace, plus a changelog for version tracking.

### Changes
- **New:** `scripts/deploy-skill.sh` — copies SKILL.md to `~/.openclaw/agents/kai/workspace/skills/building-inspection/`
- **New:** `skills/building-inspection/CHANGELOG.md` — version history

### Usage
```bash
./scripts/deploy-skill.sh
```

Closes #590