### PR TITLE
fix(e2e): fix remaining strict mode violations

### DIFF
--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -101,7 +101,7 @@ test.describe('Navigation — Auth Guard', () => {
       });
     } else {
       // Without bypass secret we cannot reach the login page past Vercel auth wall — skip
-      test.skip();
+      baseTest.skip(true, 'VERCEL_AUTOMATION_BYPASS_SECRET not set');
       return;
     }
 

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -110,14 +110,14 @@ test.describe('Project Detail — Collapsible Sections', () => {
     await expect(page.getByText('Property').first()).toBeVisible();
     await expect(propertySection.getByText('123 Test Street')).toBeVisible();
     await expect(propertySection.getByText('Testville')).toBeVisible();
-    await expect(propertySection.getByText('Auckland')).toBeVisible();
+    await expect(propertySection.getByText('Auckland', { exact: true })).toBeVisible();
     await expect(propertySection.getByText('Auckland Council')).toBeVisible();
   });
 
   test('should display Inspections section with empty state', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 
-    await expect(page.getByText('Inspections')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Inspections', level: 2 }).first()).toBeVisible();
 
     // Seeded project has no inspections
     await expect(page.getByText('No inspections recorded')).toBeVisible();


### PR DESCRIPTION
Follow-up to #656 — two remaining failures.

**navigation.spec.ts:** `test.skip()` doesn't work inside `baseTest` — changed to `baseTest.skip(true, ...)`.

**project-detail.spec.ts:**
- `'Auckland'` still ambiguous (city + council) within property section → use `{ exact: true }`
- `getByText('Inspections')` resolves to 2 elements → use `getByRole('heading', { name: 'Inspections', level: 2 })`