### PR TITLE
test(e2e): add comprehensive E2E tests for /projects page

### DIFF
--- a/test/e2e/home.spec.ts
+++ b/test/e2e/home.spec.ts
@@ -1,25 +1,26 @@
-import { test, expect } from '@playwright/test';
-import { test as authTest } from './fixtures';
+import { test, expect } from './fixtures';
 
 test.describe('Home Page', () => {
-  test('should redirect to projects', async ({ page }) => {
+  test('should redirect root to /projects', async ({ authenticatedPage: page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    // Root redirects to /projects
     await expect(page).toHaveURL(/\/projects/);
   });
 
-  authTest('should have nav and main content visible', async ({ authenticatedPage: page }) => {
+  test('should have header, main content, and footer visible', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
     await page.waitForLoadState('networkidle');
 
-    // Header should be present
-    const header = page.locator('header');
-    await expect(header).toBeVisible();
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+  });
 
-    // Main content should be present
-    const main = page.locator('main');
-    await expect(main).toBeVisible();
+  test('should show page title in browser tab', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveTitle(/Projects.*AI Inspection/);
   });
 });

--- a/test/e2e/inspection-create.spec.ts
+++ b/test/e2e/inspection-create.spec.ts
@@ -1,6 +1,8 @@
 /**
- * E2E Tests: /inspections/new redirect
- * The /inspections/new route now redirects to /projects (#624)
+ * E2E Tests: Legacy /inspections/new redirect (#624)
+ *
+ * The old inspection creation flow has been replaced by the projects system.
+ * All legacy routes redirect to /projects.
  */
 
 import { test, expect } from './fixtures';
@@ -11,12 +13,7 @@ test.describe('Legacy /inspections/new redirect', () => {
     await page.waitForLoadState('networkidle');
 
     await expect(page).toHaveURL(/\/projects/);
-  });
-
-  test('should redirect /inspections to /projects', async ({ authenticatedPage: page }) => {
-    await page.goto('/inspections');
-    await page.waitForLoadState('networkidle');
-
-    await expect(page).toHaveURL(/\/projects/);
+    // Verify the projects page actually loaded
+    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
   });
 });

--- a/test/e2e/inspections.spec.ts
+++ b/test/e2e/inspections.spec.ts
@@ -1,19 +1,12 @@
 /**
- * E2E Tests: Inspections → Projects navigation (#624)
- * /inspections now redirects to /projects
+ * E2E Tests: Legacy Inspections routes (#624)
+ *
+ * All /inspections routes now redirect to /projects.
+ * These tests verify the redirects work correctly.
  */
 import { test, expect } from './fixtures';
 
-test.describe('Projects List', () => {
-  test('should display projects list page', async ({ authenticatedPage: page }) => {
-    await page.goto('/projects');
-    await page.waitForLoadState('networkidle');
-
-    // Should show the page heading or content
-    const content = page.locator('main');
-    await expect(content).toBeVisible();
-  });
-
+test.describe('Legacy Inspections Redirects', () => {
   test('/inspections redirects to /projects', async ({ authenticatedPage: page }) => {
     await page.goto('/inspections');
     await page.waitForLoadState('networkidle');
@@ -21,15 +14,19 @@ test.describe('Projects List', () => {
     await expect(page).toHaveURL(/\/projects/);
   });
 
-  test('should navigate to project detail when clicking a project', async ({ authenticatedPage: page }) => {
-    await page.goto('/projects');
+  test('/inspections/new redirects to /projects', async ({ authenticatedPage: page }) => {
+    await page.goto('/inspections/new');
     await page.waitForLoadState('networkidle');
 
-    const projectLink = page.locator('a[href^="/projects/"]').first();
+    await expect(page).toHaveURL(/\/projects/);
+  });
 
-    if (await projectLink.isVisible()) {
-      await projectLink.click();
-      await expect(page).toHaveURL(/\/projects\/.+/);
-    }
+  test('projects page loads with content after redirect', async ({ authenticatedPage: page }) => {
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+
+    // After redirect, verify the projects page actually rendered
+    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+    await expect(page.getByText('View and manage your inspection projects')).toBeVisible();
   });
 });

--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E Tests: App Navigation
+ *
+ * Validates the header navigation links, active states, sign-out flow,
+ * and auth guard behaviour.
+ */
+
+import { test, expect } from './fixtures';
+import { test as baseTest } from '@playwright/test';
+
+test.describe('Navigation — Header Links', () => {
+  test('should show Projects link in desktop nav', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    const projectsLink = header.locator('a[href="/projects"]');
+    await expect(projectsLink).toBeVisible();
+    await expect(projectsLink).toHaveText('Projects');
+  });
+
+  test('should show user email in desktop nav', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    // The profile link shows the user's email
+    const profileLink = header.locator('a[href="/profile"]');
+    await expect(profileLink).toBeVisible();
+    await expect(profileLink).toContainText('@');
+  });
+
+  test('should show Sign Out button', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    await expect(header.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+  });
+
+  test('should navigate to profile when clicking email', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    await header.locator('a[href="/profile"]').click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL('/profile');
+  });
+
+  test('should navigate to projects when clicking Projects link', async ({ authenticatedPage: page }) => {
+    await page.goto('/profile');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    await header.locator('a[href="/projects"]').click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/projects/);
+  });
+
+  test('should navigate to projects when clicking logo', async ({ authenticatedPage: page }) => {
+    await page.goto('/profile');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    // Logo links to "/"
+    await header.locator('a[href="/"]').click();
+    await page.waitForLoadState('networkidle');
+
+    // Root redirects to /projects
+    await expect(page).toHaveURL(/\/projects/);
+  });
+});
+
+test.describe('Navigation — Auth Guard', () => {
+  baseTest('should redirect unauthenticated user to login', async ({ page }) => {
+    // No storageState — page is unauthenticated
+    await page.context().clearCookies();
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  baseTest('should not show header on login page', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('header');
+    await expect(header).not.toBeVisible();
+  });
+});
+
+test.describe('Navigation — Legacy Route Redirects', () => {
+  test('root (/) redirects to /projects', async ({ authenticatedPage: page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/projects/);
+  });
+
+  test('/inspections redirects to /projects', async ({ authenticatedPage: page }) => {
+    await page.goto('/inspections');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/projects/);
+  });
+
+  test('/inspections/new redirects to /projects', async ({ authenticatedPage: page }) => {
+    await page.goto('/inspections/new');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/projects/);
+  });
+});

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * E2E Tests: Project Detail Page
+ *
+ * Validates /projects/:id renders breadcrumbs, header info, and collapsible
+ * sections for project info, client, property, inspections, documents, photos.
+ */
+
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+
+/**
+ * Navigate to the seeded TEST-001 project detail page.
+ * Returns the page if navigation succeeds, otherwise skips the test.
+ */
+async function goToTestProject(page: Page): Promise<void> {
+  await page.goto('/projects');
+  await page.waitForLoadState('networkidle');
+
+  const table = page.locator('table');
+  await expect(table).toBeVisible({ timeout: 10000 });
+
+  const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
+  await expect(testRow).toBeVisible();
+  await testRow.click();
+  await page.waitForLoadState('networkidle');
+
+  // Confirm we landed on a project detail page
+  await expect(page).toHaveURL(/\/projects\/[\w-]+/);
+}
+
+test.describe('Project Detail — Header & Breadcrumbs', () => {
+  test('should display breadcrumb navigation', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    // Breadcrumb: Projects / TEST-001
+    const nav = page.locator('nav');
+    await expect(nav.getByText('Projects')).toBeVisible();
+
+    // Projects breadcrumb should be a link back to /projects
+    const projectsLink = nav.locator('a[href="/projects"]');
+    await expect(projectsLink).toBeVisible();
+  });
+
+  test('should display property address as page title', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByRole('heading', { name: '123 Test Street' })).toBeVisible();
+  });
+
+  test('should show job number in header subtitle', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Job: TEST-001')).toBeVisible();
+  });
+
+  test('should show report type label', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    // COA → "Certificate of Acceptance"
+    await expect(page.getByText('Certificate of Acceptance')).toBeVisible();
+  });
+
+  test('should display status badge', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    const badge = page.locator('span.rounded-full', { hasText: 'Draft' });
+    await expect(badge).toBeVisible();
+  });
+
+  test('should navigate back to projects list via breadcrumb', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    const projectsLink = page.locator('nav a[href="/projects"]');
+    await projectsLink.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/projects$/);
+  });
+});
+
+test.describe('Project Detail — Collapsible Sections', () => {
+  test('should display Project Info section with correct data', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    // The section heading
+    await expect(page.getByText('Project Info')).toBeVisible();
+
+    // Data fields
+    await expect(page.getByText('TEST-001')).toBeVisible();
+    await expect(page.getByText('Test Inspection')).toBeVisible();
+  });
+
+  test('should display Client section with correct data', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Client')).toBeVisible();
+    await expect(page.getByText('Test Client')).toBeVisible();
+    await expect(page.getByText('testclient@example.com')).toBeVisible();
+  });
+
+  test('should display Property section with correct data', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Property')).toBeVisible();
+    await expect(page.getByText('123 Test Street')).toBeVisible();
+    await expect(page.getByText('Testville')).toBeVisible();
+    await expect(page.getByText('Auckland')).toBeVisible();
+    await expect(page.getByText('Auckland Council')).toBeVisible();
+  });
+
+  test('should display Inspections section with empty state', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Inspections')).toBeVisible();
+
+    // Seeded project has no inspections
+    await expect(page.getByText('No inspections recorded')).toBeVisible();
+  });
+
+  test('should display BRANZ Zone Data section', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('BRANZ Zone Data')).toBeVisible();
+  });
+
+  test('should display Documents section', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Documents')).toBeVisible();
+  });
+
+  test('should display Photos section', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByText('Photos')).toBeVisible();
+  });
+});
+
+test.describe('Project Detail — 404 Handling', () => {
+  test('should show 404 page for non-existent project ID', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects/00000000-0000-0000-0000-000000000000');
+    await page.waitForLoadState('networkidle');
+
+    // Next.js notFound() renders a 404 page
+    await expect(page.getByText(/not found/i)).toBeVisible();
+  });
+});

