### PR TITLE
docs: update PPI design with confirmed session flow and decisions

### DIFF
--- a/docs/developer/design/024-ppi-data-model-enrichment.md
+++ b/docs/developer/design/024-ppi-data-model-enrichment.md
@@ -56,7 +56,7 @@ The current data model does not support this workflow:
 | Moisture readings (meter value + location) | ❌ Not stored |
 | Floor level survey measurements | ❌ Not stored |
 | Thermal imaging results (room by room) | ❌ Not stored |
-| Photo reference linked to specific finding | ⚠️ Photos exist but not linked to checklist items |
+| Photo reference linked to specific finding | ❌ Photos exist but not linked to checklist items → fixed: `ChecklistItem.photoIds[]` |
 
 ---
 
@@ -73,8 +73,8 @@ model Property {
   storeys       Int?
   bedrooms      Int?
   bathrooms     Int?
-  rooms         String?   // free text: "Family 1, Dining 1, Kitchen 1, WC 1"
   parking       String?   // e.g. "Single Garaging", "Garage + off street"
+  // Note: room list is captured in FloorPlan.rooms[] — not stored on Property
 }
 ```
 
@@ -121,7 +121,7 @@ model FloorPlan {
   floor         Int            // 1-based: 1 = ground/first floor
   label         String?        // e.g. "Ground Floor", "First Floor", "Third Floor"
   rooms         String[]       // e.g. ["Garage", "Storage", "Hall", "Stairs"]
-  photoId       String?        // reference to uploaded floor plan photo (existing Photo model)
+  photoIds      String[]       // floor plan photo references (one per floor, or shared) (existing Photo model)
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 
@@ -134,7 +134,7 @@ model FloorPlan {
 2. *"How many floors?"*
 3. For each floor: *"Rooms on floor [N]? (e.g. Garage, Storage, Hall, Stairs)"*
 
-The uploaded photo is stored as a project photo and referenced in `FloorPlan.photoId`. It serves as the base image for the moisture reading location map (Appendix B) and floor level survey (Appendix C).
+Photos are stored as project photos and referenced in `FloorPlan.photoIds[]`. Each floor may have its own floor plan image. They serve as the base images for Appendix B (moisture map), Appendix C (floor survey), and Appendix D (thermal imaging).
 
 ---
 
@@ -145,13 +145,18 @@ model ChecklistItem {
   // existing fields unchanged ...
 
   // New
-  room      String?  // e.g. "Bedroom 1", "Kitchen", "Attic" — null for site/exterior/services
+  room        String?  // must match a room declared in FloorPlan.rooms[] for INTERIOR items
+                       // null for SITE, EXTERIOR, SERVICES categories
+  floorPlanId String?  // reference to the FloorPlan record this room belongs to
+  photoIds    String[] // photos directly linked to this finding
   
-  // severity enum extended:
-  // existing: minor | major | urgent
-  // add:      immediate-attention | further-investigation | monitor | no-action
+  // severity — REPLACE existing minor|major|urgent with NZS4306:2005 vocabulary:
+  // immediate-attention | further-investigation | monitor | no-action
+  // Migration: minor → monitor, major → immediate-attention, urgent → immediate-attention
 }
 ```
+
+> **Room validation rule:** For `category = INTERIOR`, `room` must match one of the rooms declared in the referenced `FloorPlan`. Kai enforces this by only offering rooms from the floor plan during the interior walk.
 
 ### 5. InspectionSectionConclusion — new model
 
