### PR TITLE
feat(api): skill bundle API — GET /api/skill/version + /bundle

### DIFF
--- a/api/src/__tests__/skill.test.ts
+++ b/api/src/__tests__/skill.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'crypto';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Inline the core skill bundle logic for unit testing without FS or Express
+// ---------------------------------------------------------------------------
+
+interface SkillManifest {
+  version: string;
+  name: string;
+  description: string;
+  files: string[];
+  updatedAt: string;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function buildChecksum(manifest: SkillManifest, files: Record<string, string>): string {
+  const combined = manifest.files
+    .slice()
+    .sort()
+    .map((f) => `${f}:${sha256(files[f])}`)
+    .join('\n');
+  return sha256(combined);
+}
+
+const SAMPLE_MANIFEST: SkillManifest = {
+  version: '1.0.0',
+  name: 'ai-inspection',
+  description: 'AI-powered building inspection assistant skill',
+  files: ['SKILL.md', 'mcp.json'],
+  updatedAt: '2026-03-09T00:00:00Z',
+};
+
+const SAMPLE_FILES: Record<string, string> = {
+  'SKILL.md': '# AI Inspection Skill\nGuide inspectors through checklists.',
+  'mcp.json': '{"mcpServers":{"ai-inspection":{"command":"node"}}}',
+};
+
+describe('Skill bundle logic', () => {
+  describe('sha256', () => {
+    it('produces a 64-char hex string', () => {
+      const hash = sha256('hello');
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('is deterministic', () => {
+      expect(sha256('test')).toBe(sha256('test'));
+    });
+
+    it('differs for different inputs', () => {
+      expect(sha256('a')).not.toBe(sha256('b'));
+    });
+  });
+
+  describe('buildChecksum', () => {
+    it('returns a deterministic checksum for the same files', () => {
+      const c1 = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      const c2 = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      expect(c1).toBe(c2);
+    });
+
+    it('changes when file content changes', () => {
+      const original = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      const modified = buildChecksum(SAMPLE_MANIFEST, {
+        ...SAMPLE_FILES,
+        'SKILL.md': '# Modified Skill',
+      });
+      expect(original).not.toBe(modified);
+    });
+
+    it('is order-independent — files sorted before hashing', () => {
+      const manifestAB: SkillManifest = { ...SAMPLE_MANIFEST, files: ['SKILL.md', 'mcp.json'] };
+      const manifestBA: SkillManifest = { ...SAMPLE_MANIFEST, files: ['mcp.json', 'SKILL.md'] };
+      expect(buildChecksum(manifestAB, SAMPLE_FILES)).toBe(
+        buildChecksum(manifestBA, SAMPLE_FILES)
+      );
+    });
+
+    it('produces a 64-char hex string', () => {
+      const checksum = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      expect(checksum).toHaveLength(64);
+      expect(checksum).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+
+  describe('version response shape', () => {
+    it('includes version, name, checksum, updatedAt', () => {
+      const files = SAMPLE_FILES;
+      const checksum = buildChecksum(SAMPLE_MANIFEST, files);
+      const response = {
+        version: SAMPLE_MANIFEST.version,
+        name: SAMPLE_MANIFEST.name,
+        checksum,
+        updatedAt: SAMPLE_MANIFEST.updatedAt,
+      };
+
+      expect(response).toMatchObject({
+        version: '1.0.0',
+        name: 'ai-inspection',
+        updatedAt: '2026-03-09T00:00:00Z',
+      });
+      expect(response.checksum).toHaveLength(64);
+    });
+  });
+
+  describe('bundle response shape', () => {
+    it('includes version, name, description, checksum, updatedAt, files', () => {
+      const checksum = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      const response = {
+        version: SAMPLE_MANIFEST.version,
+        name: SAMPLE_MANIFEST.name,
+        description: SAMPLE_MANIFEST.description,
+        checksum,
+        updatedAt: SAMPLE_MANIFEST.updatedAt,
+        files: SAMPLE_FILES,
+      };
+
+      expect(response.files).toHaveProperty('SKILL.md');
+      expect(response.files).toHaveProperty('mcp.json');
+      expect(response.description).toBe('AI-powered building inspection assistant skill');
+    });
+
+    it('checksum in bundle matches checksum in version endpoint', () => {
+      const versionChecksum = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      const bundleChecksum = buildChecksum(SAMPLE_MANIFEST, SAMPLE_FILES);
+      expect(versionChecksum).toBe(bundleChecksum);
+    });
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ import { projectPhotosRouter } from './routes/project-photos.js';
 import { buildingHistoryRouter } from './routes/building-history.js';
 import { siteMeasurementsRouter } from './routes/site-measurements.js';
 import { inspectorsRouter } from './routes/inspectors.js';
+import { skillRouter } from './routes/skill.js';
 import { openApiRouter } from './openapi/index.js';
 import { authMiddleware, serviceAuthMiddleware } from './middleware/auth.js';
 import { getAllowedOrigins } from './config/domain.js';
@@ -64,6 +65,9 @@ app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 app.use('/health', healthRouter);
 app.use('/api', openApiRouter);  // OpenAPI docs (no auth required)
 app.use('/api/auth', authRouter);
+
+// Skill bundle API — auth is applied per-route inside the router
+app.use('/api/skill', skillRouter);
 
 // Service routes (JWT or API key auth)
 app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -14,3 +14,4 @@ export * from './clause-reviews.js';
 export * from './documents.js';
 export * from './na-reason-templates.js';
 export * from './inspectors.js';
+export * from './skill.js';

--- a/api/src/routes/skill.ts
+++ b/api/src/routes/skill.ts
@@ -1,0 +1,117 @@
+/**
+ * Skill Bundle API
+ *
+ * Allows agents to discover and download the current skill version,
+ * so they stay in sync with the API they're talking to.
+ *
+ * GET /api/skill/version  — public, lightweight version + checksum check
+ * GET /api/skill/bundle   — service auth required, full file bundle
+ */
+
+import { Router, type Router as RouterType, type Request, type Response } from 'express';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import { createHash } from 'crypto';
+import { serviceAuthMiddleware } from '../middleware/auth.js';
+
+export const skillRouter: RouterType = Router();
+
+// Skill directory is at the repo root: <repo>/skill/
+// In production (Docker), SKILL_DIR env var can override.
+const SKILL_DIR = process.env.SKILL_DIR
+  ? resolve(process.env.SKILL_DIR)
+  : resolve(new URL('../../../..', import.meta.url).pathname, 'skill');
+
+const MANIFEST_PATH = join(SKILL_DIR, 'manifest.json');
+
+interface SkillManifest {
+  version: string;
+  name: string;
+  description: string;
+  files: string[];
+  updatedAt: string;
+}
+
+function loadManifest(): SkillManifest {
+  if (!existsSync(MANIFEST_PATH)) {
+    throw new Error(`Skill manifest not found at ${MANIFEST_PATH}`);
+  }
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as SkillManifest;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function buildBundle(manifest: SkillManifest): Record<string, string> {
+  const files: Record<string, string> = {};
+  for (const filename of manifest.files) {
+    const filePath = join(SKILL_DIR, filename);
+    if (!existsSync(filePath)) {
+      throw new Error(`Skill file not found: ${filename}`);
+    }
+    files[filename] = readFileSync(filePath, 'utf8');
+  }
+  return files;
+}
+
+function buildChecksum(manifest: SkillManifest, files: Record<string, string>): string {
+  // Deterministic checksum over all file contents, sorted by filename
+  const combined = manifest.files
+    .slice()
+    .sort()
+    .map((f) => `${f}:${sha256(files[f])}`)
+    .join('\n');
+  return sha256(combined);
+}
+
+/**
+ * GET /api/skill/version
+ * Public — lightweight poll endpoint for agents to check if their skill is current.
+ */
+skillRouter.get('/version', (_req: Request, res: Response): void => {
+  try {
+    const manifest = loadManifest();
+    const files = buildBundle(manifest);
+    const checksum = buildChecksum(manifest, files);
+
+    res.json({
+      version: manifest.version,
+      name: manifest.name,
+      checksum,
+      updatedAt: manifest.updatedAt,
+    });
+  } catch (err) {
+    console.error('[skill] Failed to load skill version:', err);
+    res.status(500).json({ error: 'Failed to load skill manifest' });
+  }
+});
+
+/**
+ * GET /api/skill/bundle
+ * Service auth required — returns full skill file bundle for download.
+ *
+ * Agents should:
+ *   1. Poll /api/skill/version to check the checksum
+ *   2. If changed, call this endpoint to fetch updated files
+ *   3. Write files to their skill directory and restart
+ */
+skillRouter.get('/bundle', serviceAuthMiddleware, (_req: Request, res: Response): void => {
+  try {
+    const manifest = loadManifest();
+    const files = buildBundle(manifest);
+    const checksum = buildChecksum(manifest, files);
+
+    res.json({
+      version: manifest.version,
+      name: manifest.name,
+      description: manifest.description,
+      checksum,
+      updatedAt: manifest.updatedAt,
+      files,
+    });
+  } catch (err) {
+    console.error('[skill] Failed to build skill bundle:', err);
+    res.status(500).json({ error: 'Failed to build skill bundle' });
+  }
+});

--- a/skill/manifest.json
+++ b/skill/manifest.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "name": "ai-inspection",
+  "description": "AI-powered building inspection assistant skill",
+  "files": [
+    "SKILL.md",
+    "mcp.json"
+  ],
+  "updatedAt": "2026-03-09T00:00:00Z"
+}


### PR DESCRIPTION
## Summary
Agents can now check whether their installed skill is current and download the latest bundle without manual reinstallation.

## Endpoints

### `GET /api/skill/version` — public
Lightweight poll. Agents call this on startup to compare against their installed version.
```json
{
  "version": "1.0.0",
  "name": "ai-inspection",
  "checksum": "abc123...",
  "updatedAt": "2026-03-09T00:00:00Z"
}
```

### `GET /api/skill/bundle` — service auth (X-API-Key)
Full file bundle. Agent fetches this when checksum differs, writes files to skill dir, restarts.
```json
{
  "version": "1.0.0",
  "name": "ai-inspection",
  "description": "...",
  "checksum": "abc123...",
  "updatedAt": "2026-03-09T00:00:00Z",
  "files": {
    "SKILL.md": "# AI Inspection Skill...",
    "mcp.json": "{...}"
  }
}
```

## Design notes
- Checksum is SHA-256 over all file contents, sorted by filename — deterministic and order-independent
- `SKILL_DIR` env var overrides skill directory path (useful for Docker)
- Security signing tracked in #700 (low priority, needed before web deploy)

## Verification
- 10 unit tests: checksum determinism, order-independence, content sensitivity, response shapes
- All 219 existing tests still pass