### PR TITLE
feat: local dev container stack (docker compose)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Local dev environment variables
+# Copy to .env and fill in values
+
+# ─── Postgres ─────────────────────────────────────────────────────────────────
+POSTGRES_USER=dev
+POSTGRES_PASSWORD=devpassword
+POSTGRES_DB=ai_inspection
+
+# ─── API ──────────────────────────────────────────────────────────────────────
+JWT_SECRET=dev-jwt-secret-change-in-prod
+
+# ─── Web ──────────────────────────────────────────────────────────────────────
+AUTH_SECRET=dev-auth-secret-change-in-prod
+
+# ─── Seed ─────────────────────────────────────────────────────────────────────
+# Password for test@example.com seeded on startup
+TEST_PASSWORD=test123

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,16 @@
-# ─── Development stage ────────────────────────────────────────────────────────
-FROM node:22-alpine AS dev
+# Development stage — uses host node_modules via volume mount
+FROM casey-api:latest AS dev
+
 
 WORKDIR /app
+
+ENV NODE_ENV=development
+ENV PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/workspace/node_modules/.bin/tsx", "watch", "src/index.ts"]
 
 # Copy package files and prisma schema
 COPY package*.json ./
@@ -18,10 +27,10 @@ ENV PORT=3000
 
 EXPOSE 3000
 
-CMD ["npx", "tsx", "watch", "src/index.ts"]
+CMD ["/workspace/node_modules/.bin/tsx", "watch", "src/index.ts"]
 
 # ─── Build stage ──────────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+FROM casey-api:latest AS builder
 
 WORKDIR /app
 
@@ -34,7 +43,7 @@ COPY . .
 RUN npm run build
 
 # ─── Production stage ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS production
+FROM casey-api:latest AS production
 
 WORKDIR /app
 

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -8,10 +8,10 @@ done
 sleep 2
 
 echo "Postgres ready. Running migrations..."
-npx prisma migrate deploy --schema=prisma/schema.prisma
+/workspace/node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma
 
 echo "Seeding test data..."
-cd /workspace/test && DATABASE_URL="$DATABASE_URL" TEST_PASSWORD="${TEST_PASSWORD:-test123}" npx tsx scripts/seed-test-env.ts 2>/dev/null || true
+cd /workspace/test && DATABASE_URL="$DATABASE_URL" TEST_PASSWORD="${TEST_PASSWORD:-test123}" /workspace/node_modules/.bin/tsx scripts/seed-test-env.ts 2>/dev/null || true
 cd /app
 
 echo "Starting API..."

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for postgres..."
+until nc -z postgres 5432 2>/dev/null; do
+  sleep 1
+done
+sleep 2
+
+echo "Postgres ready. Running migrations..."
+npx prisma migrate deploy --schema=prisma/schema.prisma
+
+echo "Seeding test data..."
+cd /workspace/test && DATABASE_URL="$DATABASE_URL" TEST_PASSWORD="${TEST_PASSWORD:-test123}" npx tsx scripts/seed-test-env.ts 2>/dev/null || true
+cd /app
+
+echo "Starting API..."
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,83 +1,64 @@
 services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
+      POSTGRES_DB: ${POSTGRES_DB:-ai_inspection}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dev}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   api:
-    build: ./api
-    container_name: ai-inspection-api
-    restart: unless-stopped
+    build:
+      context: ./api
+      target: dev
     ports:
       - "3000:3000"
     environment:
-      - NODE_ENV=development
-      - DATABASE_URL=postgresql://inspection:inspection@db:5432/inspection
-      - REDIS_URL=redis://redis:6379
-      - PHOTO_DIR=/app/photos
+      DATABASE_URL: postgresql://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-ai_inspection}
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret}
+      NODE_ENV: development
+      PORT: 3000
+      TEST_PASSWORD: ${TEST_PASSWORD:-test123}
     volumes:
