### PR TITLE
fix(web): pass JWT auth token to /api/projects endpoints

### DIFF
--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { auth } from '@/auth';
 import { ProjectSections } from './project-sections';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
@@ -75,10 +76,13 @@ interface Project {
   }>;
 }
 
-async function getProject(id: string): Promise<Project | null> {
+async function getProject(id: string, token?: string): Promise<Project | null> {
   try {
     const response = await fetch(`${API_URL}/api/projects/${id}`, {
       cache: 'no-store',
+      headers: {
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
     });
 
     if (!response.ok) {
@@ -119,7 +123,9 @@ const REPORT_TYPE_LABELS: Record<string, string> = {
 
 export async function generateMetadata({ params }: ProjectPageProps): Promise<{ title: string }> {
   const { id } = await params;
-  const project = await getProject(id);
+  const session = await auth();
+  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const project = await getProject(id, token);
   
   if (!project) {
     return { title: 'Project Not Found | AI Inspection' };
@@ -132,7 +138,9 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<{ 
 
 export default async function ProjectPage({ params }: ProjectPageProps): Promise<React.ReactElement> {
   const { id } = await params;
-  const project = await getProject(id);
+  const session = await auth();
+  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const project = await getProject(id, token);
 
   if (!project) {
     notFound();

--- a/web/app/projects/project-list.tsx
+++ b/web/app/projects/project-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { useApiToken } from '@/lib/use-api';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
@@ -65,6 +66,7 @@ export function ProjectList(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const searchParams = useSearchParams();
   const router = useRouter();
+  const apiToken = useApiToken();
 
   const status = searchParams.get('status') || '';
   const search = searchParams.get('search') || '';
@@ -84,7 +86,9 @@ export function ProjectList(): React.ReactElement {
         }
 
         const response = await fetch(`${API_URL}/api/projects?${params}`, {
-          credentials: 'include',
+          headers: {
+            ...(apiToken && { Authorization: `Bearer ${apiToken}` }),
+          },
         });
 
         if (!response.ok) {
@@ -138,7 +142,7 @@ export function ProjectList(): React.ReactElement {
     }
 
     fetchProjects();
-  }, [status, search, sort, order]);
+  }, [status, search, sort, order, apiToken]);
 
   const handleSort = (column: string): void => {
     const params = new URLSearchParams(searchParams.toString());


### PR DESCRIPTION
## Summary
- Projects list and detail pages were making API calls without authentication tokens, causing 401 Unauthorized responses
- `project-list.tsx`: use `useApiToken()` hook and pass Bearer token in fetch
- `projects/[id]/page.tsx`: use server-side `auth()` to get session token

## Test plan
- [ ] Verify /projects page loads project data when authenticated
- [ ] Verify /projects/[id] detail page loads correctly
- [ ] Confirm no 401 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)