### PR TITLE
fix: forward auth token on inspection detail page (#679)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ test-results/
 web/e2e/.auth/
 MEMORY.md
 workspace/MEMORY.md
+
+# Uploads
+data/uploads/
+
+# Build artifacts
+server/dist/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Development stage — uses host node_modules via volume mount
-FROM casey-api:latest AS dev
+FROM node:20-alpine AS dev
 
 
 WORKDIR /app
@@ -30,7 +30,7 @@ EXPOSE 3000
 CMD ["/workspace/node_modules/.bin/tsx", "watch", "src/index.ts"]
 
 # ─── Build stage ──────────────────────────────────────────────────────────────
-FROM casey-api:latest AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -43,7 +43,7 @@ COPY . .
 RUN npm run build
 
 # ─── Production stage ─────────────────────────────────────────────────────────
-FROM casey-api:latest AS production
+FROM node:20-alpine AS production
 
 WORKDIR /app
 

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -8,6 +8,7 @@ done
 sleep 2
 
 echo "Postgres ready. Running migrations..."
+mkdir -p /app/uploads /app/data/uploads
 /workspace/node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma
 
 echo "Seeding test data..."

--- a/api/src/__tests__/photos-public.test.ts
+++ b/api/src/__tests__/photos-public.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const PRESIGNED_URL = 'https://r2.example.com/project-photo.jpg';
+
+vi.mock('../services/r2-storage.js', () => ({
+  isR2Configured: () => true,
+  getPresignedUrl: vi.fn().mockResolvedValue('https://r2.example.com/project-photo.jpg'),
+}));
+
+vi.mock('../services/project-photo.js', () => {
+  class ProjectPhotoNotFoundError extends Error {}
+  class ProjectPhotoService {
+    constructor() {
+      (globalThis as any).__projectPhotoServiceInstance = this;
+    }
+    findById = vi.fn();
+  }
+
+  return {
+    ProjectPhotoService,
+    ProjectPhotoNotFoundError,
+    __getLastInstance: () => (globalThis as any).__projectPhotoServiceInstance,
+  };
+});
+
+import { photosPublicRouter } from '../routes/photos-public.js';
+const projectPhotoModule = await import('../services/project-photo.js') as any;
+import { getPresignedUrl } from '../services/r2-storage.js';
+
+function createApp() {
+  const app = express();
+  app.use('/api/photos', photosPublicRouter);
+  return app;
+}
+
+describe('photos-public project photo file route', () => {
+  beforeEach(() => {
+    const instance = projectPhotoModule.__getLastInstance();
+    if (instance) {
+      instance.findById.mockResolvedValue({
+        id: 'photo-1',
+        filePath: 'photos/project/photo-1.jpg',
+        thumbnailPath: 'photos/project/photo-1_thumb.jpg',
+        mimeType: 'image/jpeg',
+      });
+    }
+    vi.mocked(getPresignedUrl).mockClear();
+  });
+
+  it('redirects to presigned URL for project photo thumbnails', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/photos/photo-1/file?thumbnail=true');
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(PRESIGNED_URL);
+    expect(vi.mocked(getPresignedUrl)).toHaveBeenCalledWith('photos/project/photo-1_thumb.jpg');
+  });
+
+  it('returns 404 when project photo is not found', async () => {
+    const instance = projectPhotoModule.__getLastInstance();
+    instance.findById.mockRejectedValue(new projectPhotoModule.ProjectPhotoNotFoundError('missing'));
+
+    const app = createApp();
+    const response = await request(app).get('/api/photos/missing/file');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/api/src/routes/photos-public.ts
+++ b/api/src/routes/photos-public.ts
@@ -9,13 +9,22 @@ import { logger } from '../lib/logger.js';
  */
 
 import { Router, type Request, type Response, type NextFunction, type Router as RouterType } from 'express';
+import path from 'node:path';
 import { PrismaClient } from '@prisma/client';
 import { PrismaInspectionRepository } from '../repositories/prisma/inspection.js';
+import { PrismaProjectPhotoRepository } from '../repositories/prisma/project-photo.js';
 import { PhotoService, PhotoNotFoundError } from '../services/photo.js';
+import { ProjectPhotoService, ProjectPhotoNotFoundError } from '../services/project-photo.js';
+import { getPresignedUrl, isR2Configured } from '../services/r2-storage.js';
 
 const prisma = new PrismaClient();
 const repository = new PrismaInspectionRepository(prisma);
 const service = new PhotoService(repository);
+const projectPhotoRepository = new PrismaProjectPhotoRepository(prisma);
+const projectPhotoService = new ProjectPhotoService(projectPhotoRepository);
+
+const UPLOAD_DIR = process.env.UPLOAD_DIR || './data/uploads';
+const useR2Storage = isR2Configured();
 
 export const photosPublicRouter: RouterType = Router();
 
@@ -44,6 +53,42 @@ photosPublicRouter.get('/:id', async (req: Request, res: Response, next: NextFun
     res.send(fileBuffer);
   } catch (error) {
     if (error instanceof PhotoNotFoundError) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+});
+// GET /api/photos/:id/file - Serve project photo file (public, no auth)
+photosPublicRouter.get('/:id/file', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = req.params.id as string;
+    const thumbnail = req.query.thumbnail === 'true';
+
+    const photo = await projectPhotoService.findById(id);
+    const storagePath = thumbnail && photo.thumbnailPath
+      ? photo.thumbnailPath
+      : photo.filePath;
+
+    if (useR2Storage) {
+      const presignedUrl = await getPresignedUrl(storagePath);
+      res.redirect(presignedUrl);
+      return;
+    }
+
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    if (photo.mimeType) {
+      res.setHeader('Content-Type', photo.mimeType);
+    }
+
+    res.sendFile(storagePath, { root: path.resolve(UPLOAD_DIR) }, (err) => {
+      if (err) {
+        res.status(404).json({ error: 'File not found' });
+      }
+    });
+  } catch (error) {
+    if (error instanceof ProjectPhotoNotFoundError) {
       res.status(404).json({ error: error.message });
       return;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - ./node_modules:/workspace/node_modules
       - ./test:/workspace/test
       - api_uploads:/app/uploads
+      - api_data_uploads:/app/data/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -80,3 +81,4 @@ services:
 volumes:
   pgdata:
   api_uploads:
+  api_data_uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - ./node_modules:/workspace/node_modules
       - ./test:/workspace/test
       - api_uploads:/app/uploads
-      - api_data_uploads:/app/data/uploads
+      - ./data/uploads:/app/data/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,4 +81,3 @@ services:
 volumes:
   pgdata:
   api_uploads:
-  api_data_uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,9 @@ services:
       - "3001:3001"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:3000
+      API_INTERNAL_URL: http://api:3000
       AUTH_SECRET: ${AUTH_SECRET:-dev-auth-secret}
       NEXTAUTH_URL: http://localhost:3001
-      API_INTERNAL_URL: http://api:3000
       NODE_ENV: development
     volumes:
       - ./web:/app/web

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.3.1
+version: 3.4.0
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -247,20 +247,29 @@ Default when no severity given: `MONITOR`.
 
 ### Section 1 — Site & Ground (`SITE`)
 
-> "📍 **Site & Ground** — let's start outside."
+> "📍 **Site & Ground** — let's start outside.
+>
+> Categories:
+> 1️⃣ Topography & Drainage
+> 2️⃣ Boundaries & Retaining
+> 3️⃣ Fencing & Gates
+> 4️⃣ Access Paths & Driveways
+> 5️⃣ Garden & Landscaping
+>
+> Which do you want to start with?"
 
-Elements (one at a time):
+Inspector picks any order. For each category, cover the relevant elements:
 
-1. **Topography** — slope, drainage away from building, ponding
-2. **Boundaries** — fence lines, encroachments
-3. **Retaining walls** — height, condition, drainage behind
-4. **Fencing & gates** — condition, security
-5. **Access paths** — condition, slip hazard
-6. **Driveways** — surface, drainage, condition
-7. **Garden & landscaping** — proximity to cladding, vegetation contact
+- **Topography & Drainage** — slope, drainage away from building, ponding
+- **Boundaries & Retaining** — fence lines, encroachments; retaining wall height, condition, drainage behind
+- **Fencing & Gates** — condition, security
+- **Access Paths & Driveways** — condition, slip hazard, surface, drainage
+- **Garden & Landscaping** — proximity to cladding, vegetation contact
 
-For each:
-> "**{Element}** — what's the condition? (pass / [description] / skip)"
+When inspector picks a category, prompt only for that category:
+> "**{Category}** — what's the condition? (pass / [description] / skip)"
+
+Once all categories are done (inspector says "done" or Kai detects all covered), move to section conclusion.
 
 ```bash
 curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/checklist-items" \
@@ -292,27 +301,25 @@ curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/section-conclusions"
 
 ### Section 2 — Exterior (`EXTERIOR`)
 
-> "🏠 **Exterior** — working around the building."
+> "🏠 **Exterior** — working around the building.
+>
+> Categories:
+> 1️⃣ Roof
+> 2️⃣ Cladding & Sealants
+> 3️⃣ Joinery
+> 4️⃣ Foundation
+>
+> Which do you want to start with?"
 
-**Roof:**
-1. Roof covering — type, condition, damage
-2. Roof structure — sagging, visible damage
-3. Flashings — ridges, hips, penetrations
-4. Gutters — rust, leaks, blockages, falls
-5. Downpipes — connected, discharging correctly
+Inspector picks any order. For each category, cover the relevant elements:
 
-**Cladding:**
-6. Cladding type & condition — cracks, gaps, weathertightness, paint
-7. Penetrations & sealants — around windows, pipes, service entries
-8. Cladding/wall junctions — sealed, flashed
+- **Roof** — covering type/condition/damage; structure sagging; flashings; gutters; downpipes
+- **Cladding & Sealants** — cladding type/condition; penetrations/sealants; wall junctions
+- **Joinery** — glazing type; hardware/operation; window restrictors
+- **Foundation** — type, condition, cracking, settlement, moisture
 
-**Joinery:**
-9. Glazing type — single/double/thermally broken
-10. Hardware & operation — latches, hinges, locks
-11. Restrictors — present on upper floor windows
-
-**Foundation:**
-12. Foundation type & condition — cracking, settlement, moisture
+When inspector picks a category:
+> "**{Category}** — what did you find? (pass / [description] / skip)"
 
 Record each with `category: "EXTERIOR"` (no `room` field).
 
@@ -435,22 +442,31 @@ curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/section-conclusions"
 
 ### Section 4 — Services (`SERVICES`)
 
-> "🔌 **Services** — checking all building systems."
+> "🔌 **Services** — checking all building systems.
+>
+> Categories:
+> 1️⃣ Electrical (power, internet)
+> 2️⃣ Plumbing (water supply, hot water, drainage)
+> 3️⃣ Gas
+> 4️⃣ Safety (smoke alarms, security)
+> 5️⃣ Comfort (ventilation, heat pump)
+> 6️⃣ Stormwater
+>
+> Which do you want to start with?"
 
-1. Power — switchboard, RCDs, visible wiring
-2. Internet / fibre — connection type, install quality
-3. Water supply (potable) — pressure, pipe condition
-4. Water supply (non-potable) — tank, pump, treatment
-5. Hot water — type, condition, temperature relief valve
-6. Gas — meter, pipework, appliances
-7. Drainage — waste pipes, access, condition
-8. Security system — type, condition (not tested)
-9. Smoke alarms — present, location, type, tested
-10. Ventilation — bathroom/kitchen extractors, HRV/DVS
-11. Heat pump — present, type, condition
-12. Stormwater — downpipe connections, soakage, discharge
+Inspector picks any order. For each category:
 
-Note limitations (e.g. gas not testable if disconnected; stormwater impractical with <3 days rain).
+- **Electrical** — switchboard, RCDs, visible wiring; internet/fibre install quality
+- **Plumbing** — water supply pressure/condition; non-potable tank/pump; hot water type/condition/TRV; drainage waste pipes/access
+- **Gas** — meter, pipework, appliances (note if disconnected/untestable)
+- **Safety** — smoke alarms present/location/type/tested; security system type/condition
+- **Comfort** — bathroom/kitchen extractors, HRV/DVS; heat pump type/condition
+- **Stormwater** — downpipe connections, soakage, discharge (note if <3 days rain)
+
+When inspector picks a category:
+> "**{Category}** — what did you find? (pass / [description] / skip)"
+
+Note limitations per category as applicable.
 
 **Section conclusion:**
 
@@ -594,6 +610,7 @@ curl "$API_URL/api/site-inspections/{INSPECTION_ID}" \
 4. **Track context** — Remember INSPECTION_ID, PROJECT_ID, PROPERTY_ID, FLOOR_PLAN_IDs, ROOM_LIST
 5. **Handle photos** — Convert WhatsApp images to base64 for API
 6. **Floor plan is the spine** — Walk interior in floor plan order
+9. **Category-led sections** — Present category menu at section start; inspector picks order based on site convenience. Never force a fixed sequence.
 7. **Moisture inline** — Capture readings immediately, never defer
 8. **One conclusion per section** — Always prompt before moving on
 

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.4.3
+version: 3.4.4
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -40,7 +40,17 @@ List them to the inspector:
 >
 > Continue one of these, or start a new project?"
 
-- If inspector picks an existing project → save as `PROJECT_ID` and its `propertyId` as `PROPERTY_ID`, skip to Step 5 (Create Site Inspection)
+- If inspector picks an existing project → save as `PROJECT_ID` and its `propertyId` as `PROPERTY_ID`, then **immediately fetch existing floor plans and inspection**:
+
+```bash
+curl "$API_URL/api/projects/{PROJECT_ID}/floor-plans" \
+  -H "X-API-Key: $API_SERVICE_KEY"
+```
+
+Save each floor plan `id` as `FLOOR_PLAN_ID_{N}`. Build `ROOM_LIST` from rooms across all floors in floor order. If floor plans exist, confirm to inspector:
+> "Got floor plans: Floor 1 ({rooms}), Floor 2 ({rooms})..."
+
+Then skip to Step 5 (Create Site Inspection) or pick up existing inspection if already created.
 - If inspector wants a new project → proceed to Step 2
 
 #### Branch B — Nothing found

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.4.2
+version: 3.4.3
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -266,22 +266,19 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Access Paths & Driveways** — condition, slip hazard, surface, drainage
 - **Garden & Landscaping** — proximity to cladding, vegetation contact
 
-After each category is submitted, show what's covered and what's remaining — then stop and wait:
-> "✅ Covered: {done list}
+After each category is submitted, show progress and remaining **names only** — no descriptions — then STOP:
+> "✅ {Done category 1}, {Done category 2}
 >
-> Still to go:
-> • {Remaining category 1}
-> • {Remaining category 2}
-> ...
+> Still to go: {Remaining 1} · {Remaining 2} · {Remaining 3}
 >
-> Which next? (or 'done' to wrap up)"
+> Which next?"
 
-**Do NOT ask about a specific category.** Wait for the inspector to choose.
+⛔ **STOP here. Do not ask about any specific category. Do not add any follow-up question. Wait silently for the inspector to reply.**
 
-When inspector names or picks a category:
-> "**{Category}** — what's the condition? (pass / [description] / skip)"
+When inspector names or picks a category, THEN prompt:
+> "**{Category}** — condition? (pass / [description] / skip)"
 
-Keep presenting the remaining menu after each until all are covered or inspector says "done".
+Repeat after each category until all done or inspector says "done".
 
 ```bash
 curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/checklist-items" \
@@ -330,21 +327,19 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Joinery** — glazing type; hardware/operation; window restrictors
 - **Foundation** — type, condition, cracking, settlement, moisture
 
-After each category, show covered/remaining and wait:
-> "✅ Covered: {done list}
+After each category, show progress **names only** — no descriptions — then STOP:
+> "✅ {Done category 1}, {Done category 2}
 >
-> Still to go:
-> • {Remaining category 1}
-> ...
+> Still to go: {Remaining 1} · {Remaining 2}
 >
-> Which next? (or 'done' to wrap up)"
+> Which next?"
 
-**Do NOT ask about a specific category.** Wait for the inspector to choose.
+⛔ **STOP here. Do not ask about any specific category. Wait for inspector to reply.**
 
-When inspector picks a category:
+When inspector picks a category, THEN prompt:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
 
-Keep presenting remaining menu after each until all covered or inspector says "done".
+Repeat after each until all done or inspector says "done".
 
 Record each with `category: "EXTERIOR"` (no `room` field).
 
@@ -488,21 +483,19 @@ Inspector picks any order. For each category:
 - **Comfort** — bathroom/kitchen extractors, HRV/DVS; heat pump type/condition
 - **Stormwater** — downpipe connections, soakage, discharge (note if <3 days rain)
 
-After each category, show covered/remaining and wait:
-> "✅ Covered: {done list}
+After each category, show progress **names only** — no descriptions — then STOP:
+> "✅ {Done category 1}, {Done category 2}
 >
-> Still to go:
-> • {Remaining category 1}
-> ...
+> Still to go: {Remaining 1} · {Remaining 2}
 >
-> Which next? (or 'done' to wrap up)"
+> Which next?"
 
-**Do NOT ask about a specific category.** Wait for the inspector to choose.
+⛔ **STOP here. Do not ask about any specific category. Wait for inspector to reply.**
 
-When inspector picks a category:
+When inspector picks a category, THEN prompt:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
 
-Keep presenting remaining menu after each until all covered or inspector says "done".
+Repeat after each until all done or inspector says "done".
 
 Note limitations per category as applicable.
 

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.4.0
+version: 3.4.1
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -266,10 +266,13 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Access Paths & Driveways** — condition, slip hazard, surface, drainage
 - **Garden & Landscaping** — proximity to cladding, vegetation contact
 
-When inspector picks a category, prompt only for that category:
+After each category is submitted, show the remaining categories and ask what's next:
+> "Got it. Remaining: 2️⃣ Boundaries & Retaining, 3️⃣ Fencing & Gates, 4️⃣ Access Paths & Driveways, 5️⃣ Garden & Landscaping — which next?"
+
+When inspector picks a category:
 > "**{Category}** — what's the condition? (pass / [description] / skip)"
 
-Once all categories are done (inspector says "done" or Kai detects all covered), move to section conclusion.
+Keep presenting the remaining menu after each until all are covered. Inspector can say "done" to skip remaining categories and move to section conclusion.
 
 ```bash
 curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/checklist-items" \
@@ -318,8 +321,13 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Joinery** — glazing type; hardware/operation; window restrictors
 - **Foundation** — type, condition, cracking, settlement, moisture
 
+After each category, show remaining and ask what's next:
+> "Got it. Remaining: [list remaining categories] — which next?"
+
 When inspector picks a category:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
+
+Keep presenting remaining menu after each until all covered. Inspector can say "done" to skip to section conclusion.
 
 Record each with `category: "EXTERIOR"` (no `room` field).
 
@@ -463,8 +471,13 @@ Inspector picks any order. For each category:
 - **Comfort** — bathroom/kitchen extractors, HRV/DVS; heat pump type/condition
 - **Stormwater** — downpipe connections, soakage, discharge (note if <3 days rain)
 
+After each category, show remaining and ask what's next:
+> "Got it. Remaining: [list remaining categories] — which next?"
+
 When inspector picks a category:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
+
+Keep presenting remaining menu after each until all covered. Inspector can say "done" to skip to section conclusion.
 
 Note limitations per category as applicable.
 

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.4.1
+version: 3.4.2
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -266,13 +266,22 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Access Paths & Driveways** — condition, slip hazard, surface, drainage
 - **Garden & Landscaping** — proximity to cladding, vegetation contact
 
-After each category is submitted, show the remaining categories and ask what's next:
-> "Got it. Remaining: 2️⃣ Boundaries & Retaining, 3️⃣ Fencing & Gates, 4️⃣ Access Paths & Driveways, 5️⃣ Garden & Landscaping — which next?"
+After each category is submitted, show what's covered and what's remaining — then stop and wait:
+> "✅ Covered: {done list}
+>
+> Still to go:
+> • {Remaining category 1}
+> • {Remaining category 2}
+> ...
+>
+> Which next? (or 'done' to wrap up)"
 
-When inspector picks a category:
+**Do NOT ask about a specific category.** Wait for the inspector to choose.
+
+When inspector names or picks a category:
 > "**{Category}** — what's the condition? (pass / [description] / skip)"
 
-Keep presenting the remaining menu after each until all are covered. Inspector can say "done" to skip remaining categories and move to section conclusion.
+Keep presenting the remaining menu after each until all are covered or inspector says "done".
 
 ```bash
 curl -X POST "$API_URL/api/site-inspections/{INSPECTION_ID}/checklist-items" \
@@ -321,13 +330,21 @@ Inspector picks any order. For each category, cover the relevant elements:
 - **Joinery** — glazing type; hardware/operation; window restrictors
 - **Foundation** — type, condition, cracking, settlement, moisture
 
-After each category, show remaining and ask what's next:
-> "Got it. Remaining: [list remaining categories] — which next?"
+After each category, show covered/remaining and wait:
+> "✅ Covered: {done list}
+>
+> Still to go:
+> • {Remaining category 1}
+> ...
+>
+> Which next? (or 'done' to wrap up)"
+
+**Do NOT ask about a specific category.** Wait for the inspector to choose.
 
 When inspector picks a category:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
 
-Keep presenting remaining menu after each until all covered. Inspector can say "done" to skip to section conclusion.
+Keep presenting remaining menu after each until all covered or inspector says "done".
 
 Record each with `category: "EXTERIOR"` (no `room` field).
 
@@ -471,13 +488,21 @@ Inspector picks any order. For each category:
 - **Comfort** — bathroom/kitchen extractors, HRV/DVS; heat pump type/condition
 - **Stormwater** — downpipe connections, soakage, discharge (note if <3 days rain)
 
-After each category, show remaining and ask what's next:
-> "Got it. Remaining: [list remaining categories] — which next?"
+After each category, show covered/remaining and wait:
+> "✅ Covered: {done list}
+>
+> Still to go:
+> • {Remaining category 1}
+> ...
+>
+> Which next? (or 'done' to wrap up)"
+
+**Do NOT ask about a specific category.** Wait for the inspector to choose.
 
 When inspector picks a category:
 > "**{Category}** — what did you find? (pass / [description] / skip)"
 
-Keep presenting remaining menu after each until all covered. Inspector can say "done" to skip to section conclusion.
+Keep presenting remaining menu after each until all covered or inspector says "done".
 
 Note limitations per category as applicable.
 

--- a/skills/building-inspection/SKILL.md
+++ b/skills/building-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-inspection
-version: 3.4.4
+version: 3.5.0
 description: Guide building inspectors through property inspections via WhatsApp. Supports PPI, COA, CCC, and Safe & Sanitary inspection types. Always searches for existing property/project before creating new ones.
 ---
 
@@ -40,17 +40,45 @@ List them to the inspector:
 >
 > Continue one of these, or start a new project?"
 
-- If inspector picks an existing project → save as `PROJECT_ID` and its `propertyId` as `PROPERTY_ID`, then **immediately fetch existing floor plans and inspection**:
+- If inspector picks an existing project → save as `PROJECT_ID` and its `propertyId` as `PROPERTY_ID`, then **immediately load full project state** by running all of these in parallel:
 
 ```bash
+# 1. Floor plans
 curl "$API_URL/api/projects/{PROJECT_ID}/floor-plans" \
+  -H "X-API-Key: $API_SERVICE_KEY"
+
+# 2. Most recent inspection
+curl "$API_URL/api/projects/{PROJECT_ID}/inspections" \
+  -H "X-API-Key: $API_SERVICE_KEY"
+
+# 3. Upfront data already collected
+curl "$API_URL/api/project-requirements/{reportType}?projectId={PROJECT_ID}" \
   -H "X-API-Key: $API_SERVICE_KEY"
 ```
 
-Save each floor plan `id` as `FLOOR_PLAN_ID_{N}`. Build `ROOM_LIST` from rooms across all floors in floor order. If floor plans exist, confirm to inspector:
-> "Got floor plans: Floor 1 ({rooms}), Floor 2 ({rooms})..."
+Then if an inspection exists, also fetch:
+```bash
+# 4. Section conclusions (what sections are done)
+curl "$API_URL/api/site-inspections/{INSPECTION_ID}/section-conclusions" \
+  -H "X-API-Key: $API_SERVICE_KEY"
 
-Then skip to Step 5 (Create Site Inspection) or pick up existing inspection if already created.
+# 5. Checklist summary (what items are recorded per section)
+curl "$API_URL/api/site-inspections/{INSPECTION_ID}/checklist-summary" \
+  -H "X-API-Key: $API_SERVICE_KEY"
+```
+
+Save `INSPECTION_ID`, all `FLOOR_PLAN_ID_{N}`, and build `ROOM_LIST` from floor plan rooms in floor order.
+
+Present a resume summary to the inspector:
+> "📋 **Picked up Job {jobNumber}**
+>
+> 🗺 Floor plans: {N} floors — {room count} rooms
+> 📝 Upfront data: {collected items} ✅ / {missing items} ⬜
+> 🔍 Sections: {done sections} ✅ / {remaining sections} ⬜
+>
+> Where do you want to continue?"
+
+Wait for inspector to direct which section/area to resume from. Do not assume or auto-advance.
 - If inspector wants a new project → proceed to Step 2
 
 #### Branch B — Nothing found

--- a/test/e2e/project-detail.spec.ts
+++ b/test/e2e/project-detail.spec.ts
@@ -129,6 +129,17 @@ test.describe('Project Detail — Collapsible Sections', () => {
     await expect(page.getByRole('heading', { name: 'Site Data (BRANZ Maps)', level: 2 })).toBeVisible();
   });
 
+  test('should display Floor Plans section with thumbnails', async ({ authenticatedPage: page }) => {
+    await goToTestProject(page);
+
+    await expect(page.getByRole('heading', { name: 'Floor Plans', level: 2 })).toBeVisible();
+
+    const floorPlansSection = page.locator('#section-content-floor-plans');
+    const thumbnails = floorPlansSection.locator('img');
+    await expect(thumbnails.first()).toBeVisible();
+    await expect(thumbnails.first()).toHaveAttribute('src', /\/api\/photos\/.+\/file\?thumbnail=true/);
+  });
+
   test('should display Documents section', async ({ authenticatedPage: page }) => {
     await goToTestProject(page);
 

--- a/test/scripts/seed-test-env.ts
+++ b/test/scripts/seed-test-env.ts
@@ -15,6 +15,9 @@
 
 import { PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+import * as fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
 
 const prisma = new PrismaClient();
 
@@ -42,6 +45,84 @@ async function seedTestUser(): Promise<void> {
   console.log(`✅ Test user ready: ${TEST_EMAIL} (id: ${user.id})`);
 }
 
+
+const FLOORPLAN_IMAGE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+function resolveUploadDir(): string {
+  if (process.env.UPLOAD_DIR) return process.env.UPLOAD_DIR;
+  const dockerPath = '/app/data/uploads';
+  if (existsSync(dockerPath)) {
+    return dockerPath;
+  }
+  return path.resolve(process.cwd(), '../data/uploads');
+}
+
+async function ensureFloorPlanForProject(projectId: string): Promise<void> {
+  const existingPhoto = await prisma.projectPhoto.findFirst({
+    where: { projectId },
+    orderBy: { reportNumber: 'asc' },
+  });
+
+  let projectPhotoId = existingPhoto?.id;
+
+  if (!existingPhoto) {
+    const uploadDir = resolveUploadDir();
+    const projectDir = path.join(uploadDir, 'photos', projectId);
+    await fs.mkdir(projectDir, { recursive: true });
+
+    const fileName = 'floor-plan-test.jpg';
+    const thumbName = 'floor-plan-test_thumb.jpg';
+    const filePath = path.join(projectDir, fileName);
+    const thumbPath = path.join(projectDir, thumbName);
+    const buffer = Buffer.from(FLOORPLAN_IMAGE_BASE64, 'base64');
+
+    await fs.writeFile(filePath, buffer);
+    await fs.writeFile(thumbPath, buffer);
+
+    const relativeFilePath = path.join('photos', projectId, fileName);
+    const relativeThumbPath = path.join('photos', projectId, thumbName);
+
+    const createdPhoto = await prisma.projectPhoto.create({
+      data: {
+        projectId,
+        reportNumber: 1,
+        sortOrder: 0,
+        filePath: relativeFilePath,
+        thumbnailPath: relativeThumbPath,
+        mimeType: 'image/jpeg',
+        fileSize: buffer.length,
+        caption: 'Floor Plan',
+        source: 'OWNER',
+        linkedClauses: [],
+      },
+    });
+
+    projectPhotoId = createdPhoto.id;
+  }
+
+  const existingFloorPlan = await prisma.floorPlan.findFirst({
+    where: { projectId },
+    orderBy: { floor: 'asc' },
+  });
+
+  if (!existingFloorPlan) {
+    await prisma.floorPlan.create({
+      data: {
+        projectId,
+        floor: 1,
+        label: 'Ground Floor',
+        rooms: ['Living', 'Kitchen'],
+        photoIds: projectPhotoId ? [projectPhotoId] : [],
+      },
+    });
+  } else if (projectPhotoId && existingFloorPlan.photoIds.length === 0) {
+    await prisma.floorPlan.update({
+      where: { id: existingFloorPlan.id },
+      data: { photoIds: [projectPhotoId] },
+    });
+  }
+}
+
 async function seedTestProject(): Promise<void> {
   // Check if test project exists by job number
   const testJobNumber = 'TEST-001';
@@ -51,6 +132,7 @@ async function seedTestProject(): Promise<void> {
 
   if (existing) {
     console.log(`✅ Test project exists: ${testJobNumber} (id: ${existing.id})`);
+    await ensureFloorPlanForProject(existing.id);
     return;
   }
 
@@ -105,6 +187,7 @@ async function seedTestProject(): Promise<void> {
   });
 
   console.log(`✅ Test project created: ${testJobNumber} (id: ${project.id})`);
+  await ensureFloorPlanForProject(project.id);
 }
 
 async function main(): Promise<void> {

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Development stage
-FROM casey-api:latest AS dev
+FROM node:20-alpine AS dev
 
 WORKDIR /app
 

--- a/web/app/admin/service-keys/page.tsx
+++ b/web/app/admin/service-keys/page.tsx
@@ -1,5 +1,5 @@
 import { getApiUrl } from '@/lib/api-url';
-import { auth } from '@/auth';
+import { getServerToken } from '@/lib/server-api';
 import { ServiceKeysClient } from './service-keys-client';
 
 const API_URL = getApiUrl();
@@ -28,9 +28,7 @@ async function getServiceKeys(token: string): Promise<ServiceKey[]> {
 }
 
 export default async function ServiceKeysPage(): Promise<React.ReactElement> {
-  const session = await auth();
-  // @ts-expect-error apiToken is added via extended session
-  const token: string = session?.apiToken ?? '';
+  const token = await getServerToken() ?? '';
 
   const keys = await getServiceKeys(token);
 

--- a/web/app/projects/[id]/floor-plans-section.tsx
+++ b/web/app/projects/[id]/floor-plans-section.tsx
@@ -70,9 +70,22 @@ export function FloorPlansSection({ projectId, authToken }: FloorPlansSectionPro
               <p className="text-xs text-gray-400 italic">No rooms listed</p>
             )}
             {plan.photoIds.length > 0 && (
-              <p className="mt-2 text-xs text-gray-400">
-                📎 {plan.photoIds.length} photo{plan.photoIds.length !== 1 ? 's' : ''}
-              </p>
+              <>
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  {plan.photoIds.map((photoId) => (
+                    <img
+                      key={photoId}
+                      src={`${API_URL}/api/photos/${photoId}/file?thumbnail=true`}
+                      alt={plan.label || `Floor ${plan.floor}`}
+                      className="h-32 w-full rounded border border-gray-200 object-cover"
+                      loading="lazy"
+                    />
+                  ))}
+                </div>
+                <p className="mt-2 text-xs text-gray-400">
+                  📎 {plan.photoIds.length} photo{plan.photoIds.length !== 1 ? 's' : ''}
+                </p>
+              </>
             )}
           </div>
         ))}

--- a/web/app/projects/[id]/inspections/[iid]/page.tsx
+++ b/web/app/projects/[id]/inspections/[iid]/page.tsx
@@ -1,9 +1,7 @@
-import { getApiUrl } from '@/lib/api-url';
-import { auth } from '@/auth';
+import { getServerToken, serverFetch, serverFetchList } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 
-const API_URL = getApiUrl();
 
 interface PageProps {
   params: Promise<{ id: string; iid: string }>;
@@ -69,39 +67,22 @@ const DECISION_COLORS: Record<string, string> = {
 };
 
 async function getSiteInspection(id: string, token?: string): Promise<SiteInspection | null> {
-  const response = await fetch(`${API_URL}/api/site-inspections/${id}`, {
-    cache: 'no-store',
-    headers: { ...(token && { Authorization: `Bearer ${token}` }) },
-  });
-  if (!response.ok) return null;
-  return response.json();
+  return serverFetch<SiteInspection>(`/api/site-inspections/${id}`, token);
 }
 
 async function getProject(id: string, token?: string): Promise<Project | null> {
-  const response = await fetch(`${API_URL}/api/projects/${id}`, {
-    cache: 'no-store',
-    headers: { ...(token && { Authorization: `Bearer ${token}` }) },
-  });
-  if (!response.ok) return null;
-  return response.json();
+  return serverFetch<Project>(`/api/projects/${id}`, token);
 }
 
 async function getChecklistItems(inspectionId: string, token?: string): Promise<ChecklistItem[]> {
-  const response = await fetch(
-    `${API_URL}/api/site-inspections/${inspectionId}/checklist-items`,
-    { cache: 'no-store', headers: { ...(token && { Authorization: `Bearer ${token}` }) } }
-  );
-  if (!response.ok) return [];
-  return response.json();
+  return serverFetchList<ChecklistItem>(`/api/site-inspections/${inspectionId}/checklist-items`, token);
 }
 
 async function getClauseReviews(inspectionId: string, token?: string): Promise<ClauseReview[]> {
-  const response = await fetch(
-    `${API_URL}/api/site-inspections/${inspectionId}/clause-reviews`,
-    { cache: 'no-store', headers: { ...(token && { Authorization: `Bearer ${token}` }) } }
+  const data = await serverFetch<ClauseReview[] | { reviews: ClauseReview[] }>(
+    `/api/site-inspections/${inspectionId}/clause-reviews`, token
   );
-  if (!response.ok) return [];
-  const data = await response.json();
+  if (!data) return [];
   return Array.isArray(data) ? data : data.reviews ?? [];
 }
 
@@ -124,8 +105,7 @@ function groupBy<T>(arr: T[], key: (item: T) => string): Record<string, T[]> {
 
 export async function generateMetadata({ params }: PageProps): Promise<{ title: string }> {
   const { iid } = await params;
-  const session = await auth();
-  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const token = await getServerToken();
   const inspection = await getSiteInspection(iid, token);
   if (!inspection) return { title: 'Inspection Not Found | AI Inspection' };
   return { title: `${inspection.stage} Inspection | AI Inspection` };
@@ -133,8 +113,7 @@ export async function generateMetadata({ params }: PageProps): Promise<{ title: 
 
 export default async function InspectionDetailPage({ params }: PageProps): Promise<React.ReactElement> {
   const { id, iid } = await params;
-  const session = await auth();
-  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const token = await getServerToken();
 
   const [inspection, project] = await Promise.all([
     getSiteInspection(iid, token),

--- a/web/app/projects/[id]/inspections/[iid]/page.tsx
+++ b/web/app/projects/[id]/inspections/[iid]/page.tsx
@@ -1,4 +1,5 @@
 import { getApiUrl } from '@/lib/api-url';
+import { auth } from '@/auth';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 
@@ -67,35 +68,37 @@ const DECISION_COLORS: Record<string, string> = {
   NA: 'text-gray-400',
 };
 
-async function getSiteInspection(id: string): Promise<SiteInspection | null> {
+async function getSiteInspection(id: string, token?: string): Promise<SiteInspection | null> {
   const response = await fetch(`${API_URL}/api/site-inspections/${id}`, {
     cache: 'no-store',
+    headers: { ...(token && { Authorization: `Bearer ${token}` }) },
   });
   if (!response.ok) return null;
   return response.json();
 }
 
-async function getProject(id: string): Promise<Project | null> {
+async function getProject(id: string, token?: string): Promise<Project | null> {
   const response = await fetch(`${API_URL}/api/projects/${id}`, {
     cache: 'no-store',
+    headers: { ...(token && { Authorization: `Bearer ${token}` }) },
   });
   if (!response.ok) return null;
   return response.json();
 }
 
-async function getChecklistItems(inspectionId: string): Promise<ChecklistItem[]> {
+async function getChecklistItems(inspectionId: string, token?: string): Promise<ChecklistItem[]> {
   const response = await fetch(
     `${API_URL}/api/site-inspections/${inspectionId}/checklist-items`,
-    { cache: 'no-store' }
+    { cache: 'no-store', headers: { ...(token && { Authorization: `Bearer ${token}` }) } }
   );
   if (!response.ok) return [];
   return response.json();
 }
 
-async function getClauseReviews(inspectionId: string): Promise<ClauseReview[]> {
+async function getClauseReviews(inspectionId: string, token?: string): Promise<ClauseReview[]> {
   const response = await fetch(
     `${API_URL}/api/site-inspections/${inspectionId}/clause-reviews`,
-    { cache: 'no-store' }
+    { cache: 'no-store', headers: { ...(token && { Authorization: `Bearer ${token}` }) } }
   );
   if (!response.ok) return [];
   const data = await response.json();
@@ -121,24 +124,29 @@ function groupBy<T>(arr: T[], key: (item: T) => string): Record<string, T[]> {
 
 export async function generateMetadata({ params }: PageProps): Promise<{ title: string }> {
   const { iid } = await params;
-  const inspection = await getSiteInspection(iid);
+  const session = await auth();
+  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const inspection = await getSiteInspection(iid, token);
   if (!inspection) return { title: 'Inspection Not Found | AI Inspection' };
   return { title: `${inspection.stage} Inspection | AI Inspection` };
 }
 
 export default async function InspectionDetailPage({ params }: PageProps): Promise<React.ReactElement> {
   const { id, iid } = await params;
+  const session = await auth();
+  const token = (session as { apiToken?: string } | null)?.apiToken;
+
   const [inspection, project] = await Promise.all([
-    getSiteInspection(iid),
-    getProject(id),
+    getSiteInspection(iid, token),
+    getProject(id, token),
   ]);
 
   if (!inspection) notFound();
 
   const isSimple = inspection.type === 'SIMPLE';
   const [checklistItems, clauseReviews] = await Promise.all([
-    isSimple ? getChecklistItems(iid) : Promise.resolve([]),
-    !isSimple ? getClauseReviews(iid) : Promise.resolve([]),
+    isSimple ? getChecklistItems(iid, token) : Promise.resolve([]),
+    !isSimple ? getClauseReviews(iid, token) : Promise.resolve([]),
   ]);
 
   const address = project?.property.streetAddress ?? id;

--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -1,10 +1,8 @@
-import { getApiUrl } from '@/lib/api-url';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { auth } from '@/auth';
+import { getServerToken, serverFetch } from '@/lib/server-api';
 import { ProjectSections } from './project-sections';
 
-const API_URL = getApiUrl();
 
 interface ProjectPageProps {
   params: Promise<{ id: string }>;
@@ -79,21 +77,7 @@ interface Project {
 
 async function getProject(id: string, token?: string): Promise<Project | null> {
   try {
-    const response = await fetch(`${API_URL}/api/projects/${id}`, {
-      cache: 'no-store',
-      headers: {
-        ...(token && { Authorization: `Bearer ${token}` }),
-      },
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        return null;
-      }
-      throw new Error(`Failed to fetch project: ${response.status}`);
-    }
-
-    return response.json();
+    return await serverFetch<Project>(`/api/projects/${id}`, token);
   } catch (error) {
     console.error('Error fetching project:', error);
     return null;
@@ -124,8 +108,7 @@ const REPORT_TYPE_LABELS: Record<string, string> = {
 
 export async function generateMetadata({ params }: ProjectPageProps): Promise<{ title: string }> {
   const { id } = await params;
-  const session = await auth();
-  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const token = await getServerToken();
   const project = await getProject(id, token);
   
   if (!project) {
@@ -139,8 +122,7 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<{ 
 
 export default async function ProjectPage({ params }: ProjectPageProps): Promise<React.ReactElement> {
   const { id } = await params;
-  const session = await auth();
-  const token = (session as { apiToken?: string } | null)?.apiToken;
+  const token = await getServerToken();
   const project = await getProject(id, token);
 
   if (!project) {

--- a/web/lib/server-api.ts
+++ b/web/lib/server-api.ts
@@ -1,0 +1,68 @@
+/**
+ * Server-side API helper
+ *
+ * Use this for ALL server-side fetches (RSC, generateMetadata, etc.).
+ * Handles:
+ *   - Correct API URL (API_INTERNAL_URL inside Docker, NEXT_PUBLIC_API_URL for local dev)
+ *   - Auth token injection
+ *   - Consistent error handling
+ *
+ * Usage:
+ *   const token = await getServerToken();
+ *   const project = await serverFetch<Project>(`/api/projects/${id}`, token);
+ */
+
+import { auth } from '@/auth';
+import { getApiUrl } from '@/lib/api-url';
+
+type Session = { apiToken?: string } | null;
+
+/**
+ * Extract API token from session. Call once at the top of your page/metadata fn.
+ */
+export async function getServerToken(): Promise<string | undefined> {
+  const session = (await auth()) as Session;
+  return session?.apiToken;
+}
+
+/**
+ * Server-side fetch with auth token and correct base URL.
+ * Returns null on 404, throws on other errors.
+ */
+export async function serverFetch<T>(
+  path: string,
+  token?: string,
+  init?: RequestInit
+): Promise<T | null> {
+  const url = `${getApiUrl()}${path}`;
+  const res = await fetch(url, {
+    cache: 'no-store',
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers as Record<string, string> | undefined),
+    },
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`API error ${res.status} for ${path}`);
+  if (res.status === 204) return null;
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Server-side fetch that returns [] on failure (for list endpoints).
+ */
+export async function serverFetchList<T>(
+  path: string,
+  token?: string,
+  init?: RequestInit
+): Promise<T[]> {
+  try {
+    const result = await serverFetch<T[]>(path, token, init);
+    return result ?? [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Fixes #679\n\nServer-side fetches in the inspection detail page now forward the session API token via `Authorization: Bearer`, matching the pattern used in the project detail page.\n\n**Note:** Photo display on inspection detail is not yet implemented — tracked as a follow-up. Any photo serving must support both local disk (dev) and Cloudflare R2 (prod).