### PR TITLE
fix(e2e): update tests broken by navigation refactor

### DIFF
--- a/test/e2e/finding-editor.spec.ts
+++ b/test/e2e/finding-editor.spec.ts
@@ -4,10 +4,17 @@ import { test, expect } from './fixtures';
  * Helper to navigate to first inspection detail page
  */
 async function navigateToInspectionDetail(page: import('@playwright/test').Page): Promise<boolean> {
-  await page.goto('/inspections');
+  await page.goto('/projects');
   await page.waitForLoadState('networkidle');
 
-  const inspectionLink = page.locator('a[href^="/inspections/"]').first();
+  // Navigate into a project first
+  const projectLink = page.locator('a[href^="/projects/"]').first();
+  if (!await projectLink.isVisible()) return false;
+  await projectLink.click();
+  await page.waitForLoadState('networkidle');
+
+  // Then into an inspection
+  const inspectionLink = page.locator('a[href*="/inspections/"]').first();
   if (await inspectionLink.isVisible()) {
     await inspectionLink.click();
     await page.waitForLoadState('networkidle');

--- a/test/e2e/profile.spec.ts
+++ b/test/e2e/profile.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('Profile Page', () => {
   test('should be accessible from header email link', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
+    await page.goto('/projects');
     const profileLink = page.locator('a[href="/profile"]');
     await expect(profileLink).toBeVisible();
     await profileLink.click();


### PR DESCRIPTION
## Summary

Fixes 2 E2E test files that still used old `/inspections` routes after the navigation refactor in #627.

### Changes
- **`test/e2e/profile.spec.ts`** — `goto('/inspections')` → `goto('/projects')`
- **`test/e2e/finding-editor.spec.ts`** — navigate via `/projects` → project → inspection (inspection detail now at `/projects/:id/inspections/:iid`)

Closes #632