### PR TITLE
feat: surface findings on project page, remove inspection terminology (#687)

### DIFF
--- a/api/src/repositories/prisma/project.ts
+++ b/api/src/repositories/prisma/project.ts
@@ -35,6 +35,15 @@ export class PrismaProjectRepository implements IProjectRepository {
         client: true,
         siteInspections: {
           orderBy: { date: 'asc' },
+          take: 1,
+          include: {
+            checklistItems: {
+              orderBy: [{ category: 'asc' }, { sortOrder: 'asc' }],
+            },
+            sectionConclusions: {
+              orderBy: { section: 'asc' },
+            },
+          },
         },
       },
     });

--- a/web/app/projects/[id]/findings-section.tsx
+++ b/web/app/projects/[id]/findings-section.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { CollapsibleSection } from '@/components/collapsible-section';
+
+const DECISION_STYLES: Record<string, string> = {
+  PASS: 'bg-green-100 text-green-800',
+  FAIL: 'bg-red-100 text-red-800',
+  NA: 'bg-gray-100 text-gray-500',
+  MONITOR: 'bg-yellow-100 text-yellow-800',
+};
+
+const SEVERITY_STYLES: Record<string, string> = {
+  CRITICAL: 'text-red-600 font-semibold',
+  MAJOR: 'text-orange-600 font-semibold',
+  MINOR: 'text-yellow-600',
+  COSMETIC: 'text-gray-500',
+};
+
+const DECISION_LABEL: Record<string, string> = {
+  PASS: 'Pass',
+  FAIL: 'Fail',
+  NA: 'N/A',
+  MONITOR: 'Monitor',
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+export interface ChecklistItem {
+  id: string;
+  category: string;
+  item: string;
+  decision: string;
+  notes: string | null;
+  room: string | null;
+  floorPlanId: string | null;
+  severity: string | null;
+  photoIds: string[];
+  sortOrder: number;
+}
+
+export interface SectionConclusion {
+  section: string;
+  conclusion: string;
+}
+
+function FindingCard({ item }: { item: ChecklistItem }) {
+  return (
+    <div className="rounded border border-gray-200 bg-white p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-medium text-gray-800 flex-1">{item.item}</p>
+        <div className="flex items-center gap-2 shrink-0">
+          {item.severity && SEVERITY_STYLES[item.severity] && (
+            <span className={`text-xs ${SEVERITY_STYLES[item.severity]}`}>
+              {item.severity}
+            </span>
+          )}
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${DECISION_STYLES[item.decision] ?? 'bg-gray-100 text-gray-600'}`}>
+            {DECISION_LABEL[item.decision] ?? item.decision}
+          </span>
+        </div>
+      </div>
+      {item.notes && (
+        <p className="text-sm text-gray-600">{item.notes}</p>
+      )}
+      {item.photoIds.length > 0 && (
+        <div className="grid grid-cols-3 gap-1 mt-1">
+          {item.photoIds.map((photoId) => (
+            <img
+              key={photoId}
+              src={`${API_URL}/api/photos/${photoId}/file?thumbnail=true`}
+              alt=""
+              className="h-20 w-full rounded object-cover border border-gray-200"
+              loading="lazy"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SectionFindingsProps {
+  id: string;
+  title: string;
+  items: ChecklistItem[];
+  conclusion?: SectionConclusion;
+  groupByRoom?: boolean;
+}
+
+function SectionFindings({ id, title, items, conclusion, groupByRoom }: SectionFindingsProps) {
+  if (items.length === 0) return null;
+
+  const failCount = items.filter((i) => i.decision === 'FAIL').length;
+  const completionStatus = failCount > 0
+    ? `${failCount} issue${failCount !== 1 ? 's' : ''}`
+    : `${items.length} item${items.length !== 1 ? 's' : ''}`;
+
+  let content: React.ReactNode;
+
+  if (groupByRoom) {
+    const byRoom = new Map<string, ChecklistItem[]>();
+    for (const item of items) {
+      const room = item.room ?? 'General';
+      if (!byRoom.has(room)) byRoom.set(room, []);
+      byRoom.get(room)!.push(item);
+    }
+    content = (
+      <div className="space-y-4">
+        {[...byRoom.entries()].map(([room, roomItems]) => (
+          <div key={room}>
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">{room}</h4>
+            <div className="space-y-2">
+              {roomItems.map((item) => <FindingCard key={item.id} item={item} />)}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  } else {
+    content = (
+      <div className="space-y-2">
+        {items.map((item) => <FindingCard key={item.id} item={item} />)}
+      </div>
+    );
+  }
+
+  return (
+    <CollapsibleSection id={id} title={title} completionStatus={completionStatus}>
+      {conclusion && (
+        <div className="mb-4 rounded bg-blue-50 border border-blue-200 px-3 py-2 text-sm text-blue-800">
+          {conclusion.conclusion}
+        </div>
+      )}
+      {content}
+    </CollapsibleSection>
+  );
+}
+
+interface FindingsSectionsProps {
+  checklistItems: ChecklistItem[];
+  sectionConclusions: SectionConclusion[];
+}
+
+const CATEGORY_CONFIG = [
+  { category: 'SITE', id: 'findings-site', title: 'Site & Ground' },
+  { category: 'EXTERIOR', id: 'findings-exterior', title: 'Exterior' },
+  { category: 'INTERIOR', id: 'findings-interior', title: 'Interior', groupByRoom: true },
+  { category: 'SERVICES', id: 'findings-services', title: 'Services' },
+];
+
+export function FindingsSections({ checklistItems, sectionConclusions }: FindingsSectionsProps) {
+  if (checklistItems.length === 0) return null;
+
+  const conclusionMap = new Map(sectionConclusions.map((c) => [c.section, c]));
+
+  return (
+    <>
+      {CATEGORY_CONFIG.map(({ category, id, title, groupByRoom }) => {
+        const items = checklistItems.filter((i) => i.category === category);
+        const conclusion = conclusionMap.get(category);
+        return (
+          <SectionFindings
+            key={category}
+            id={id}
+            title={title}
+            items={items}
+            conclusion={conclusion}
+            groupByRoom={groupByRoom}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -5,11 +5,11 @@ import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { CollapsibleSection } from '@/components/collapsible-section';
 import { PhotoGrid, Photo } from '@/components/photo-grid';
-import { ClauseReviewSection } from './clause-review-section';
 import { DocumentUpload } from '@/components/document-upload';
 import { DocumentList, Document } from '@/components/document-list';
 import { BranzZoneSection } from './branz-zone-section';
 import { FloorPlansSection } from './floor-plans-section';
+import { FindingsSections } from './findings-section';
 
 const API_URL = getApiUrl();
 
@@ -58,21 +58,21 @@ interface Project {
     status: string;
     inspectorName: string;
     outcome: string | null;
-    clauseReviews?: Array<{
+    checklistItems?: Array<{
       id: string;
-      clauseId: string;
-      applicability: 'APPLICABLE' | 'NA';
-      naReason: string | null;
-      observations: string | null;
+      category: string;
+      item: string;
+      decision: string;
+      notes: string | null;
+      room: string | null;
+      floorPlanId: string | null;
+      severity: string | null;
       photoIds: string[];
-      docIds: string[];
-      docsRequired: string | null;
-      remedialWorks: string | null;
-      clause: {
-        code: string;
-        title: string;
-        description: string | null;
-      };
+      sortOrder: number;
+    }>;
+    sectionConclusions?: Array<{
+      section: string;
+      conclusion: string;
     }>;
   }>;
   documents?: Array<{
@@ -118,13 +118,6 @@ const TA_LABELS: Record<string, string> = {
   OTHER: 'Other',
 };
 
-const INSPECTION_STATUS_COLORS: Record<string, string> = {
-  DRAFT: 'bg-gray-100 text-gray-800',
-  IN_PROGRESS: 'bg-blue-100 text-blue-800',
-  REVIEW: 'bg-yellow-100 text-yellow-800',
-  COMPLETED: 'bg-green-100 text-green-800',
-};
-
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString('en-NZ', {
     day: 'numeric',
@@ -144,11 +137,6 @@ function InfoRow({ label, value }: { label: string; value: string | null | undef
 }
 
 export function ProjectSections({ project, authToken }: ProjectSectionsProps): React.ReactElement {
-  const inspectionCount = project.siteInspections?.length ?? 0;
-  const completedInspections = project.siteInspections?.filter(
-    (i) => i.status === 'COMPLETED'
-  ).length ?? 0;
-
   const photoCount = project.photos?.length ?? 0;
 
   return (
@@ -214,69 +202,10 @@ export function ProjectSections({ project, authToken }: ProjectSectionsProps): R
       {/* Floor Plans Section */}
       <FloorPlansSection projectId={project.id} authToken={authToken} />
 
-      {/* Inspections Section */}
-      <CollapsibleSection
-        id="inspections"
-        title="Inspections"
-        completionStatus={inspectionCount > 0 ? `${completedInspections}/${inspectionCount} complete` : undefined}
-      >
-        {inspectionCount === 0 ? (
-          <p className="text-sm text-gray-500 italic">No inspections recorded</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead>
-                <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  <th className="py-2 pr-4">Stage</th>
-                  <th className="py-2 pr-4">Type</th>
-                  <th className="py-2 pr-4">Date</th>
-                  <th className="py-2 pr-4">Inspector</th>
-                  <th className="py-2 pr-4">Status</th>
-                  <th className="py-2">Outcome</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {project.siteInspections?.map((inspection) => (
-                  <tr
-                    key={inspection.id}
-                    className="text-sm cursor-pointer hover:bg-gray-50 transition-colors"
-                    onClick={() => { window.location.href = `/projects/${project.id}/inspections/${inspection.id}`; }}
-                  >
-                    <td className="py-2 pr-4 font-medium">
-                      <Link
-                        href={`/projects/${project.id}/inspections/${inspection.id}`}
-                        className="hover:text-blue-600"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {inspection.stage}
-                      </Link>
-                    </td>
-                    <td className="py-2 pr-4">{inspection.type}</td>
-                    <td className="py-2 pr-4">{formatDate(inspection.date)}</td>
-                    <td className="py-2 pr-4">{inspection.inspectorName}</td>
-                    <td className="py-2 pr-4">
-                      <span
-                        className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                          INSPECTION_STATUS_COLORS[inspection.status] || 'bg-gray-100'
-                        }`}
-                      >
-                        {inspection.status}
-                      </span>
-                    </td>
-                    <td className="py-2">{inspection.outcome || '—'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </CollapsibleSection>
-
-      {/* Clause Reviews Section */}
-      <ClauseReviewSection
-        inspections={project.siteInspections || []}
-        photos={project.photos}
-        documents={project.documents}
+      {/* Findings Sections — Site, Exterior, Interior, Services */}
+      <FindingsSections
+        checklistItems={project.siteInspections?.[0]?.checklistItems ?? []}
+        sectionConclusions={project.siteInspections?.[0]?.sectionConclusions ?? []}
       />
 
       {/* Documents Section */}

--- a/web/app/projects/[id]/project-sections.tsx
+++ b/web/app/projects/[id]/project-sections.tsx
@@ -2,7 +2,6 @@
 import { getApiUrl } from '@/lib/api-url';
 
 import { useState, useCallback } from 'react';
-import Link from 'next/link';
 import { CollapsibleSection } from '@/components/collapsible-section';
 import { PhotoGrid, Photo } from '@/components/photo-grid';
 import { DocumentUpload } from '@/components/document-upload';


### PR DESCRIPTION
Closes #687\n\n## Changes\n\n**API**\n- `project.findById` now includes `checklistItems` and `sectionConclusions` from the first site inspection\n\n**Web**\n- New `findings-section.tsx` — renders Site & Ground, Exterior, Interior (grouped by room), Services sections from checklist items\n- Each finding shows: item, decision badge, severity, notes, photo thumbnails inline\n- Section conclusions shown as blue summary banners\n- Removed Inspections section and Clause Reviews section from project page\n- No "inspection" terminology visible to user\n\n## Version\nBreaking change → bump to v0.2.0 on merge