### PR TITLE
fix(e2e): resolve E2E test failures in CD pipeline

### DIFF
--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -76,6 +76,14 @@ test.describe('Navigation — Header Links', () => {
 
 test.describe('Navigation — Auth Guard', () => {
   baseTest('should redirect unauthenticated user to login', async ({ page }) => {
+    // Add Vercel bypass header so we reach the actual app (not Vercel auth wall)
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    if (bypassSecret) {
+      await page.setExtraHTTPHeaders({
+        'x-vercel-protection-bypass': bypassSecret,
+      });
+    }
+
     // No storageState — page is unauthenticated
     await page.context().clearCookies();
     await page.goto('/projects');
@@ -85,6 +93,14 @@ test.describe('Navigation — Auth Guard', () => {
   });
 
   baseTest('should not show header on login page', async ({ page }) => {
+    // Add Vercel bypass header so we reach the actual app (not Vercel auth wall)
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    if (bypassSecret) {
+      await page.setExtraHTTPHeaders({
+        'x-vercel-protection-bypass': bypassSecret,
+      });
+    }
+
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
 

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -16,11 +16,12 @@ async function goToTestProject(page: Page): Promise<void> {
   await page.goto('/projects');
   await page.waitForLoadState('networkidle');
 
+  // Wait for the projects table — may take time while session/token loads
   const table = page.locator('table');
-  await expect(table).toBeVisible({ timeout: 10000 });
+  await expect(table).toBeVisible({ timeout: 30000 });
 
   const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
-  await expect(testRow).toBeVisible();
+  await expect(testRow).toBeVisible({ timeout: 10000 });
   await testRow.click();
   await page.waitForLoadState('networkidle');
 

--- a/test/e2e/projects-list.spec.ts
+++ b/test/e2e/projects-list.spec.ts
@@ -27,7 +27,7 @@ test.describe('Projects List — Table Rendering', () => {
 
     // Wait for skeleton to disappear and table to appear
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Verify all column headers
     const headers = table.locator('thead th');
@@ -43,7 +43,7 @@ test.describe('Projects List — Table Rendering', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Seeded project should appear with correct data
     const rows = table.locator('tbody tr');
@@ -62,7 +62,7 @@ test.describe('Projects List — Table Rendering', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Draft status badge should have gray styling
     const draftBadge = table.locator('span.rounded-full', { hasText: 'Draft' }).first();
@@ -75,7 +75,7 @@ test.describe('Projects List — Table Rendering', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Date cells should contain a date-like string (e.g. "3/1/2026" or "1/03/2026")
     const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
@@ -88,7 +88,7 @@ test.describe('Projects List — Table Rendering', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
     await expect(testRow).toBeVisible();
@@ -103,7 +103,7 @@ test.describe('Projects List — Table Rendering', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     const testRow = table.locator('tbody tr').filter({ hasText: 'TEST-001' });
     const addressCell = testRow.locator('td').nth(1);

--- a/test/e2e/projects-search.spec.ts
+++ b/test/e2e/projects-search.spec.ts
@@ -26,7 +26,7 @@ test.describe('Projects Search & Filter', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Search for the seeded address
     const searchInput = page.getByPlaceholder('Search by address or job number...');
@@ -48,7 +48,7 @@ test.describe('Projects Search & Filter', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     const searchInput = page.getByPlaceholder('Search by address or job number...');
     await searchInput.fill('TEST-001');
@@ -132,7 +132,7 @@ test.describe('Projects Column Sorting', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Click Job # header
     const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });
@@ -148,7 +148,7 @@ test.describe('Projects Column Sorting', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // Click Job # header again to toggle to asc
     const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });
@@ -163,7 +163,7 @@ test.describe('Projects Column Sorting', () => {
     await page.waitForLoadState('networkidle');
 
     const table = page.locator('table');
-    await expect(table).toBeVisible({ timeout: 10000 });
+    await expect(table).toBeVisible({ timeout: 30000 });
 
     // The Job # header should have a down arrow indicator
     const jobHeader = table.locator('thead th').filter({ hasText: 'Job #' });

--- a/web/app/projects/project-list.tsx
+++ b/web/app/projects/project-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { useApiToken } from '@/lib/use-api';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
@@ -66,6 +67,7 @@ export function ProjectList(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const searchParams = useSearchParams();
   const router = useRouter();
+  const { status: sessionStatus } = useSession();
   const apiToken = useApiToken();
 
   const status = searchParams.get('status') || '';
@@ -74,6 +76,9 @@ export function ProjectList(): React.ReactElement {
   const order = searchParams.get('order') || 'desc';
 
   useEffect(() => {
+    // Don't fetch until session has loaded — avoids 401 from missing token
+    if (sessionStatus === 'loading') return;
+
     async function fetchProjects(): Promise<void> {
       setLoading(true);
       setError(null);
@@ -142,7 +147,7 @@ export function ProjectList(): React.ReactElement {
     }
 
     fetchProjects();
-  }, [status, search, sort, order, apiToken]);
+  }, [sessionStatus, status, search, sort, order, apiToken]);
 
   const handleSort = (column: string): void => {
     const params = new URLSearchParams(searchParams.toString());


### PR DESCRIPTION
## Summary
- Add Vercel bypass headers to `baseTest` auth guard tests in navigation spec
- Increase table visibility timeouts from 10s to 30s across project specs for CI stability
- Guard fetch in `project-list.tsx` to wait for session before firing API request (fixes transient 401 race)

## Test plan
- [ ] Verify E2E tests pass in CD pipeline against Vercel preview
- [ ] Confirm no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)