### PR TITLE
[Riley] docs: service key management + scoped auth developer guide

### DIFF
--- a/docs/developer/service-auth.md
+++ b/docs/developer/service-auth.md
@@ -1,0 +1,120 @@
+# Service Authentication (Developer Guide)
+
+## Overview
+
+The API supports two authentication methods:
+
+| Method | Used By | Middleware |
+|--------|---------|------------|
+| JWT | Web UI users | `authMiddleware` |
+| API Key | Kai agent / services | `serviceAuthMiddleware` |
+
+See `docs/developer/authentication.md` for the high-level overview.
+
+## Protecting Routes
+
+### JWT-only Routes
+
+Use `authMiddleware` — rejects API keys:
+
+```typescript
+app.use('/api/personnel', authMiddleware, personnelRouter);
+```
+
+Use this for sensitive routes (personnel, credentials, companies, admin functions).
+
+### Service + JWT Routes
+
+Use `serviceAuthMiddleware` — accepts both JWT and API key — then add `requireScope`:
+
+```typescript
+import { serviceAuthMiddleware, requireScope } from './middleware/auth.js';
+
+app.use('/api/projects', serviceAuthMiddleware, requireScope('projects:read'), projectsRouter);
+```
+
+Individual write operations within the router should use `requireScope('projects:write')`.
+
+### Wildcard Scopes
+
+The scope check supports `resource:*` wildcards:
+
+```typescript
+requireScope('inspections:read')  // matches "inspections:read" or "inspections:*"
+requireScope('inspections:write') // matches "inspections:write" or "inspections:*"
+```
+
+## Request Context
+
+After authentication, the following fields are set on `req`:
+
+| Field | JWT Auth | API Key Auth |
+|-------|----------|--------------|
+| `req.userId` | User UUID | `"service:<keyName>"` e.g. `"service:kai-agent"` |
+| `req.serviceActor` | `undefined` | `"agent:kai"` |
+| `req.serviceScopes` | `undefined` | `["inspections:*", ...]` |
+| `req.isServiceAuth` | `false` | `true` |
+
+Use `req.serviceActor` for audit trails and `createdBy`/`updatedBy` attribution:
+
+```typescript
+const inspection = await service.create({
+  ...data,
+  createdBy: req.serviceActor || req.userId,
+});
+```
+
+## Service Key Repository
+
+```typescript
+import { ServiceKeyService } from '../services/service-key.js';
+
+// Create a key (returns plaintext once)
+const { key, record } = await serviceKeyService.create({
+  name: 'kai-agent',
+  actor: 'agent:kai',
+  scopes: ['inspections:*', 'projects:*'],
+});
+
+// Validate a key (called by middleware)
+const record = await serviceKeyService.validateKey(apiKey);
+
+// Deactivate
+await serviceKeyService.deactivate(id);
+```
+
+## Adding a New Scope
+
+1. Add the scope string to the relevant `requireScope()` call in `api/src/index.ts`
+2. Update Kai's key via the admin endpoint to include the new scope
+3. Document the scope in `docs/ops/service-keys.md`
+
+## Testing
+
+Use the `ServiceKey` test helpers:
+
+```typescript
+import { createTestServiceKey } from '../__tests__/helpers/service-key.js';
+
+const { key } = await createTestServiceKey({
+  scopes: ['inspections:read'],
+});
+
+const res = await request(app)
+  .get('/api/site-inspections')
+  .set('X-API-Key', key);
+
+expect(res.status).toBe(200);
+```
+
+Test scope rejection:
+
+```typescript
+const { key } = await createTestServiceKey({ scopes: ['projects:read'] });
+
+const res = await request(app)
+  .get('/api/site-inspections')
+  .set('X-API-Key', key);
+
+expect(res.status).toBe(403);
+```

--- a/docs/ops/service-keys.md
+++ b/docs/ops/service-keys.md
@@ -1,0 +1,102 @@
+# Service Key Management
+
+## Overview
+
+Service API keys allow external services (e.g. the Kai WhatsApp agent) to authenticate with the API without a JWT. Keys are scoped to specific resources and stored hashed in the database.
+
+## Creating a Service Key
+
+Call the admin endpoint (requires admin JWT):
+
+```bash
+curl -X POST https://api-ai-inspection.apexphere.co.nz/api/admin/service-keys \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "kai-agent",
+    "actor": "agent:kai",
+    "scopes": [
+      "inspections:*",
+      "projects:*",
+      "properties:*",
+      "clients:*",
+      "checklist:*",
+      "clause-reviews:*",
+      "building-code:read",
+      "photos:*"
+    ]
+  }'
+```
+
+Response (key shown **once only**):
+
+```json
+{
+  "id": "uuid",
+  "name": "kai-agent",
+  "key": "sk_abc12345...",
+  "actor": "agent:kai",
+  "scopes": ["inspections:*", ...]
+}
+```
+
+Store the key securely — it cannot be retrieved again.
+
+## Available Scopes
+
+| Scope | Access |
+|-------|--------|
+| `inspections:read` | GET site-inspections |
+| `inspections:write` | POST/PUT site-inspections |
+| `projects:read` | GET projects |
+| `projects:write` | POST/PUT projects |
+| `properties:read` | GET properties |
+| `properties:write` | POST/PUT properties |
+| `clients:read` | GET clients |
+| `clients:write` | POST/PUT clients |
+| `checklist:read` | GET checklist items/summary |
+| `checklist:write` | POST/PUT/DELETE checklist items |
+| `clause-reviews:read` | GET clause reviews/summary |
+| `clause-reviews:write` | POST/PUT/DELETE clause reviews |
+| `building-code:read` | GET building code clauses |
+| `photos:read` | GET project photos |
+| `photos:write` | POST/PUT/DELETE project photos |
+
+Use `resource:*` as a wildcard for both read and write (e.g. `inspections:*`).
+
+**Never grant service keys access to:** personnel, credentials, companies, report-management (JWT only).
+
+## Listing Keys
+
+```bash
+curl https://api-ai-inspection.apexphere.co.nz/api/admin/service-keys \
+  -H "Authorization: Bearer <admin-jwt>"
+```
+
+Returns all keys with metadata (no keyHash).
+
+## Deactivating a Key
+
+```bash
+curl -X DELETE https://api-ai-inspection.apexphere.co.nz/api/admin/service-keys/<id> \
+  -H "Authorization: Bearer <admin-jwt>"
+```
+
+Key is deactivated (not deleted) — `active: false`. Existing requests using it will immediately return 401.
+
+## Key Rotation (Zero-Downtime)
+
+1. Create a new key with the same scopes
+2. Update the consumer (e.g. set `SERVICE_API_KEY` in OpenClaw agent env)
+3. Deactivate the old key
+4. Both keys work during the transition window
+
+## Kai Agent Configuration
+
+Set the key in the OpenClaw host environment:
+
+```bash
+export SERVICE_API_KEY=sk_abc12345...
+```
+
+The building-inspection skill sends it automatically as `X-API-Key: $SERVICE_API_KEY` on every API call.


### PR DESCRIPTION
Docs for #577 — two docs, ops and dev:

- `docs/ops/service-keys.md` — create/list/deactivate keys, available scopes, key rotation, Kai config
- `docs/developer/service-auth.md` — middleware usage, `requireScope`, request context, testing patterns

Ref #577

📐 **Riley** — Docs PR ready for review