### PR TITLE
refactor(auth): document middleware selection rule and group routes by auth type

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -60,15 +60,19 @@ app.use(cors({
 app.use(cookieParser());
 app.use(express.json({ limit: '10mb' })); // Increased limit for base64 photos
 
-// Public routes (no auth required)
+// ─── Public routes (no auth) ──────────────────────────────────────────────────
 app.use('/health', healthRouter);
-app.use('/api', openApiRouter);  // OpenAPI docs (no auth required)
+app.use('/api', openApiRouter);
 app.use('/api/auth', authRouter);
-
-// Service routes (JWT or API key auth)
+// ─── Service-to-service routes (serviceAuthMiddleware) ────────────────────────
+// These routes are called by the OpenClaw agent or internal services.
+// They accept X-API-Key (service identity) or JWT (user identity).
+// See auth middleware module for the full selection rule.
 app.use('/api/inspectors', serviceAuthMiddleware, inspectorsRouter);
 
-// Protected routes (auth required)
+// ─── User-facing routes (authMiddleware — JWT only) ───────────────────────────
+// These routes are called by the web UI. JWT required.
+// Do not use serviceAuthMiddleware here — API keys should not access user data.
 app.use('/api/inspections', authMiddleware, inspectionsRouter);
 app.use('/api', authMiddleware, findingsRouter);
 app.use('/api', authMiddleware, photosRouter);

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,7 +1,24 @@
 /**
  * Auth Middleware — Issue #41
  *
- * JWT-based authentication middleware.
+ * ## Middleware selection rule
+ *
+ * Use `authMiddleware` for user-facing routes (web UI).
+ *   - Accepts: JWT token (cookie or Authorization header)
+ *   - Caller: browser / web UI
+ *   - Sets: req.userId = <user id from JWT>
+ *
+ * Use `serviceAuthMiddleware` for service-to-service routes (agent / OpenClaw).
+ *   - Accepts: X-API-Key header (preferred) OR JWT token (fallback)
+ *   - Caller: OpenClaw agent, MCP server, internal services
+ *   - Sets: req.userId = 'service' (API key path) or <user id> (JWT path)
+ *   - Note: JWT callers via this middleware bypass API-key scope checks —
+ *     there are currently no scoped permissions, but keep this in mind
+ *     when scoped auth is added (see issue #577).
+ *
+ * Do not mix them on the same route. If unsure, prefer `authMiddleware`
+ * for user routes and only use `serviceAuthMiddleware` where an agent
+ * or automated service explicitly needs API-key access.
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -14,7 +31,9 @@ export interface AuthRequest extends Request {
 }
 
 /**
- * Verify JWT token from cookie or Authorization header
+ * User-facing auth middleware.
+ * Use on routes called by the web UI. Accepts JWT only.
+ * See module-level comment for selection rule.
  */
 export function authMiddleware(
   req: AuthRequest,
@@ -48,9 +67,10 @@ export function generateToken(userId: string): string {
 }
 
 /**
- * Service authentication middleware — Issue #351
- * Allows either JWT token OR X-API-Key header for service-to-service auth.
- * Used for endpoints that OpenClaw agent needs to call.
+ * Service-to-service auth middleware.
+ * Use on routes called by the OpenClaw agent or internal services.
+ * Accepts X-API-Key (sets userId='service') or JWT (sets userId from token).
+ * See module-level comment for selection rule and JWT bypass note.
  */
 export function serviceAuthMiddleware(
   req: AuthRequest,


### PR DESCRIPTION
## Problem
Closes #684

`authMiddleware` and `serviceAuthMiddleware` were used inconsistently with no documented rule for which to apply where. JWT callers could reach `serviceAuthMiddleware` routes and bypass any future scope checks.

## Changes
**No logic changes** — documentation and structure only.

### `auth.ts`
- Added module-level JSDoc explaining the selection rule:
  - `authMiddleware` → user-facing routes (web UI, JWT only)
  - `serviceAuthMiddleware` → service-to-service routes (agent/API key or JWT)
- Added note about JWT bypass behaviour (ref #577 for future scoped permissions)
- Added per-function JSDoc to both middlewares

### `index.ts`
- Routes grouped into three labelled sections:
  - **Public** — no auth
  - **Service-to-service** — `serviceAuthMiddleware`
  - **User-facing** — `authMiddleware` (JWT only)
- Comment explicitly warns: do not use `serviceAuthMiddleware` on user data routes

## Verification
- 212 existing tests pass, no regressions