### PR TITLE
fix(e2e): add timeouts for 404 page and filter hydration tests

### DIFF
--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -148,6 +148,6 @@ test.describe('Project Detail — 404 Handling', () => {
     await page.waitForLoadState('networkidle');
 
     // Next.js notFound() renders a 404 page
-    await expect(page.getByText(/not found/i)).toBeVisible();
+    await expect(page.getByText(/not found/i)).toBeVisible({ timeout: 20000 });
   });
 });

--- a/test/e2e/projects-search.spec.ts
+++ b/test/e2e/projects-search.spec.ts
@@ -115,7 +115,9 @@ test.describe('Projects Search & Filter', () => {
     await page.waitForLoadState('networkidle');
 
     const statusSelect = page.locator('select#status');
-    await expect(statusSelect).toHaveValue('DRAFT');
+    // Wait for client component to hydrate with the correct value
+    await expect(statusSelect).toBeVisible({ timeout: 15000 });
+    await expect(statusSelect).toHaveValue('DRAFT', { timeout: 10000 });
 
     // Clear the filter
     await statusSelect.selectOption('');


### PR DESCRIPTION
- 404 test: increase timeout to 20s to allow server component fetch + notFound() to complete
- Filter test: wait for select to be visible and hydrated before asserting value