### PR TITLE
fix: project photo serving and fetch

### DIFF
--- a/web/app/projects/[id]/page.tsx
+++ b/web/app/projects/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { getServerToken, serverFetch } from '@/lib/server-api';
+import { getServerToken, serverFetch, serverFetchList } from '@/lib/server-api';
 import { ProjectSections } from './project-sections';
 
 
@@ -84,6 +84,18 @@ async function getProject(id: string, token?: string): Promise<Project | null> {
   }
 }
 
+async function getProjectPhotos(id: string, token?: string) {
+  return serverFetchList<{
+    id: string;
+    reportNumber: number;
+    caption: string;
+    filePath: string;
+    thumbnailPath: string | null;
+    source: string;
+    linkedClauses: string[];
+  }>(`/api/projects/${id}/photos`, token);
+}
+
 const STATUS_COLORS: Record<string, string> = {
   DRAFT: 'bg-gray-100 text-gray-700',
   IN_PROGRESS: 'bg-blue-100 text-blue-700',
@@ -123,7 +135,10 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<{ 
 export default async function ProjectPage({ params }: ProjectPageProps): Promise<React.ReactElement> {
   const { id } = await params;
   const token = await getServerToken();
-  const project = await getProject(id, token);
+  const [project, photos] = await Promise.all([
+    getProject(id, token),
+    getProjectPhotos(id, token),
+  ]);
 
   if (!project) {
     notFound();
@@ -171,7 +186,7 @@ export default async function ProjectPage({ params }: ProjectPageProps): Promise
       </div>
 
       {/* Sections */}
-      <ProjectSections project={project} authToken={token} />
+      <ProjectSections project={{ ...project, photos }} authToken={token} />
     </div>
   );
 }

--- a/web/components/photo-card.tsx
+++ b/web/components/photo-card.tsx
@@ -93,11 +93,7 @@ export function PhotoCard({
     }
   };
 
-  const thumbnailUrl = photo.thumbnailPath
-    ? photo.thumbnailPath.startsWith('http')
-      ? photo.thumbnailPath
-      : `${API_URL}${photo.thumbnailPath}`
-    : null;
+  const thumbnailUrl = `${API_URL}/api/photos/${photo.id}/file?thumbnail=true`;
 
   return (
     <div

--- a/web/components/photo-lightbox.tsx
+++ b/web/components/photo-lightbox.tsx
@@ -84,9 +84,7 @@ export function PhotoLightbox({
 
   if (!photo) return null;
 
-  const imageUrl = photo.filePath.startsWith('http')
-    ? photo.filePath
-    : `${API_URL}${photo.filePath}`;
+  const imageUrl = `${API_URL}/api/photos/${photo.id}/file`;
 
   return (
     <div


### PR DESCRIPTION
- Fetch project photos separately on project page (were missing from API response)\n- Serve thumbnails via `/api/photos/:id/file?thumbnail=true` (photo-card.tsx was using broken file path)\n- Serve full images via `/api/photos/:id/file` (photo-lightbox.tsx same issue)