### PR TITLE
fix(e2e): resolve remaining E2E test failures

### DIFF
--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -104,8 +104,12 @@ test.describe('Navigation — Auth Guard', () => {
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
 
+    // Confirm we're on the actual login page (not Vercel auth wall)
+    await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 10000 });
+
+    // AppHeader returns null on /login — no <header> should be in the DOM
     const header = page.locator('header');
-    await expect(header).not.toBeVisible();
+    await expect(header).toHaveCount(0);
   });
 });
 

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -33,12 +33,13 @@ test.describe('Project Detail — Header & Breadcrumbs', () => {
   test('should display breadcrumb navigation', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 
-    // Breadcrumb: Projects / TEST-001
-    const nav = page.locator('nav');
-    await expect(nav.getByText('Projects')).toBeVisible();
+    // Breadcrumb nav has class "mb-4" — distinct from AppHeader nav
+    const breadcrumb = page.locator('nav.mb-4');
+    await expect(breadcrumb).toBeVisible();
+    await expect(breadcrumb.getByText('Projects')).toBeVisible();
 
     // Projects breadcrumb should be a link back to /projects
-    const projectsLink = nav.locator('a[href="/projects"]');
+    const projectsLink = breadcrumb.locator('a[href="/projects"]');
     await expect(projectsLink).toBeVisible();
   });
 
@@ -71,8 +72,9 @@ test.describe('Project Detail — Header & Breadcrumbs', () => {
   test('should navigate back to projects list via breadcrumb', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 
-    const projectsLink = page.locator('nav a[href="/projects"]');
-    await projectsLink.click();
+    // Use breadcrumb nav (class "mb-4") to avoid matching AppHeader nav
+    const breadcrumb = page.locator('nav.mb-4');
+    await breadcrumb.locator('a[href="/projects"]').click();
     await page.waitForLoadState('networkidle');
 
     await expect(page).toHaveURL(/\/projects$/);


### PR DESCRIPTION
## Summary
- Fix navigation auth guard test: assert header count is 0 on login page and wait for login form to confirm the app loaded
- Fix project-detail breadcrumb tests: scope locators to `nav.mb-4` to avoid strict mode violations from matching both AppHeader and breadcrumb nav elements

## Test plan
- [ ] Verify E2E tests pass in CI/CD pipeline
- [ ] Confirm no strict mode violations in Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)