### PR TITLE
feat: move FloorPlan from SiteInspection to Project

### DIFF
--- a/api/prisma/migrations/20260302_move_floor_plan_to_project/migration.sql
+++ b/api/prisma/migrations/20260302_move_floor_plan_to_project/migration.sql
@@ -1,0 +1,30 @@
+-- Move FloorPlan from SiteInspection to Project
+-- Issue #662: floor plan is building metadata, not an inspection finding
+
+-- Step 1: Add projectId column
+ALTER TABLE "FloorPlan" ADD COLUMN "projectId" TEXT;
+
+-- Step 2: Populate projectId from the inspection's project
+UPDATE "FloorPlan" fp
+SET "projectId" = si."projectId"
+FROM "SiteInspection" si
+WHERE fp."inspectionId" = si.id;
+
+-- Step 3: Make projectId NOT NULL
+ALTER TABLE "FloorPlan" ALTER COLUMN "projectId" SET NOT NULL;
+
+-- Step 4: Add FK constraint
+ALTER TABLE "FloorPlan" ADD CONSTRAINT "FloorPlan_projectId_fkey"
+  FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Step 5: Drop old unique index and index on inspectionId
+DROP INDEX IF EXISTS "FloorPlan_inspectionId_floor_key";
+DROP INDEX IF EXISTS "FloorPlan_inspectionId_idx";
+
+-- Step 6: Add new unique index and index on projectId
+CREATE UNIQUE INDEX "FloorPlan_projectId_floor_key" ON "FloorPlan"("projectId", "floor");
+CREATE INDEX "FloorPlan_projectId_idx" ON "FloorPlan"("projectId");
+
+-- Step 7: Drop old FK and column
+ALTER TABLE "FloorPlan" DROP CONSTRAINT IF EXISTS "FloorPlan_inspectionId_fkey";
+ALTER TABLE "FloorPlan" DROP COLUMN "inspectionId";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -333,6 +333,7 @@ model Project {
   siteInspections SiteInspection[]
   documents       Document[]
   photos          ProjectPhoto[]
+  floorPlans      FloorPlan[]
 }
 
 model Property {
@@ -470,7 +471,6 @@ model SiteInspection {
   reports           Report[]
   defects           Defect[]
   moistureReadings  MoistureReading[]
-  floorPlans        FloorPlan[]
   sectionConclusions InspectionSectionConclusion[]
   floorLevelSurveys FloorLevelSurvey[]
   thermalImages     ThermalImagingRecord[]
@@ -1129,8 +1129,8 @@ model ServiceKey {
 
 model FloorPlan {
   id            String         @id @default(uuid())
-  inspectionId  String
-  inspection    SiteInspection @relation(fields: [inspectionId], references: [id], onDelete: Cascade)
+  projectId     String
+  project       Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
   floor         Int            // 1-based: 1 = ground/first floor
   label         String?        // e.g. "Ground Floor", "First Floor"
   rooms         String[]       // canonical room list for this floor
@@ -1141,8 +1141,8 @@ model FloorPlan {
 
   checklistItems ChecklistItem[]
 
-  @@unique([inspectionId, floor])
-  @@index([inspectionId])
+  @@unique([projectId, floor])
+  @@index([projectId])
 }
 
 model InspectionSectionConclusion {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -117,7 +117,7 @@ app.use('/api', serviceAuthMiddleware, requireScope('inspections:read'), buildin
 app.use('/api', serviceAuthMiddleware, requireScope('inspections:read'), siteMeasurementsRouter);
 app.use('/api', serviceAuthMiddleware, requireScope('inspections:read'), moistureReadingsRouter);
 app.use('/api/project-requirements', serviceAuthMiddleware, requireScope('projects:read'), projectRequirementsRouter);
-app.use('/api/site-inspections/:id/floor-plans', serviceAuthMiddleware, requireScope('inspections:read'), floorPlansRouter);
+app.use('/api/projects/:id/floor-plans', serviceAuthMiddleware, requireScope('projects:read'), floorPlansRouter);
 app.use('/api/site-inspections/:id/section-conclusions', serviceAuthMiddleware, requireScope('inspections:read'), sectionConclusionsRouter);
 app.use('/api/site-inspections/:id/floor-level-surveys', serviceAuthMiddleware, requireScope('inspections:read'), floorLevelSurveysRouter);
 app.use('/api/site-inspections/:id/thermal-imaging', serviceAuthMiddleware, requireScope('inspections:read'), thermalImagingRouter);

--- a/api/src/routes/floor-plans.ts
+++ b/api/src/routes/floor-plans.ts
@@ -1,9 +1,9 @@
 /**
  * Floor Plans routes
- * POST/GET /api/site-inspections/:id/floor-plans
- * PUT/DELETE /api/site-inspections/:id/floor-plans/:fid
+ * POST/GET /api/projects/:id/floor-plans
+ * PUT/DELETE /api/projects/:id/floor-plans/:fid
  *
- * Floor plan is the spatial anchor for the entire PPI inspection.
+ * Floor plan is building metadata owned by the Project.
  * Each floor has a canonical room list that interior findings reference.
  */
 
@@ -23,11 +23,11 @@ const CreateFloorPlanSchema = z.object({
 
 const UpdateFloorPlanSchema = CreateFloorPlanSchema.partial().omit({ floor: true });
 
-// GET /api/site-inspections/:id/floor-plans
+// GET /api/projects/:id/floor-plans
 floorPlansRouter.get('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const floorPlans = await prisma.floorPlan.findMany({
-      where: { inspectionId: req.params.id as string },
+      where: { projectId: req.params.id as string },
       orderBy: { floor: 'asc' },
     });
     res.json(floorPlans);
@@ -36,21 +36,20 @@ floorPlansRouter.get('/', async (req: Request, res: Response, next: NextFunction
   }
 });
 
-// POST /api/site-inspections/:id/floor-plans
+// POST /api/projects/:id/floor-plans
 floorPlansRouter.post('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const data = CreateFloorPlanSchema.parse(req.body);
 
-    // Verify inspection exists
-    const inspection = await prisma.siteInspection.findUnique({ where: { id: req.params.id as string } });
-    if (!inspection) {
-      res.status(404).json({ error: 'Inspection not found' });
+    const project = await prisma.project.findUnique({ where: { id: req.params.id as string } });
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
       return;
     }
 
     const floorPlan = await prisma.floorPlan.create({
       data: {
-        inspectionId: req.params.id as string,
+        projectId: req.params.id as string,
         floor: data.floor,
         label: data.label,
         rooms: data.rooms,
@@ -63,7 +62,7 @@ floorPlansRouter.post('/', async (req: Request, res: Response, next: NextFunctio
   }
 });
 
-// PUT /api/site-inspections/:id/floor-plans/:fid
+// PUT /api/projects/:id/floor-plans/:fid
 floorPlansRouter.put('/:fid', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const data = UpdateFloorPlanSchema.parse(req.body);
@@ -77,7 +76,7 @@ floorPlansRouter.put('/:fid', async (req: Request, res: Response, next: NextFunc
   }
 });
 
-// DELETE /api/site-inspections/:id/floor-plans/:fid
+// DELETE /api/projects/:id/floor-plans/:fid
 floorPlansRouter.delete('/:fid', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     await prisma.floorPlan.delete({ where: { id: req.params.fid as string } });

--- a/api/src/routes/project-requirements.ts
+++ b/api/src/routes/project-requirements.ts
@@ -17,7 +17,7 @@ interface UpfrontDataItem {
   label: string;
   description: string;
   required: boolean;
-  storeOn: 'siteInspection' | 'property' | 'floorPlan';
+  storeOn: 'siteInspection' | 'property' | 'project';
   fields: string[];
 }
 
@@ -51,7 +51,7 @@ const REQUIREMENTS: Record<string, ProjectRequirements> = {
         label: 'Floor plan',
         description: 'Floor plan photo (optional) + room list per floor',
         required: false,
-        storeOn: 'floorPlan',
+        storeOn: 'project',
         fields: ['photoIds', 'rooms'],
       },
     ],

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.2.0
+version: 3.3.0
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -192,7 +192,9 @@ curl -X PUT "$API_URL/api/properties/{PROPERTY_ID}" \
   }'
 ```
 
-**Floor plan** (`storeOn: floorPlan`, optional):
+**Floor plan** (`storeOn: project`, optional):
+
+Floor plan is metadata about the building — stored on the Project, not the inspection.
 
 If photo received → upload first:
 
@@ -212,7 +214,7 @@ curl -X POST "$API_URL/api/projects/{PROJECT_ID}/photos/base64" \
 Save photo `id` as `FLOOR_PLAN_PHOTO_ID`. Then for each floor:
 
 ```bash
-curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/floor-plans" \
+curl -X POST "$API_URL/api/projects/{PROJECT_ID}/floor-plans" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $API_SERVICE_KEY" \
   -d '{

--- a/web/app/projects/[id]/floor-plans-section.tsx
+++ b/web/app/projects/[id]/floor-plans-section.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CollapsibleSection } from '@/components/collapsible-section';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+interface FloorPlan {
+  id: string;
+  floor: number;
+  label: string;
+  rooms: string[];
+  photoIds: string[];
+}
+
+interface FloorPlansSectionProps {
+  projectId: string;
+  authToken?: string;
+}
+
+export function FloorPlansSection({ projectId, authToken }: FloorPlansSectionProps): React.ReactElement | null {
+  const [floorPlans, setFloorPlans] = useState<FloorPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchFloorPlans(): Promise<void> {
+      try {
+        const res = await fetch(`${API_URL}/api/projects/${projectId}/floor-plans`, {
+          headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+        });
+        if (res.ok) {
+          setFloorPlans(await res.json() as FloorPlan[]);
+        }
+      } catch {
+        // silent fail
+      } finally {
+        setLoading(false);
+      }
+    }
+    void fetchFloorPlans();
+  }, [projectId, authToken]);
+
+  if (loading || floorPlans.length === 0) return null;
+
+  return (
+    <CollapsibleSection
+      id="floor-plans"
+      title="Floor Plans"
+      completionStatus={`${floorPlans.length} floor${floorPlans.length !== 1 ? 's' : ''}`}
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        {floorPlans.map((plan) => (
+          <div key={plan.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+            <h3 className="text-sm font-semibold text-gray-900 mb-2">
+              {plan.label || `Floor ${plan.floor}`}
+            </h3>
+            {plan.rooms.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {plan.rooms.map((room) => (
+                  <span
+                    key={room}
+                    className="inline-block px-2 py-0.5 rounded-md text-xs bg-white border border-gray-200 text-gray-700"
+                  >
+                    {room}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-400 italic">No rooms listed</p>
+            )}
+            {plan.photoIds.length > 0 && (
+              <p className="mt-2 text-xs text-gray-400">
+                📎 {plan.photoIds.length} photo{plan.photoIds.length !== 1 ? 's' : ''}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -188,7 +188,7 @@ export default async function ProjectPage({ params }: ProjectPageProps): Promise
       </div>
 
       {/* Sections */}
-      <ProjectSections project={project} />
+      <ProjectSections project={project} authToken={token} />
     </div>
   );
 }

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -8,6 +8,7 @@ import { ClauseReviewSection } from './clause-review-section';
 import { DocumentUpload } from '@/components/document-upload';
 import { DocumentList, Document } from '@/components/document-list';
 import { BranzZoneSection } from './branz-zone-section';
+import { FloorPlansSection } from './floor-plans-section';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
@@ -96,6 +97,7 @@ interface Project {
 
 interface ProjectSectionsProps {
   project: Project;
+  authToken?: string;
 }
 
 const TA_LABELS: Record<string, string> = {
@@ -140,7 +142,7 @@ function InfoRow({ label, value }: { label: string; value: string | null | undef
   );
 }
 
-export function ProjectSections({ project }: ProjectSectionsProps): React.ReactElement {
+export function ProjectSections({ project, authToken }: ProjectSectionsProps): React.ReactElement {
   const inspectionCount = project.siteInspections?.length ?? 0;
   const completedInspections = project.siteInspections?.filter(
     (i) => i.status === 'COMPLETED'
@@ -207,6 +209,9 @@ export function ProjectSections({ project }: ProjectSectionsProps): React.ReactE
           windZone: project.property.windZone || '',
         }}
       />
+
+      {/* Floor Plans Section */}
+      <FloorPlansSection projectId={project.id} authToken={authToken} />
 
       {/* Inspections Section */}
       <CollapsibleSection


### PR DESCRIPTION
Closes #662

## Changes

**Schema**
- `FloorPlan.inspectionId` → `FloorPlan.projectId`
- Migration populates `projectId` from existing inspection data, then drops `inspectionId`

**API**
- `POST/GET /api/site-inspections/:id/floor-plans` → `POST/GET /api/projects/:id/floor-plans`
- `project-requirements`: `storeOn: 'floorPlan'` → `storeOn: 'project'`

**Skill v3.3.0**
- Floor plan curl commands updated to use project endpoint

**Web UI**
- `FloorPlansSection` component fetches from project endpoint
- Displays floor cards with room tags on project detail page
- Hidden when no floor plans recorded (no empty state clutter)