### PR TITLE
fix(web): project detail 404 + RSC infinite loop on projects page

### DIFF
--- a/web/app/admin/service-keys/page.tsx
+++ b/web/app/admin/service-keys/page.tsx
@@ -1,7 +1,8 @@
+import { getApiUrl } from '@/lib/api-url';
 import { auth } from '@/auth';
 import { ServiceKeysClient } from './service-keys-client';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface ServiceKey {
   id: string;

--- a/web/app/projects/[id]/branz-zone-section.tsx
+++ b/web/app/projects/[id]/branz-zone-section.tsx
@@ -1,3 +1,4 @@
+import { getApiUrl } from '@/lib/api-url';
 'use client';
 
 import { useState, useCallback } from 'react';
@@ -5,7 +6,7 @@ import { CollapsibleSection } from '@/components/collapsible-section';
 import { SaveIndicator } from '@/components/save-indicator';
 import { useAutoSave } from '@/hooks/use-auto-save';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface BranzZoneData {
   climateZone: string;

--- a/web/app/projects/[id]/clause-review-section.tsx
+++ b/web/app/projects/[id]/clause-review-section.tsx
@@ -1,9 +1,10 @@
+import { getApiUrl } from '@/lib/api-url';
 'use client';
 
 import { useState, useCallback } from 'react';
 import { CollapsibleSection } from '@/components/collapsible-section';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface ClauseReview {
   id: string;

--- a/web/app/projects/[id]/floor-plans-section.tsx
+++ b/web/app/projects/[id]/floor-plans-section.tsx
@@ -1,9 +1,10 @@
+import { getApiUrl } from '@/lib/api-url';
 'use client';
 
 import { useEffect, useState } from 'react';
 import { CollapsibleSection } from '@/components/collapsible-section';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface FloorPlan {
   id: string;

--- a/web/app/projects/[id]/inspections/[iid]/page.tsx
+++ b/web/app/projects/[id]/inspections/[iid]/page.tsx
@@ -1,7 +1,8 @@
+import { getApiUrl } from '@/lib/api-url';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface PageProps {
   params: Promise<{ id: string; iid: string }>;

--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -1,9 +1,10 @@
+import { getApiUrl } from '@/lib/api-url';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { auth } from '@/auth';
 import { ProjectSections } from './project-sections';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface ProjectPageProps {
   params: Promise<{ id: string }>;

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -1,3 +1,4 @@
+import { getApiUrl } from '@/lib/api-url';
 'use client';
 
 import { useState, useCallback } from 'react';
@@ -10,7 +11,7 @@ import { DocumentList, Document } from '@/components/document-list';
 import { BranzZoneSection } from './branz-zone-section';
 import { FloorPlansSection } from './floor-plans-section';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiUrl();
 
 interface Project {
   id: string;

--- a/web/app/projects/project-filters.tsx
+++ b/web/app/projects/project-filters.tsx
@@ -18,10 +18,12 @@ export function ProjectFilters(): React.ReactElement {
   const [search, setSearch] = useState(searchParams.get('search') || '');
   const status = searchParams.get('status') || '';
 
-  // Debounce search input
+  // Debounce search input — only depend on search value, not searchParams,
+  // to avoid an infinite loop (push → searchParams change → push → ...)
   useEffect(() => {
     const timer = setTimeout(() => {
-      const params = new URLSearchParams(searchParams.toString());
+      // Read searchParams inside the timer to get current value without it being a dep
+      const params = new URLSearchParams(window.location.search);
       if (search) {
         params.set('search', search);
       } else {
@@ -31,7 +33,8 @@ export function ProjectFilters(): React.ReactElement {
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [search, searchParams, router]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
 
   const handleStatusChange = (newStatus: string): void => {
     const params = new URLSearchParams(searchParams.toString());

--- a/web/lib/api-url.ts
+++ b/web/lib/api-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the correct API URL depending on execution context.
+ *
+ * - Server-side (SSR/RSC): uses API_INTERNAL_URL if set (Docker internal hostname)
+ *   so containers can talk to each other via the Docker network.
+ * - Client-side (browser): always uses NEXT_PUBLIC_API_URL (host-accessible URL).
+ */
+export function getApiUrl(): string {
+  // typeof window === 'undefined' means we are server-side
+  if (typeof window === 'undefined') {
+    return (
+      process.env.API_INTERNAL_URL ||
+      process.env.NEXT_PUBLIC_API_URL ||
+      'http://localhost:3000'
+    );
+  }
+  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+}


### PR DESCRIPTION
Closes #672

## Fixes

### 1. Project detail 404 (server-side fetch using wrong host)
Server components were fetching `http://localhost:3000/api/projects/:id` from inside the Docker container — but `localhost` resolves to the web container itself, not the API.

Added `web/lib/api-url.ts` utility:
```ts
export function getApiUrl(): string {
  if (typeof window === 'undefined') {
    return process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
  }
  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
}
```

Applied to all server-side fetch pages (project detail, inspections, admin).

### 2. Infinite RSC polling on /projects
`ProjectFilters` debounce effect depended on `searchParams` in its dep array. Every `router.push()` changed `searchParams`, triggering the effect again → infinite loop.

Fixed by reading `window.location.search` inside the timer (not as a dep) and only depending on `search` value.