### PR TITLE
[Sam] fix(e2e): update E2E tests for /inspections → /projects navigation

### DIFF
--- a/test/e2e/home.spec.ts
+++ b/test/e2e/home.spec.ts
@@ -2,22 +2,20 @@ import { test, expect } from '@playwright/test';
 import { test as authTest } from './fixtures';
 
 test.describe('Home Page', () => {
-  test('should display welcome message', async ({ page }) => {
+  test('should redirect to projects', async ({ page }) => {
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
 
-    await expect(page.getByRole('heading', { name: /ai inspection/i })).toBeVisible();
+    // Root redirects to /projects
+    await expect(page).toHaveURL(/\/projects/);
   });
 
-  // This test needs auth since /inspections is protected
-  authTest('should have navigation to inspections', async ({ authenticatedPage: page }) => {
-    await page.goto('/');
+  authTest('should have navigation to projects', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
 
-    // Should have a link to inspections
-    const inspectionsLink = page.getByRole("link", { name: "Inspections", exact: true }).first();
-    await expect(inspectionsLink).toBeVisible();
-
-    // Click and verify navigation (already authenticated)
-    await inspectionsLink.click();
-    await expect(page).toHaveURL('/inspections');
+    // Should have a Projects link in the nav
+    const projectsLink = page.getByRole('link', { name: 'Projects', exact: true }).first();
+    await expect(projectsLink).toBeVisible();
   });
 });

--- a/test/e2e/inspection-create.spec.ts
+++ b/test/e2e/inspection-create.spec.ts
@@ -1,60 +1,22 @@
 /**
- * E2E Tests: Create New Inspection
- * Covers the /inspections/new flow added in #384
+ * E2E Tests: /inspections/new redirect
+ * The /inspections/new route now redirects to /projects (#624)
  */
 
 import { test, expect } from './fixtures';
 
-test.describe('Create New Inspection', () => {
-  test('should display the new inspection form', async ({ authenticatedPage: page }) => {
+test.describe('Legacy /inspections/new redirect', () => {
+  test('should redirect /inspections/new to /projects', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections/new');
     await page.waitForLoadState('networkidle');
 
-    // Should show form heading
-    await expect(page.getByRole('heading', { name: /new inspection/i })).toBeVisible();
-
-    // Should show required form fields
-    await expect(page.getByLabel(/address/i)).toBeVisible();
-    await expect(page.getByLabel(/client/i)).toBeVisible();
-
-    // Should show submit button
-    await expect(page.getByRole('button', { name: /start inspection|create/i })).toBeVisible();
+    await expect(page).toHaveURL(/\/projects/);
   });
 
-  test('should show validation errors for empty form submission', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections/new');
-    await page.waitForLoadState('networkidle');
-
-    // Submit without filling in required fields
-    await page.getByRole('button', { name: /start inspection|create/i }).click();
-
-    // Should show validation error
-    const errorMessage = page.locator('[role="alert"], .text-red, [class*="error"]').first();
-    await expect(errorMessage).toBeVisible();
-  });
-
-  test('should navigate back to inspections list', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections/new');
-    await page.waitForLoadState('networkidle');
-
-    // Should have a back/cancel link
-    const backLink = page.getByRole('link', { name: /back|cancel/i }).first();
-    if (await backLink.isVisible()) {
-      await backLink.click();
-      await expect(page).toHaveURL('/inspections');
-    }
-  });
-
-  test('should be accessible from inspections list', async ({ authenticatedPage: page }) => {
+  test('should redirect /inspections to /projects', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
 
-    // Should have a link/button to create new inspection
-    const newLink = page.getByRole('link', { name: /new inspection/i })
-      .or(page.getByRole('button', { name: /new inspection/i }));
-    await expect(newLink).toBeVisible();
-
-    await newLink.click();
-    await expect(page).toHaveURL('/inspections/new');
+    await expect(page).toHaveURL(/\/projects/);
   });
 });

--- a/test/e2e/inspections.spec.ts
+++ b/test/e2e/inspections.spec.ts
@@ -1,99 +1,35 @@
+/**
+ * E2E Tests: Inspections → Projects navigation (#624)
+ * /inspections now redirects to /projects
+ */
 import { test, expect } from './fixtures';
 
-test.describe('Inspections List', () => {
-  test('should display inspections list page', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
+test.describe('Projects List', () => {
+  test('should display projects list page', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
 
-    // Should show the page title
-    await expect(page.getByRole('heading', { name: 'Inspections' })).toBeVisible();
-  });
-
-  test('should show loading state initially', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
-
-    // Should show loading indicator or content
+    // Should show the page heading or content
     const content = page.locator('main');
     await expect(content).toBeVisible();
   });
 
-  test('should navigate to inspection detail when clicking an inspection', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
-
-    // Wait for the list to load
-    await page.waitForLoadState('networkidle');
-
-    // Click on the first inspection link (exclude /inspections/new)
-    const inspectionLink = page.locator('a[href^="/inspections/"]:not([href="/inspections/new"])').first();
-
-    if (await inspectionLink.isVisible()) {
-      await inspectionLink.click();
-
-      // Should navigate to detail page
-      await expect(page).toHaveURL(/\/inspections\/.+/);
-
-      // Should show back link
-      await expect(page.getByText('← Back to Inspections')).toBeVisible();
-    }
-  });
-});
-
-test.describe('Inspection Detail', () => {
-  test('should display inspection details', async ({ authenticatedPage: page }) => {
-    // Navigate to inspections first
+  test('/inspections redirects to /projects', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
 
-    // Click on the first inspection (exclude /inspections/new)
-    const inspectionLink = page.locator('a[href^="/inspections/"]:not([href="/inspections/new"])').first();
-
-    if (await inspectionLink.isVisible()) {
-      await inspectionLink.click();
-      await page.waitForLoadState('networkidle');
-
-      // Should show address as heading
-      await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
-
-      // Should show status badge
-      await expect(
-        page.locator('span').filter({ hasText: /(Started|In Progress|Completed)/ }).first()
-      ).toBeVisible();
-
-      // Should show summary section
-      await expect(page.getByText('Summary')).toBeVisible();
-      await expect(page.getByText('Total Findings')).toBeVisible();
-    }
+    await expect(page).toHaveURL(/\/projects/);
   });
 
-  test('should show findings grouped by section', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
+  test('should navigate to project detail when clicking a project', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
     await page.waitForLoadState('networkidle');
 
-    const inspectionLink = page.locator('a[href^="/inspections/"]:not([href="/inspections/new"])').first();
+    const projectLink = page.locator('a[href^="/projects/"]').first();
 
-    if (await inspectionLink.isVisible()) {
-      await inspectionLink.click();
-      await page.waitForLoadState('networkidle');
-
-      // Should show Findings heading
-      await expect(page.getByRole('heading', { name: 'Findings' })).toBeVisible();
-    }
-  });
-
-  test('should navigate back to list', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
-    await page.waitForLoadState('networkidle');
-
-    const inspectionLink = page.locator('a[href^="/inspections/"]:not([href="/inspections/new"])').first();
-
-    if (await inspectionLink.isVisible()) {
-      await inspectionLink.click();
-      await page.waitForLoadState('networkidle');
-
-      // Click back link
-      await page.getByText('← Back to Inspections').click();
-
-      // Should be back on list page
-      await expect(page).toHaveURL('/inspections');
+    if (await projectLink.isVisible()) {
+      await projectLink.click();
+      await expect(page).toHaveURL(/\/projects\/.+/);
     }
   });
 });


### PR DESCRIPTION
## Problem
CD is failing on develop because my #624 (projects navigation) removed/redirected `/inspections` and `/inspections/new`, but the E2E tests still expected those pages to exist.

## Fix
- `home.spec.ts` — expect `/` to redirect to `/projects`, check Projects nav link
- `inspection-create.spec.ts` — replace form tests with redirect tests
- `inspections.spec.ts` — update to test `/projects` list + redirect from `/inspections`

## Root Cause
My fault — should have updated E2E tests as part of #624.