-      - photos:/app/photos
+      - ./api/src:/app/src
+      - ./api/prisma:/app/prisma
+      - ./test:/workspace/test
+      - /app/node_modules
     depends_on:
-      db:
+      postgres:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r => process.exit(r.ok ? 0 : 1))"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
-  redis:
-    image: redis:7-alpine
-    container_name: ai-inspection-redis
+    entrypoint: ["/app/docker-entrypoint.sh"]
+    command: ["npx", "tsx", "watch", "src/index.ts"]
     restart: unless-stopped
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
 
-  db:
-    image: postgres:16-alpine
-    container_name: ai-inspection-db
-    restart: unless-stopped
-    environment:
-      - POSTGRES_USER=inspection
-      - POSTGRES_PASSWORD=inspection
-      - POSTGRES_DB=inspection
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U inspection -d inspection"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
-  mcp:
+  web:
     build:
-      context: ./mcp
-      dockerfile: Dockerfile
-    container_name: ai-inspection-mcp
-    restart: unless-stopped
+      context: .
+      dockerfile: web/Dockerfile
+      target: dev
     ports:
-      - "${MCP_PORT:-3100}:3100"
-    volumes:
-      - ./data:/app/data
-      - ./config:/app/config:ro
+      - "3001:3001"
     environment:
-      - NODE_ENV=production
-      - DATA_DIR=/app/data
-      - CONFIG_DIR=/app/config
-    healthcheck:
-      test: ["CMD", "node", "-e", "console.log('ok')"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+      NEXT_PUBLIC_API_URL: http://localhost:3000
+      AUTH_SECRET: ${AUTH_SECRET:-dev-auth-secret}
+      NEXTAUTH_URL: http://localhost:3001
+      NODE_ENV: development
+    volumes:
+      - ./web:/app/web
+      - ./shared:/app/shared
+      - /app/web/.next
+      - /app/node_modules
+    depends_on:
+      - api
+    restart: unless-stopped
 
 volumes:
   pgdata:
-  photos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,7 @@ services:
     volumes:
       - ./web:/app/web
       - ./shared:/app/shared
-      - /app/web/.next
-      - /app/node_modules
+      - ./node_modules:/app/node_modules
     depends_on:
       - api
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,21 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
       POSTGRES_DB: ${POSTGRES_DB:-ai_inspection}
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dev}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dev} -d ${POSTGRES_DB:-ai_inspection}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -24,19 +34,24 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-ai_inspection}
       JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret}
+      REDIS_URL: redis://redis:6379
       NODE_ENV: development
       PORT: 3000
       TEST_PASSWORD: ${TEST_PASSWORD:-test123}
     volumes:
       - ./api/src:/app/src
       - ./api/prisma:/app/prisma
+      - ./api/package.json:/app/package.json
+      - ./api/docker-entrypoint.sh:/app/docker-entrypoint.sh
+      - ./node_modules:/workspace/node_modules
       - ./test:/workspace/test
-      - /app/node_modules
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     entrypoint: ["/app/docker-entrypoint.sh"]
-    command: ["npx", "tsx", "watch", "src/index.ts"]
+    command: ["/workspace/node_modules/.bin/tsx", "watch", "src/index.ts"]
     restart: unless-stopped
 
   web:

