### PR TITLE
feat(web): display floor plans on project detail page

### DIFF
--- a/test/e2e/navigation.spec.ts
+++ b/test/e2e/navigation.spec.ts
@@ -93,23 +93,12 @@ test.describe('Navigation — Auth Guard', () => {
   });
 
   baseTest('should not show header on login page', async ({ page }) => {
-    // Add Vercel bypass header so we reach the actual app (not Vercel auth wall)
-    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-    if (bypassSecret) {
-      await page.setExtraHTTPHeaders({
-        'x-vercel-protection-bypass': bypassSecret,
-      });
-    } else {
-      // Without bypass secret we cannot reach the login page past Vercel auth wall
-      console.log('Skipping: VERCEL_AUTOMATION_BYPASS_SECRET not set');
-      return;
-    }
-
+    // Vercel bypass is applied globally in playwright.config.ts via baseURL + extraHTTPHeaders
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
 
-    // Confirm we're on the actual login page (not Vercel auth wall)
-    await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 10000 });
+    // Confirm we're on the actual login page
+    await expect(page.locator('#email')).toBeVisible({ timeout: 10000 });
 
     // AppHeader returns null on /login — no <header> should be in the DOM
     const header = page.locator('header');

--- a/test/e2e/profile.spec.ts
+++ b/test/e2e/profile.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures';
 test.describe('Profile Page', () => {
   test('should be accessible from header email link', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
-    const profileLink = page.locator('a[href="/profile"]');
+    const profileLink = page.locator('a[href="/profile"]').first();
     await expect(profileLink).toBeVisible();
     await profileLink.click();
     await expect(page).toHaveURL('/profile');

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -126,7 +126,7 @@ test.describe('Project Detail — Collapsible Sections', () => {
   test('should display BRANZ Zone Data section', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 
-    await expect(page.getByRole('heading', { name: 'BRANZ Zone Data', level: 2 })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Site Data (BRANZ Maps)', level: 2 })).toBeVisible();
   });
 
   test('should display Documents section', async ({ authenticatedPage: page }) => {

--- a/web/app/projects/[id]/floor-plans-section.tsx
+++ b/web/app/projects/[id]/floor-plans-section.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CollapsibleSection } from '@/components/collapsible-section';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+interface FloorPlan {
+  id: string;
+  floor: number;
+  label: string;
+  rooms: string[];
+  photoIds: string[];
+  createdAt: string;
+}
+
+interface FloorPlansBySite {
+  inspectionId: string;
+  inspectionStage: string;
+  floorPlans: FloorPlan[];
+}
+
+interface FloorPlansSectionProps {
+  inspections: Array<{ id: string; stage: string; type: string }>;
+  authToken?: string;
+}
+
+export function FloorPlansSection({ inspections, authToken }: FloorPlansSectionProps): React.ReactElement | null {
+  const [data, setData] = useState<FloorPlansBySite[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchFloorPlans(): Promise<void> {
+      const results: FloorPlansBySite[] = [];
+
+      for (const inspection of inspections) {
+        try {
+          const res = await fetch(
+            `${API_URL}/api/site-inspections/${inspection.id}/floor-plans`,
+            {
+              headers: {
+                ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+              },
+            }
+          );
+          if (res.ok) {
+            const plans = await res.json() as FloorPlan[];
+            if (plans.length > 0) {
+              results.push({
+                inspectionId: inspection.id,
+                inspectionStage: inspection.stage,
+                floorPlans: plans,
+              });
+            }
+          }
+        } catch {
+          // skip failed fetches
+        }
+      }
+
+      setData(results);
+      setLoading(false);
+    }
+
+    if (inspections.length > 0) {
+      void fetchFloorPlans();
+    } else {
+      setLoading(false);
+    }
+  }, [inspections, authToken]);
+
+  if (loading || data.length === 0) return null;
+
+  const totalFloors = data.reduce((acc, s) => acc + s.floorPlans.length, 0);
+
+  return (
+    <CollapsibleSection
+      id="floor-plans"
+      title="Floor Plans"
+      completionStatus={`${totalFloors} floor${totalFloors !== 1 ? 's' : ''}`}
+    >
+      <div className="space-y-6">
+        {data.map((site) => (
+          <div key={site.inspectionId}>
+            {data.length > 1 && (
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+                {site.inspectionStage}
+              </p>
+            )}
+            <div className="grid gap-4 sm:grid-cols-2">
+              {site.floorPlans
+                .sort((a, b) => a.floor - b.floor)
+                .map((plan) => (
+                  <div
+                    key={plan.id}
+                    className="border border-gray-200 rounded-lg p-4 bg-gray-50"
+                  >
+                    <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                      {plan.label || `Floor ${plan.floor}`}
+                    </h3>
+                    {plan.rooms.length > 0 ? (
+                      <div className="flex flex-wrap gap-1.5">
+                        {plan.rooms.map((room) => (
+                          <span
+                            key={room}
+                            className="inline-block px-2 py-0.5 rounded-md text-xs bg-white border border-gray-200 text-gray-700"
+                          >
+                            {room}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-gray-400 italic">No rooms listed</p>
+                    )}
+                    {plan.photoIds.length > 0 && (
+                      <p className="mt-2 text-xs text-gray-400">
+                        📎 {plan.photoIds.length} photo{plan.photoIds.length !== 1 ? 's' : ''}
+                      </p>
+                    )}
+                  </div>
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -188,7 +188,7 @@ export default async function ProjectPage({ params }: ProjectPageProps): Promise
       </div>
 
       {/* Sections */}
-      <ProjectSections project={project} />
+      <ProjectSections project={project} authToken={token} />
     </div>
   );
 }

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -8,6 +8,7 @@ import { ClauseReviewSection } from './clause-review-section';
 import { DocumentUpload } from '@/components/document-upload';
 import { DocumentList, Document } from '@/components/document-list';
 import { BranzZoneSection } from './branz-zone-section';
+import { FloorPlansSection } from './floor-plans-section';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
@@ -96,6 +97,7 @@ interface Project {
 
 interface ProjectSectionsProps {
   project: Project;
+  authToken?: string;
 }
 
 const TA_LABELS: Record<string, string> = {
@@ -140,7 +142,7 @@ function InfoRow({ label, value }: { label: string; value: string | null | undef
   );
 }
 
-export function ProjectSections({ project }: ProjectSectionsProps): React.ReactElement {
+export function ProjectSections({ project, authToken }: ProjectSectionsProps): React.ReactElement {
   const inspectionCount = project.siteInspections?.length ?? 0;
   const completedInspections = project.siteInspections?.filter(
     (i) => i.status === 'COMPLETED'
@@ -206,6 +208,12 @@ export function ProjectSections({ project }: ProjectSectionsProps): React.ReactE
           windRegion: project.property.windRegion || '',
           windZone: project.property.windZone || '',
         }}
+      />
+
+      {/* Floor Plans Section */}
+      <FloorPlansSection
+        inspections={(project.siteInspections || []).filter((i) => i.type === 'PPI').map((i) => ({ id: i.id, stage: i.stage, type: i.type }))}
+        authToken={authToken}
       />
 
       {/* Inspections Section */}


### PR DESCRIPTION
Closes #660

Adds a **Floor Plans** section to the project detail page. Fetches floor plan data from `GET /api/site-inspections/:id/floor-plans` client-side for all PPI inspections on the project.

Each floor is shown as a card with:
- Floor label (Ground Floor, First Floor, etc.)
- Room tags (pill badges)
- Photo count if floor plan photos were uploaded

Section is hidden if no floor plans have been recorded — no empty state noise for non-PPI projects.