@@ -229,7 +234,7 @@ model SpecialistTest {
 ### Modified endpoints
 
 - `PUT /api/site-inspections/:id` — accept `rainfallLast3Days`, `areasNotAccessed`
-- `POST /api/properties` / `PUT /api/properties/:id` — accept `buildingType`, `storeys`, `bedrooms`, `bathrooms`, `rooms`, `parking`
+- `POST /api/properties` / `PUT /api/properties/:id` — accept `buildingType`, `storeys`, `bedrooms`, `bathrooms`, `parking`
 - `POST /api/site-inspections/:id/checklist-items` — accept `room`; extend severity values
 
 ---

--- a/docs/developer/design/024-ppi-data-model-enrichment.md
+++ b/docs/developer/design/024-ppi-data-model-enrichment.md
@@ -90,9 +90,28 @@ model SiteInspection {
 }
 ```
 
-### 3. FloorPlan — new model
+### 3. FloorPlan — new model (spatial anchor)
 
-Captures the room layout per floor, collected upfront before the interior walk. The floor plan photo is reused as the base image for moisture and floor survey maps (Appendix B/C).
+The floor plan is the **spatial index** of the entire inspection. Every finding, photo, moisture reading, and measurement is anchored to a room, which lives on a floor, which lives on the floor plan.
+
+This is not just metadata — it is the foundation the report is built on.
+
+```
+FloorPlan
+  └── Floor (1, 2, 3...)
+        └── Room ("Master Bedroom", "Kitchen", "Garage"...)
+              ├── ChecklistItems    (findings)
+              ├── SpecialistTests   (moisture readings, thermal)
+              └── Photos            (evidence)
+```
+
+Everything in the report is generated in floor plan order. The floor plan photo becomes the base image for:
+- Appendix A — room photo groupings
+- Appendix B — moisture reading location map
+- Appendix C — floor level survey measurements
+- Appendix D — thermal imaging room sequence
+
+Future: defect locations visualised directly on the floor plan image.
 
 ```prisma
 model FloorPlan {

--- a/docs/developer/design/024-ppi-data-model-enrichment.md
+++ b/docs/developer/design/024-ppi-data-model-enrichment.md
@@ -90,7 +90,36 @@ model SiteInspection {
 }
 ```
 
-### 3. ChecklistItem — room + severity alignment
+### 3. FloorPlan — new model
+
+Captures the room layout per floor, collected upfront before the interior walk. The floor plan photo is reused as the base image for moisture and floor survey maps (Appendix B/C).
+
+```prisma
+model FloorPlan {
+  id            String         @id @default(cuid())
+  inspectionId  String
+  inspection    SiteInspection @relation(fields: [inspectionId], references: [id])
+  floor         Int            // 1-based: 1 = ground/first floor
+  label         String?        // e.g. "Ground Floor", "First Floor", "Third Floor"
+  rooms         String[]       // e.g. ["Garage", "Storage", "Hall", "Stairs"]
+  photoId       String?        // reference to uploaded floor plan photo (existing Photo model)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  @@unique([inspectionId, floor])
+}
+```
+
+**Kai flow for floor plan collection (Step 4, after building info):**
+1. *"Do you have a floor plan photo? Send it now or skip."* → uploads via existing photo API, tagged as floor plan
+2. *"How many floors?"*
+3. For each floor: *"Rooms on floor [N]? (e.g. Garage, Storage, Hall, Stairs)"*
+
+The uploaded photo is stored as a project photo and referenced in `FloorPlan.photoId`. It serves as the base image for the moisture reading location map (Appendix B) and floor level survey (Appendix C).
+
+---
+
+### 4. ChecklistItem — room + severity alignment
 
 ```prisma
 model ChecklistItem {
@@ -105,7 +134,7 @@ model ChecklistItem {
 }
 ```
 
-### 4. InspectionSectionConclusion — new model
+### 5. InspectionSectionConclusion — new model
 
 ```prisma
 model InspectionSectionConclusion {
@@ -121,7 +150,7 @@ model InspectionSectionConclusion {
 }
 ```
 
-### 5. SpecialistTest — new model
+### 6. SpecialistTest — new model
 
 Covers all three appendices (moisture, floor survey, thermal imaging).
 
@@ -170,6 +199,8 @@ model SpecialistTest {
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
+| POST | `/api/site-inspections/:id/floor-plans` | Add floor plan (rooms per floor) |
+| GET | `/api/site-inspections/:id/floor-plans` | Get all floor plans |
 | POST | `/api/site-inspections/:id/specialist-tests` | Add moisture/floor/thermal record |
 | GET | `/api/site-inspections/:id/specialist-tests` | List all specialist tests |
 | PUT | `/api/site-inspections/:id/specialist-tests/:tid` | Update a specialist test |
@@ -209,9 +240,16 @@ After project and inspection are created, Kai collects:
 Stores `weatherConditions` + `rainfallLast3Days` on `SiteInspection`.
 
 **Building info:**
-> "Quick building details — new build or existing? How many storeys? Year built? Bedrooms / bathrooms? Rooms (family, dining, etc.)? Parking?"
+> "Quick building details — new build or existing? How many storeys? Year built? Bedrooms / bathrooms? Parking?"
 
-Stores `buildingType`, `storeys`, `bedrooms`, `bathrooms`, `rooms`, `parking` on `Property`.
+Stores `buildingType`, `storeys`, `bedrooms`, `bathrooms`, `parking` on `Property`.
+
+**Floor plan:**
+> "Do you have a floor plan photo? Send it now or skip."
+> "Rooms on floor 1? (e.g. Garage, Storage, Hall)"
+> "Rooms on floor 2? ..."
+
+Stores `FloorPlan` records per floor. Photo stored as project photo, referenced in `FloorPlan.photoId`.
 
 Only then does Kai begin the inspection sections.
 

--- a/docs/developer/design/024-ppi-data-model-enrichment.md
+++ b/docs/developer/design/024-ppi-data-model-enrichment.md
@@ -186,30 +186,53 @@ model SpecialistTest {
 
 ## Kai / SKILL.md Changes (Phase 2 — after data model ships)
 
-**Onboarding additions:**
+### Confirmed Session Flow
 
-1. After address confirmed → collect building info:
-   > "Quick building details — new or existing? How many storeys, bedrooms, bathrooms? Parking?"
+```
+1. Inspector gives address
+2. Search for existing project → reuse or create new
+3. Create site inspection record
+4. ★ Collect upfront data (NEW) — store to Property + SiteInspection
+5. Walk inspection sections: Site → Exterior → Interior → Services
+6. Specialist tests inline / at end
+7. Conclude each section
+8. Complete inspection
+```
 
-2. At inspection start → collect weather:
-   > "Weather today? Rainfall in last 3 days (mm)?"
+### Step 4 — Upfront Data Collection (new phase)
 
-**Interior section:**
-- Walk room by room, not category-level
+After project and inspection are created, Kai collects:
+
+**Weather:**
+> "What's the weather today? Any rainfall in the last 3 days? (mm)"
+
+Stores `weatherConditions` + `rainfallLast3Days` on `SiteInspection`.
+
+**Building info:**
+> "Quick building details — new build or existing? How many storeys? Year built? Bedrooms / bathrooms? Rooms (family, dining, etc.)? Parking?"
+
+Stores `buildingType`, `storeys`, `bedrooms`, `bathrooms`, `rooms`, `parking` on `Property`.
+
+Only then does Kai begin the inspection sections.
+
+### Step 5 — Interior: room-by-room (not category-level)
+
+- Kai asks which room the inspector is in
 - Each finding tagged with room name
-- Prompt: *"Which room? Findings for [room]?"*
+- Moisture readings captured inline → `SpecialistTest(MOISTURE_READING)`
 
-**After each section:**
-- Prompt for conclusion text
-- Prompt: *"Section conclusion for [Site/Exterior/Interior/Services]?"*
+### Step 6 — Specialist tests
 
-**Moisture readings** — captured inline during interior walk:
-- When inspector reports elevated moisture → create `SpecialistTest(MOISTURE_READING)`
-- Prompt: *"Where exactly? Meter reading?"*
+- Moisture: captured inline during interior walk
+- Floor survey: prompted after interior section
+- Thermal imaging: prompted after interior section
 
-**Specialist tests** — prompted at appropriate points:
-- After interior: *"Floor level survey done? Results?"*
-- After interior: *"Thermal imaging done? Any anomalies?"*
+### Step 7 — Section conclusions
+
+After each section, Kai prompts:
+> *"Conclusion for [Site/Exterior/Interior/Services]? (or say 'no obvious defects')"*
+
+Stores to `InspectionSectionConclusion`.
 
 ---
 
@@ -234,8 +257,8 @@ model SpecialistTest {
 
 ---
 
-## Open Questions for Master
+## Decisions
 
-1. **Room discovery** — should Kai ask for the room list upfront ("how many bedrooms?") and walk through each in order, or let the inspector name rooms dynamically as they walk?
-2. **Floor level survey** — always required for PPI, or only when relevant (e.g. ground floor slab, multi-storey)?
-3. **Thermal imaging** — always done, or optional per job?
+1. **Upfront data collection** is a mandatory phase immediately after project creation, before any inspection sections begin.
+2. **Room discovery** — Kai asks for room counts upfront (bedrooms, bathrooms, rooms) and walks through each dynamically as the inspector moves through the building.
+3. **Floor level survey and thermal imaging** — treated as standard PPI components; Kai prompts for both after the interior section. Inspector can skip if not conducted (noted as limitation).

--- a/docs/domain/ppi-workflow.md
+++ b/docs/domain/ppi-workflow.md
@@ -62,8 +62,10 @@ Before the inspection begins, capture:
 | → Year built | |
 | → Bedrooms | |
 | → Bathrooms | |
-| → Rooms | Family, dining, living, WC, storage, etc. |
 | → Parking | e.g. "Single Garaging", "Garage + off street" |
+| **Floor plan** | |
+| → Photo | Inspector uploads floor plan image (used as base for moisture map) |
+| → Room list per floor | e.g. Floor 1: Garage, Storage, Hall · Floor 2: Bedroom 1, Bathroom... |
 
 ---
 
@@ -82,11 +84,11 @@ Before the inspection begins, capture:
 - **Foundation** — type and condition
 
 ### Section 8 — Interior of Building
-Inspected **room by room**:
+Inspected **room by room** (using floor plan declared upfront):
 - Floors, walls, ceilings
 - Doors and windows
 - Internal fittings and fixtures
-- Moisture readings at risk points
+- Moisture readings at risk points (recorded as SpecialistTest inline)
 - Attic space
 
 ### Section 9 — Service Systems

--- a/docs/domain/ppi-workflow.md
+++ b/docs/domain/ppi-workflow.md
@@ -66,6 +66,7 @@ Before the inspection begins, capture:
 | **Floor plan** | The spatial anchor for the entire inspection |
 | → Photo | Inspector uploads floor plan image — base for all appendix maps |
 | → Room list per floor | e.g. Floor 1: Garage, Storage, Hall · Floor 2: Bedroom 1, Bathroom... |
+| | Room list is the canonical source — all interior findings reference it |
 
 > **Why the floor plan matters:** Every finding, photo, moisture reading, and measurement is anchored to a room on the floor plan. The report is generated in floor plan order. The floor plan photo becomes the base image for Appendix A (photos), B (moisture map), C (floor survey), and D (thermal imaging).
 

--- a/docs/domain/ppi-workflow.md
+++ b/docs/domain/ppi-workflow.md
@@ -63,9 +63,11 @@ Before the inspection begins, capture:
 | → Bedrooms | |
 | → Bathrooms | |
 | → Parking | e.g. "Single Garaging", "Garage + off street" |
-| **Floor plan** | |
-| → Photo | Inspector uploads floor plan image (used as base for moisture map) |
+| **Floor plan** | The spatial anchor for the entire inspection |
+| → Photo | Inspector uploads floor plan image — base for all appendix maps |
 | → Room list per floor | e.g. Floor 1: Garage, Storage, Hall · Floor 2: Bedroom 1, Bathroom... |
+
+> **Why the floor plan matters:** Every finding, photo, moisture reading, and measurement is anchored to a room on the floor plan. The report is generated in floor plan order. The floor plan photo becomes the base image for Appendix A (photos), B (moisture map), C (floor survey), and D (thermal imaging).
 
 ---
 

--- a/docs/domain/ppi-workflow.md
+++ b/docs/domain/ppi-workflow.md
@@ -6,6 +6,36 @@
 
 ---
 
+## 0. Session Flow
+
+This is the sequence Kai follows for every PPI. Steps are sequential — do not skip.
+
+```
+1. Inspector gives address
+        ↓
+2. Search for existing project (GET /api/projects?address=...)
+        ↓
+3a. Existing project found → confirm with inspector, reuse it
+3b. Nothing found → create property → create client → create project
+        ↓
+4. Collect upfront data (weather, rainfall, building info)
+   Store to: Property + SiteInspection
+        ↓
+5. Create site inspection record
+        ↓
+6. Walk through inspection sections in order:
+   Site & Ground → Exterior → Interior (room-by-room) → Services
+        ↓
+7. Record specialist tests:
+   Moisture readings (inline during interior) → Floor survey → Thermal imaging
+        ↓
+8. Conclude each section (free text summary)
+        ↓
+9. Complete inspection
+```
+
+---
+
 ## 1. Data Collected Upfront
 
 Before the inspection begins, capture:


### PR DESCRIPTION
## Summary

Updates to the PPI design following review session with Master.

### ppi-workflow.md
- Added **Section 0 — Session Flow**: explicit 9-step sequence diagram showing the full Kai-guided PPI session from address → project → upfront data → sections → specialist tests → complete

### design/024-ppi-data-model-enrichment.md
- Rewrote Kai/SKILL.md changes section with the confirmed flow
- **Upfront data collection** is now an explicit mandatory phase immediately after project creation
- Closed all 3 open questions with confirmed decisions:
  1. Upfront data collection is mandatory before sections begin
  2. Rooms discovered dynamically during walk, count collected upfront
  3. Floor survey + thermal imaging are standard — inspector can skip with limitation note