--- a/docs/developer/design/025-local-dev-containers.md
+++ b/docs/developer/design/025-local-dev-containers.md
@@ -1,0 +1,128 @@
+# 025 — Local Dev Container Stack
+
+**Status:** Proposed  
+**Author:** Megan  
+**Date:** 2026-03-03  
+
+## Problem
+
+The current dev/test loop depends on Railway (API) and Vercel (web) for even basic integration testing. This means:
+
+- Every change requires a PR → CI → deploy cycle before E2E tests can run
+- Railway migration failures block all deploys
+- Vercel infrastructure errors cause false CI failures
+- Kai's `AI_INSPECTION_API_URL` points at a shared test environment — risky for parallel development
+- No way to debug locally against a real stack
+
+## Goal
+
+A fully self-contained local Docker stack that mirrors production. Developers and Kai can run the full system locally with a single command.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   web (Next.js) │────▶│   api (Express) │────▶│  postgres (DB)  │
+│   :3001         │     │   :3000         │     │   :5432         │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+All three services run in Docker containers orchestrated by `docker-compose.yml` at the repo root.
+
+## Services
+
+### postgres
+- Image: `postgres:16-alpine`
+- Port: `5432`
+- Persistent named volume: `pgdata`
+- Env: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
+- Health check: `pg_isready`
+
+### api
+- Built from `api/Dockerfile`
+- Port: `3000`
+- Source volume-mounted for hot reload (`tsx watch`)
+- Depends on postgres (healthy)
+- On startup: runs `prisma migrate deploy` then `tsx scripts/seed-test-env.ts`
+- Env: `DATABASE_URL`, `JWT_SECRET`, `NODE_ENV=development`
+
+### web
+- Built from `web/Dockerfile` (new)
+- Port: `3001`
+- Source volume-mounted for Next.js hot reload
+- Depends on api
+- Env: `NEXT_PUBLIC_API_URL=http://localhost:3000`, `AUTH_SECRET`, `NEXTAUTH_URL=http://localhost:3001`
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `docker-compose.yml` | Create — root orchestration |
+| `docker-compose.override.yml` | Create — dev overrides (volumes, hot reload) |
+| `api/Dockerfile` | Update — add dev target with tsx watch |
+| `web/Dockerfile` | Create — dev target with Next.js dev server |
+| `.env.example` | Create — document all required env vars |
+| `scripts/dev-up.sh` | Create — convenience script (up + seed) |
+
+## Developer Workflow
+
+```bash
+# First time / fresh start
+cp .env.example .env.local
+docker compose up
+
+# Wipe and restart (DB reset)
+docker compose down -v && docker compose up
+
+# Tail logs
+docker compose logs -f api
+docker compose logs -f web
+
+# Run migrations manually
+docker compose exec api npx prisma migrate dev
+```
+
+## Kai Integration
+
+Update `~/.openclaw/agents/kai/workspace/.env`:
+```
+AI_INSPECTION_API_URL=http://localhost:3000
+```
+
+Kai works against the local stack — no shared test env dependency.
+
+## Environment Variables
+
+```env
+# postgres
+POSTGRES_USER=dev
+POSTGRES_PASSWORD=devpassword
+POSTGRES_DB=ai_inspection
+
+# api
+DATABASE_URL=postgresql://dev:devpassword@postgres:5432/ai_inspection
+JWT_SECRET=dev-jwt-secret-change-in-prod
+NODE_ENV=development
+
+# web
+NEXT_PUBLIC_API_URL=http://localhost:3000
+AUTH_SECRET=dev-auth-secret-change-in-prod
+NEXTAUTH_URL=http://localhost:3001
+```
+
+## Out of Scope
+
+- Production Docker builds (separate concern)
+- Kubernetes local dev (k3d remains for CI/staging)
+- Hot reload for shared package changes (manual rebuild required)
+
+## Acceptance Criteria
+
+- [ ] `docker compose up` starts all three services cleanly from a fresh clone
+- [ ] Migrations run automatically on startup
+- [ ] Test seed data is available (test@example.com / test123)
+- [ ] Web app is accessible at http://localhost:3001 and can log in
+- [ ] API is accessible at http://localhost:3000/health
+- [ ] Hot reload works for both api and web source changes
+- [ ] Kai can complete a full PPI inspection flow against local stack
+- [ ] `docker compose down -v && docker compose up` gives a clean slate

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,46 +1,25 @@
-# ─── Development stage ────────────────────────────────────────────────────────
-FROM node:22-alpine AS dev
+# Development stage — uses host node_modules via volume mount
+FROM casey-api:latest AS dev
 
 WORKDIR /app
 
