### PR TITLE
fix(#635): use Authorization header for /api/projects

### DIFF
--- a/web/app/projects/page.tsx
+++ b/web/app/projects/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { auth } from '@/auth';
 import { ProjectList } from './project-list';
 import { ProjectFilters } from './project-filters';
 
@@ -40,7 +41,11 @@ function ListSkeleton(): React.ReactElement {
   );
 }
 
-export default function ProjectsPage(): React.ReactElement {
+export default async function ProjectsPage(): Promise<React.ReactElement> {
+  const session = await auth();
+  // @ts-expect-error apiToken is added via extended session
+  const apiToken: string = session?.apiToken ?? '';
+
   return (
     <div>
       {/* Page Header */}
@@ -56,7 +61,7 @@ export default function ProjectsPage(): React.ReactElement {
       </Suspense>
 
       <Suspense fallback={<ListSkeleton />}>
-        <ProjectList />
+        <ProjectList apiToken={apiToken} />
       </Suspense>
     </div>
   );

--- a/web/app/projects/project-list.tsx
+++ b/web/app/projects/project-list.tsx
@@ -59,7 +59,7 @@ function ProjectListSkeleton(): React.ReactElement {
   );
 }
 
-export function ProjectList(): React.ReactElement {
+export function ProjectList({ apiToken }: { apiToken: string }): React.ReactElement {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -84,7 +84,7 @@ export function ProjectList(): React.ReactElement {
         }
 
         const response = await fetch(`${API_URL}/api/projects?${params}`, {
-          credentials: 'include',
+          headers: apiToken ? { Authorization: `Bearer ${apiToken}` } : {},
         });
 
         if (!response.ok) {
@@ -138,7 +138,7 @@ export function ProjectList(): React.ReactElement {
     }
 
     fetchProjects();
-  }, [status, search, sort, order]);
+  }, [status, search, sort, order, apiToken]);
 
   const handleSort = (column: string): void => {
     const params = new URLSearchParams(searchParams.toString());


### PR DESCRIPTION
## Summary

Fixes #635 — `/projects` returning 401 in test env.

**Root cause:** `project-list.tsx` used `credentials: 'include'` which doesn't send cookies cross-domain.

**Fix:** Match existing pattern (admin/service-keys). `ProjectsPage` now fetches the NextAuth session server-side and passes `apiToken` as a prop to `ProjectList`, which sends `Authorization: Bearer <token>` instead.

## Changes
- `web/app/projects/page.tsx` — async server component, fetch session + pass apiToken prop
- `web/app/projects/project-list.tsx` — accept apiToken prop, use Authorization header