### PR TITLE
fix(e2e): navigation bypass, BRANZ title, profile link

### DIFF
--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -93,23 +93,12 @@ test.describe('Navigation — Auth Guard', () => {
   });
 
   baseTest('should not show header on login page', async ({ page }) => {
-    // Add Vercel bypass header so we reach the actual app (not Vercel auth wall)
-    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-    if (bypassSecret) {
-      await page.setExtraHTTPHeaders({
-        'x-vercel-protection-bypass': bypassSecret,
-      });
-    } else {
-      // Without bypass secret we cannot reach the login page past Vercel auth wall
-      console.log('Skipping: VERCEL_AUTOMATION_BYPASS_SECRET not set');
-      return;
-    }
-
+    // Vercel bypass is applied globally in playwright.config.ts via baseURL + extraHTTPHeaders
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
 
-    // Confirm we're on the actual login page (not Vercel auth wall)
-    await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 10000 });
+    // Confirm we're on the actual login page
+    await expect(page.locator('#email')).toBeVisible({ timeout: 10000 });
 
     // AppHeader returns null on /login — no <header> should be in the DOM
     const header = page.locator('header');

--- a/test/e2e/profile.spec.ts
+++ b/test/e2e/profile.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('Profile Page', () => {
   test('should be accessible from header email link', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
-    const profileLink = page.locator('a[href="/profile"]');
+    const profileLink = page.locator('a[href="/profile"]').first();
     await expect(profileLink).toBeVisible();
     await profileLink.click();
     await expect(page).toHaveURL('/profile');

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -126,7 +126,7 @@ test.describe('Project Detail — Collapsible Sections', () => {
   test('should display BRANZ Zone Data section', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 
-    await expect(page.getByRole('heading', { name: 'BRANZ Zone Data', level: 2 })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Site Data (BRANZ Maps)', level: 2 })).toBeVisible();
   });
 
   test('should display Documents section', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
Fourth pass.

**navigation.spec.ts:** The global playwright config already applies the Vercel bypass — manual `setExtraHTTPHeaders` was conflicting. Removed it. Also use `#email` id selector (stable) instead of `input[type="email"]`.

**project-detail.spec.ts:** BRANZ section heading is `'Site Data (BRANZ Maps)'` not `'BRANZ Zone Data'`.

**profile.spec.ts:** Profile link renders at both desktop and mobile breakpoints → `a[href="/profile"]` resolves to 2 elements → use `.first()`.