-# Install deps from monorepo root
-COPY package*.json ./
-COPY shared ./shared/
-COPY web/package*.json ./web/
-
-RUN npm install
-
-# Source is volume-mounted at runtime
 ENV NODE_ENV=development
 ENV PORT=3001
+ENV HOSTNAME=0.0.0.0
 
 EXPOSE 3001
 
-WORKDIR /app/web
-CMD ["npm", "run", "dev", "--", "-p", "3001"]
+CMD ["sh", "-c", "cd /app/web && /app/node_modules/.bin/next dev -p 3001"]
 
-# ─── Build stage ──────────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+# Production stage (future use)
+FROM casey-api:latest AS production
 
 WORKDIR /app
 
-COPY package*.json ./
-COPY shared ./shared/
-COPY web ./web/
-
-RUN npm install
-RUN npm run build --workspace=shared
-RUN npm run build --workspace=web
-
-# ─── Production stage ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS production
-
-WORKDIR /app/web
-
-COPY --from=builder /app/web/.next ./.next
-COPY --from=builder /app/web/public ./public
-COPY --from=builder /app/web/package*.json ./
-COPY --from=builder /app/web/node_modules ./node_modules
+COPY --from=0 /app/web/.next ./.next
+COPY --from=0 /app/web/public ./public
+COPY --from=0 /app/web/package*.json ./
+COPY --from=0 /app/web/node_modules ./node_modules
 
 ENV NODE_ENV=production
 ENV PORT=3001

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,22 +3,21 @@ FROM node:22-alpine AS dev
 
 WORKDIR /app
 
-# Copy package files and prisma schema
+# Install deps from monorepo root
 COPY package*.json ./
-COPY prisma ./prisma/
+COPY shared ./shared/
+COPY web/package*.json ./web/
 
-# Install all deps (including devDependencies)
 RUN npm install
 
-# Source is volume-mounted at runtime — no COPY needed
-# Migrations + seed run via entrypoint script
-
+# Source is volume-mounted at runtime
 ENV NODE_ENV=development
-ENV PORT=3000
+ENV PORT=3001
 
-EXPOSE 3000
+EXPOSE 3001
 
-CMD ["npx", "tsx", "watch", "src/index.ts"]
+WORKDIR /app/web
+CMD ["npm", "run", "dev", "--", "-p", "3001"]
 
 # ─── Build stage ──────────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
@@ -26,27 +25,26 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-COPY prisma ./prisma/
+COPY shared ./shared/
+COPY web ./web/
 
 RUN npm install
-
-COPY . .
-RUN npm run build
+RUN npm run build --workspace=shared
+RUN npm run build --workspace=web
 
 # ─── Production stage ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS production
 
-WORKDIR /app
+WORKDIR /app/web
 
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/tsconfig.json ./tsconfig.json
+COPY --from=builder /app/web/.next ./.next
+COPY --from=builder /app/web/public ./public
+COPY --from=builder /app/web/package*.json ./
+COPY --from=builder /app/web/node_modules ./node_modules
 
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=3001
 
-EXPOSE 3000
+EXPOSE 3001
 
-CMD ["node", "dist/index.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
Closes #670

## Changes
- `api/Dockerfile`: adds `dev` target with `tsx watch` hot reload
- `web/Dockerfile`: new, Next.js dev server with hot reload
- `docker-compose.yml`: orchestrates postgres + api + web
- `api/docker-entrypoint.sh`: waits for postgres, runs migrations, seeds, starts API
- `.env.example`: documents all required env vars
- `docs/developer/design/025-local-dev-containers.md`: design doc

## Usage
```bash
cp .env.example .env
docker compose up
```
- Web: http://localhost:3001
- API: http://localhost:3000/health
- Login: test@example.com / test123