--- a/test/e2e/projects-list.spec.ts
+++ b/test/e2e/projects-list.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * E2E Tests: Projects List Page
+ *
+ * Validates the /projects page renders a table with correct columns,
+ * displays seeded project data, and handles empty/error states.
+ *
+ * Seed data (from seed-test-env.ts):
+ *   - Project: TEST-001, activity "Test Inspection", COA, DRAFT
+ *   - Property: 123 Test Street, Testville, Auckland
+ *   - Client: Test Client
+ */
+
+import { test, expect } from './fixtures';
+
+test.describe('Projects List — Table Rendering', () => {
+  test('should display page heading and description', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+    await expect(page.getByText('View and manage your inspection projects')).toBeVisible();
+  });
+
+  test('should render table with correct column headers', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for skeleton to disappear and table to appear
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Verify all column headers
+    const headers = table.locator('thead th');
+    await expect(headers.filter({ hasText: 'Job #' })).toBeVisible();
+    await expect(headers.filter({ hasText: 'Address' })).toBeVisible();
+    await expect(headers.filter({ hasText: 'Client' })).toBeVisible();
+    await expect(headers.filter({ hasText: 'Status' })).toBeVisible();
+    await expect(headers.filter({ hasText: 'Last Updated' })).toBeVisible();
+  });
+
+  test('should display seeded project data in the table', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Seeded project should appear with correct data
+    const rows = table.locator('tbody tr');
+    await expect(rows).not.toHaveCount(0);
+
+    // Look for the seeded TEST-001 project data
+    const testRow = rows.filter({ hasText: 'TEST-001' });
+    await expect(testRow).toBeVisible();
+    await expect(testRow).toContainText('123 Test Street');
+    await expect(testRow).toContainText('Test Client');
+    await expect(testRow).toContainText('Draft');
+  });
+
+  test('should show status badge with correct styling', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Draft status badge should have gray styling
+    const draftBadge = table.locator('span.rounded-full', { hasText: 'Draft' }).first();
+    await expect(draftBadge).toBeVisible();
+    await expect(draftBadge).toHaveClass(/bg-gray-100/);
+  });
+
+  test('should display formatted dates in Last Updated column', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Date cells should contain a date-like string (e.g. "3/1/2026" or "1/03/2026")
+    const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
+    const dateCell = testRow.locator('td').last();
+    await expect(dateCell).toHaveText(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  });
+
+  test('should navigate to project detail when clicking a row', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
+    await expect(testRow).toBeVisible();
+    await testRow.click();
+
+    await expect(page).toHaveURL(/\/projects\/[\w-]+/);
+  });
+
+  test('should not show address as dash when data exists', async ({ authenticatedPage: page }) => {
+    // This is a regression test for the property.address → property.streetAddress fix
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
+    const addressCell = testRow.locator('td').nth(1);
+
+    // Address should NOT be a dash — it should show the actual street address
+    await expect(addressCell).not.toHaveText('—');
+    await expect(addressCell).toContainText('123 Test Street');
+  });
+});

