### PR TITLE
fix(api): include siteInspections in project findById response

### DIFF
--- a/api/src/repositories/prisma/project.ts
+++ b/api/src/repositories/prisma/project.ts
@@ -33,6 +33,9 @@ export class PrismaProjectRepository implements IProjectRepository {
       include: {
         property: true,
         client: true,
+        siteInspections: {
+          orderBy: { date: 'asc' },
+        },
       },
     });
   }


### PR DESCRIPTION
## Summary

Fixes #642

`GET /api/projects/:id` was not including `siteInspections` in its Prisma query, causing the project detail page to always show "No inspections recorded" even when inspections existed.

## Change

Added `siteInspections` to the `include` block in `ProjectRepository.findById`, ordered by date ascending.

```ts
include: {
  property: true,
  client: true,
  siteInspections: {
    orderBy: { date: 'asc' },
  },
},
```

## Testing

- Build: ✅ clean
- Tests: ✅ 725 passed
- The project detail page's Inspections section will now populate with linked site inspections