### PR TITLE
feat(api,web): include isAdmin flag in auth response and session

### DIFF
--- a/api/src/__tests__/auth-isadmin.test.ts
+++ b/api/src/__tests__/auth-isadmin.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Auth isAdmin Tests — Issue #608
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { mockUserFindUnique, mockUserUpdate } = vi.hoisted(() => ({
+  mockUserFindUnique: vi.fn(),
+  mockUserUpdate: vi.fn(),
+}));
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: class {
+    user = {
+      findUnique: mockUserFindUnique,
+      update: mockUserUpdate,
+    };
+  },
+}));
+
+vi.mock('bcrypt', () => ({
+  default: { compare: vi.fn().mockResolvedValue(true) },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: vi.fn().mockReturnValue('mock-token'),
+    verify: vi.fn().mockReturnValue({ sub: 'user-admin-1' }),
+  },
+}));
+
+import request from 'supertest';
+import express from 'express';
+import { authRouter } from '../routes/auth.js';
+
+const mockUser = {
+  id: 'user-admin-1',
+  email: 'admin@example.com',
+  passwordHash: '$2b$10$hash',
+  lastLoginAt: null,
+};
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', authRouter);
+  return app;
+}
+
+describe('Auth isAdmin — #608', () => {
+  const app = createTestApp();
+
+  beforeEach(() => {
+    mockUserFindUnique.mockResolvedValue(mockUser);
+    mockUserUpdate.mockResolvedValue(mockUser);
+    delete process.env.ADMIN_USER_IDS;
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_USER_IDS;
+  });
+
+  it('returns isAdmin: true when userId is in ADMIN_USER_IDS', async () => {
+    process.env.ADMIN_USER_IDS = 'user-admin-1,user-admin-2';
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'password' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.isAdmin).toBe(true);
+  });
+
+  it('returns isAdmin: false when userId is NOT in ADMIN_USER_IDS', async () => {
+    process.env.ADMIN_USER_IDS = 'other-user-id';
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'password' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.isAdmin).toBe(false);
+  });
+
+  it('returns isAdmin: false when ADMIN_USER_IDS is not set', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'password' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.isAdmin).toBe(false);
+  });
+});

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -153,10 +153,14 @@ authRouter.post('/login', authLimiter, async (req: Request, res: Response) => {
     // Set HttpOnly cookie
     setTokenCookie(res, token);
 
+    // Check admin status
+    const adminUserIds = (process.env.ADMIN_USER_IDS || '').split(',').filter(Boolean);
+    const isAdmin = adminUserIds.includes(user.id);
+
     // Return token in response for cross-origin clients (NextAuth)
     res.json({
       message: 'Login successful',
-      user: { id: user.id, email: user.email },
+      user: { id: user.id, email: user.email, isAdmin },
       token,
     });
   } catch (err) {

--- a/web/lib/auth-config.ts
+++ b/web/lib/auth-config.ts
@@ -14,14 +14,17 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 // Extended types for API token
 interface ExtendedUser extends User {
   apiToken?: string;
+  isAdmin?: boolean;
 }
 
 interface ExtendedJWT extends JWT {
   apiToken?: string;
+  isAdmin?: boolean;
 }
 
 interface ExtendedSession extends Session {
   apiToken?: string;
+  isAdmin?: boolean;
 }
 
 export const authConfig: NextAuthConfig = {
@@ -59,6 +62,7 @@ export const authConfig: NextAuthConfig = {
               id: data.user.id,
               email: data.user.email,
               apiToken: data.token, // Store API token for authenticated requests
+              isAdmin: data.user.isAdmin ?? false,
             };
           }
 
@@ -103,7 +107,8 @@ export const authConfig: NextAuthConfig = {
         const extUser = user as ExtendedUser;
         token.id = extUser.id;
         token.email = extUser.email;
-        token.apiToken = extUser.apiToken; // Persist API token in JWT
+token.apiToken = extUser.apiToken; // Persist API token in JWT
+        token.isAdmin = extUser.isAdmin ?? false;
       }
       return token as ExtendedJWT;
     },
@@ -119,6 +124,7 @@ export const authConfig: NextAuthConfig = {
       if (extToken.apiToken) {
         extSession.apiToken = extToken.apiToken;
       }
+      extSession.isAdmin = extToken.isAdmin ?? false;
       return extSession;
     },
   },


### PR DESCRIPTION
## Summary

Exposes `isAdmin` in login response and threads it through NextAuth JWT + session.

### Changes
- **`api/src/routes/auth.ts`** — checks `ADMIN_USER_IDS` on login, includes `isAdmin` in user response
- **`web/lib/auth-config.ts`** — extends `ExtendedUser`, `ExtendedJWT`, `ExtendedSession` with `isAdmin`
- **3 tests** — admin match, no match, env not set

### Example
```json
{ "user": { "id": "...", "email": "...", "isAdmin": true }, "token": "..." }
```

Closes #608