--- a/test/e2e/projects-search.spec.ts
+++ b/test/e2e/projects-search.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * E2E Tests: Projects Search & Filtering
+ *
+ * Validates the search input, status filter dropdown, and column sorting
+ * on the /projects page.
+ */
+
+import { test, expect } from './fixtures';
+
+test.describe('Projects Search & Filter', () => {
+  test('should display search input and status filter', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    // Search input
+    const searchInput = page.getByPlaceholder('Search by address or job number...');
+    await expect(searchInput).toBeVisible();
+
+    // Status filter dropdown
+    const statusSelect = page.locator('select#status');
+    await expect(statusSelect).toBeVisible();
+  });
+
+  test('should filter by search term matching address', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Search for the seeded address
+    const searchInput = page.getByPlaceholder('Search by address or job number...');
+    await searchInput.fill('Test Street');
+
+    // Wait for debounced search to fire and results to update
+    await page.waitForTimeout(500);
+    await page.waitForLoadState('networkidle');
+
+    // URL should have the search param
+    await expect(page).toHaveURL(/search=Test/);
+
+    // Table should still show the matching project
+    await expect(table.locator('tbody tr').filter({ hasText: '123 Test Street' })).toBeVisible();
+  });
+
+  test('should filter by search term matching job number', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder('Search by address or job number...');
+    await searchInput.fill('TEST-001');
+
+    await page.waitForTimeout(500);
+    await page.waitForLoadState('networkidle');
+
+    await expect(table.locator('tbody tr').filter({ hasText: 'TEST-001' })).toBeVisible();
+  });
+
+  test('should show no results message for unmatched search', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const searchInput = page.getByPlaceholder('Search by address or job number...');
+    await searchInput.fill('zzz-nonexistent-address-zzz');
+
+    await page.waitForTimeout(500);
+    await page.waitForLoadState('networkidle');
+
+    // Should show empty state message
+    await expect(page.getByText('No projects found')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Try adjusting your filters')).toBeVisible();
+  });
+
+  test('should filter by status dropdown', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const statusSelect = page.locator('select#status');
+    await expect(statusSelect).toBeVisible();
+
+    // Filter by DRAFT status — seeded project is DRAFT
+    await statusSelect.selectOption('DRAFT');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/status=DRAFT/);
+
+    // The seeded project should still be visible
+    const table = page.locator('table');
+    if (await table.isVisible()) {
+      await expect(table.locator('tbody tr').filter({ hasText: 'TEST-001' })).toBeVisible();
+    }
+  });
+
+  test('should show no results for non-matching status filter', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const statusSelect = page.locator('select#status');
+
+    // Filter by COMPLETED — seeded project is DRAFT so it should disappear
+    await statusSelect.selectOption('COMPLETED');
+    await page.waitForLoadState('networkidle');
+
+    // Either the table has no TEST-001 row, or the empty state shows
+    const testRow = page.locator('table tbody tr').filter({ hasText: 'TEST-001' });
+    await expect(testRow).toHaveCount(0);
+  });
+
+  test('should clear status filter when selecting All Status', async ({ authenticatedPage: page }) => {
+    // Start with a status filter applied
+    await page.goto('/projects?status=DRAFT');
+    await page.waitForLoadState('networkidle');
+
+    const statusSelect = page.locator('select#status');
+    await expect(statusSelect).toHaveValue('DRAFT');
+
+    // Clear the filter
+    await statusSelect.selectOption('');
+    await page.waitForLoadState('networkidle');
+
+    // URL should not have status param
+    expect(page.url()).not.toContain('status=');
+  });
+});
+
+test.describe('Projects Column Sorting', () => {
+  test('should sort by Job # when clicking column header', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Click Job # header
+    const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });
+    await jobHeader.click();
+    await page.waitForLoadState('networkidle');
+
+    // URL should have sort params
+    await expect(page).toHaveURL(/sort=jobNumber/);
+  });
+
+  test('should toggle sort order on second click', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects?sort=jobNumber&order=desc');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // Click Job # header again to toggle to asc
+    const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });
+    await jobHeader.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/order=asc/);
+  });
+
+  test('should show sort indicator arrow on active column', async ({ authenticatedPage: page }) => {
+    await page.goto('/projects?sort=jobNumber&order=desc');
+    await page.waitForLoadState('networkidle');
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible({ timeout: 10000 });
+
+    // The Job # header should have a down arrow indicator
+    const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });
+    await expect(jobHeader).toContainText('↓');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 new E2E test files covering projects list, search/filter, project detail, and navigation (41 new tests)
- Strengthen existing home, inspections, and inspection-create tests with additional assertions
- Total test coverage increased from 22 to 63 E2E tests

## Test plan
- [ ] Verify all E2E tests pass in CI
- [ ] Confirm no regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)