### PR TITLE
feat(api): add service key regenerate endpoint

### DIFF
--- a/api/src/__tests__/service-keys-admin.test.ts
+++ b/api/src/__tests__/service-keys-admin.test.ts
@@ -13,6 +13,7 @@ function createTestApp(serviceMock: {
   create: (input: any) => Promise<ServiceKey>;
   list: () => Promise<Omit<ServiceKey, 'keyHash'>[]>;
   deactivate: (id: string) => Promise<ServiceKey>;
+  regenerate?: (id: string, rawKey: string) => Promise<ServiceKey>;
 }) {
   const app = express();
   app.use(express.json());
@@ -156,4 +157,59 @@ describe('Service Keys Admin Routes — #597', () => {
     expect(res.status).toBe(200);
     expect(res.body.active).toBe(false);
   });
+
+  it('regenerates a service key and returns new plaintext key', async () => {
+    const newKey: ServiceKey = {
+      id: 'key-2',
+      name: 'kai',
+      keyHash: 'newhash',
+      keyPrefix: 'sk_new12',
+      scopes: ['projects:read'],
+      actor: 'agent:kai',
+      active: true,
+      expiresAt: null,
+      lastUsedAt: null,
+      createdAt: new Date('2026-03-01T01:00:00Z'),
+      updatedAt: new Date('2026-03-01T01:00:00Z'),
+    };
+
+    const serviceMock = {
+      create: vi.fn(),
+      list: vi.fn(),
+      deactivate: vi.fn(),
+      regenerate: vi.fn().mockResolvedValue(newKey),
+    };
+
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .post('/api/admin/service-keys/key-1/regenerate')
+      .set('x-user-id', adminId);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('key');
+    expect(res.body.key).toMatch(/^sk_/);
+    expect(res.body.name).toBe('kai');
+    expect(res.body.active).toBe(true);
+  });
+
+  it('returns 404 when regenerating inactive or missing key', async () => {
+    const { ServiceKeyNotFoundError } = await import('../services/service-key.js');
+
+    const serviceMock = {
+      create: vi.fn(),
+      list: vi.fn(),
+      deactivate: vi.fn(),
+      regenerate: vi.fn().mockRejectedValue(new ServiceKeyNotFoundError('key-99')),
+    };
+
+    const app = createTestApp(serviceMock);
+
+    const res = await request(app)
+      .post('/api/admin/service-keys/key-99/regenerate')
+      .set('x-user-id', adminId);
+
+    expect(res.status).toBe(404);
+  });
+
 });

--- a/api/src/routes/admin/service-keys.ts
+++ b/api/src/routes/admin/service-keys.ts
@@ -101,6 +101,33 @@ export function createServiceKeysAdminRouter(
     }
   });
 
+  // POST /api/admin/service-keys/:id/regenerate
+  router.post('/:id/regenerate', async (req: Request, res: Response) => {
+    const rawKey = generateRawKey();
+
+    try {
+      const newKey = await svc.regenerate(req.params.id as string, rawKey);
+      res.status(201).json({
+        id: newKey.id,
+        name: newKey.name,
+        actor: newKey.actor,
+        scopes: newKey.scopes,
+        keyPrefix: newKey.keyPrefix,
+        active: newKey.active,
+        expiresAt: newKey.expiresAt,
+        createdAt: newKey.createdAt,
+        key: rawKey, // returned only once
+      });
+    } catch (err) {
+      if (err instanceof ServiceKeyNotFoundError) {
+        res.status(404).json({ error: err.message });
+        return;
+      }
+      res.status(500).json({ error: 'Failed to regenerate service key' });
+    }
+  });
+
+
   return router;
 }
 

--- a/api/src/services/service-key.ts
+++ b/api/src/services/service-key.ts
@@ -107,4 +107,44 @@ export class ServiceKeyService {
       data: { active: false },
     });
   }
+
+  /**
+   * Regenerate a service key — Issue #609
+   *
+   * Archives the old key (rename + deactivate) and creates a new one
+   * with the same name, actor, and scopes. Returns the new key record.
+   */
+  async regenerate(id: string, rawKey: string): Promise<ServiceKey> {
+    const existing = await this.prisma.serviceKey.findFirst({
+      where: { id, active: true },
+    });
+
+    if (!existing) {
+      throw new ServiceKeyNotFoundError(id);
+    }
+
+    const keyHash = await bcrypt.hash(rawKey, SALT_ROUNDS);
+    const keyPrefix = rawKey.slice(0, PREFIX_LENGTH);
+    const archivedName = `${existing.name}__rotated_${Date.now()}`;
+
+    // Rename + deactivate old key, then create new with original name
+    const [, newKey] = await this.prisma.$transaction([
+      this.prisma.serviceKey.update({
+        where: { id },
+        data: { active: false, name: archivedName },
+      }),
+      this.prisma.serviceKey.create({
+        data: {
+          name: existing.name,
+          keyHash,
+          keyPrefix,
+          scopes: existing.scopes,
+          actor: existing.actor,
+          expiresAt: existing.expiresAt,
+        },
+      }),
+    ]);
+
+    return newKey;
+  }
 }


### PR DESCRIPTION
## Summary

Adds `POST /api/admin/service-keys/:id/regenerate` to rotate a key in one step.

### Changes
- **`api/src/services/service-key.ts`** — `regenerate()` method: archives old key (rename + deactivate in transaction), creates new with same name/actor/scopes
- **`api/src/routes/admin/service-keys.ts`** — new `POST /:id/regenerate` route
- **2 new tests**: success (plaintext returned once) + 404 for inactive/missing

### Behaviour
- Old key renamed to `{name}__rotated_{timestamp}` and deactivated
- New key created with original name — no downtime gap
- Admin only (403 otherwise)

Closes #609